### PR TITLE
Updating rtofs perf diag plots to have 3-digit fcst hours

### DIFF
--- a/ush/rtofs/performance_diagram.py
+++ b/ush/rtofs/performance_diagram.py
@@ -122,7 +122,7 @@ def plot_performance_diagram(df: pd.DataFrame, logger: logging.Logger,
                 frange_phrase = 's '+', '.join([str(f) for f in flead])
             else:
                 frange_phrase = ' '+', '.join([str(f) for f in flead])
-            frange_save_phrase = '-'.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([f'{f:03d}' for f in flead])
         else:
             frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
             frange_save_phrase = f'{flead[0]}_TO_F{flead[-1]}'


### PR DESCRIPTION
## Pull Request Testing ##

- [ ] Describe testing already performed for this Pull Request:</br>

Updated the performance diagram plot code in the same manner that the time series plot code was to get the 3-digit forecast hour in the filename.  

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Pull in the stats from the emc.vpppg parallel, then run the plot code to see that the perf diagrams are written out to have 3-digit forecast hours.  

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes or No]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes or No]**

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

ASAP.  

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
