### PR TITLE
revert settings that should now be default in machine.conf

### DIFF
--- a/parm/metplus_config/machine.conf
+++ b/parm/metplus_config/machine.conf
@@ -2,7 +2,7 @@
 [config]
 
 MET_INSTALL_DIR = {ENV[MET_ROOT]}
-MET_BIN_DIR = {MET_INSTALL_DIR}/{ENV[MET_bin_exec]}
+MET_BIN_DIR = {MET_INSTALL_DIR}/bin
 METPLUS_BASE = {ENV[METPLUS_PATH]}
 PARM_BASE = {METPLUS_BASE}/parm
 OUTPUT_BASE = {ENV[DATA]}
@@ -12,9 +12,9 @@ CONVERT = convert
 GEMPPAKTOCF_JAR = GempakToCF.jar
 LOG_TIMESTAMP_TEMPLATE = %Y%m%d%H%M%S
 LOG_TIMESTAMP_USE_DATATIME = no
-LOG_MET_OUTPUT_TO_METPLUS = {ENV[log_met_output_to_metplus]}
-LOG_LEVEL = {ENV[metplus_verbosity]}
-LOG_MET_VERBOSITY = {ENV[met_verbosity]}
+LOG_MET_OUTPUT_TO_METPLUS = yes
+LOG_LEVEL = DEBUG
+LOG_MET_VERBOSITY = 2
 LOG_LINE_FORMAT = %(asctime)s.%(msecs)03d %(name)s (%(filename)s:%(lineno)d) %(levelname)s: %(message)s
 LOG_ERR_LINE_FORMAT = {LOG_LINE_FORMAT}
 LOG_DEBUG_LINE_FORMAT = {LOG_LINE_FORMAT}


### PR DESCRIPTION
## Pull Request Testing ##

- [ ] Describe testing already performed for this Pull Request:</br>

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
No testing was done or is really needed. PR #156 reverted to the old way of setting common METplus config settings (verbosity, MET_bin_exec) using environment variables that many developers have removed from their drivers and parm files. Need to push this through ASAP so jobs don't start failing once folks merge the current develop branch into their feature branches.

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes or No]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes or No]**

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
