### PR TITLE
bugfix for aqm output dir and envir

### DIFF
--- a/dev/drivers/scripts/aqm/prep/jevs_aqm_prep.sh
+++ b/dev/drivers/scripts/aqm/prep/jevs_aqm_prep.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=02:30:00
+#PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=1:mem=2GB
 #PBS -l debug=true
 
@@ -38,6 +38,7 @@ export VERIF_CASE=grid2obs
 export MODELNAME=aqm
 export modsys=aqm
 export mod_ver=${aqm_ver}
+export envir=prod
 
 export config=$HOMEevs/parm/evs_config/aqm/config.evs.aqm.prod
 source $config

--- a/dev/drivers/scripts/aqm/prep/jevs_aqm_prep.sh
+++ b/dev/drivers/scripts/aqm/prep/jevs_aqm_prep.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l select=1:ncpus=1:mem=10GB
+#PBS -l select=1:ncpus=1:mem=2GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/aqm/prep/jevs_aqm_prep.sh
+++ b/dev/drivers/scripts/aqm/prep/jevs_aqm_prep.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l select=1:ncpus=1:mem=2GB
+#PBS -l select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 
 set -x

--- a/scripts/aqm/prep/exevs_aqm_prep.sh
+++ b/scripts/aqm/prep/exevs_aqm_prep.sh
@@ -35,10 +35,9 @@ fi
 export dirname=cs
 export gridspec=148
 
-#export PREP_SAVE_DIR=${COMOUT}/${RUN}.${VDATE}/${MODELNAME}
 export PREP_SAVE_DIR=${DATA}/prepsave
 mkdir -p ${PREP_SAVE_DIR}
-mkdir -p ${COMOUT}/${RUN}.${VDATE}/${MODELNAME}
+mkdir -p ${COMOUT}.${VDATE}/${MODELNAME}
 
 export model1=`echo $MODELNAME | tr a-z A-Z`
 echo $model1
@@ -58,7 +57,7 @@ while [ ${ic} -le ${endvhr} ]; do
 	if [ -s ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf ]; then
             run_metplus.py ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf $PARMevs/metplus_config/machine.conf
 	    if [ $SENDCOM = "YES" ]; then
-	      cp ${PREP_SAVE_DIR}/airnow_hourly_aqobs_${VDATE}${VHOUR}.nc ${COMOUT}/${RUN}.${VDATE}/${MODELNAME}
+	      cp ${PREP_SAVE_DIR}/airnow_hourly_aqobs_${VDATE}${VHOUR}.nc ${COMOUT}.${VDATE}/${MODELNAME}
 	    fi
         else
             echo "can not find ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf"
@@ -83,7 +82,7 @@ if [ -s ${checkfile} ]; then
     if [ -s ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf ]; then
         run_metplus.py ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf $PARMevs/metplus_config/machine.conf
 	if [ $SENDCOM = "YES" ]; then
-	  cp ${PREP_SAVE_DIR}/airnow_daily_$VDATE.nc ${COMOUT}/${RUN}.${VDATE}/${MODELNAME}
+	  cp ${PREP_SAVE_DIR}/airnow_daily_$VDATE.nc ${COMOUT}.${VDATE}/${MODELNAME}
 	fi
     else
         echo "can not find ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf"
@@ -132,7 +131,7 @@ then
         wgrib2 -d 2 ${ozmax8_file} -set_ftime "30-53 hour ave fcst" -grib out2.grb2
         wgrib2 -d 3 ${ozmax8_file} -set_ftime "54-77 hour ave fcst" -grib out3.grb2
 	if [ $SENDCOM = "YES" ]; then
-         cat out1.grb2 out2.grb2 out3.grb2 > ${COMOUT}/${RUN}.${VDATE}/${MODELNAME}/aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
+         cat out1.grb2 out2.grb2 out3.grb2 > ${COMOUT}.${VDATE}/${MODELNAME}/aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
 	fi
     else
         export subject="t${hour}z OZMAX8${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"
@@ -155,7 +154,7 @@ then
         wgrib2 -d 2 ${ozmax8_file} -set_ftime "24-47 hour ave fcst" -grib out2.grb2
         wgrib2 -d 3 ${ozmax8_file} -set_ftime "48-71 hour ave fcst" -grib out3.grb2
 	if [ $SENDCOM = "YES" ]; then
-         cat out1.grb2 out2.grb2 out3.grb2 > ${COMOUT}/${RUN}.${VDATE}/${MODELNAME}/aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
+         cat out1.grb2 out2.grb2 out3.grb2 > ${COMOUT}.${VDATE}/${MODELNAME}/aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
 	fi
     else
         export subject="t${hour}z OZMAX8${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"


### PR DESCRIPTION
## Pull Request Testing ##

- [ ] Describe testing already performed for this Pull Request:</br>

This bugfix makes the following corrections in the aqm:

- Makes sure there is no additional atmos in the output directory of the prep step.  
- Sets envir=prod

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Only the aqm prep step needs to be run.  

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes or No]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes or No]**

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

ASAP

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
