### PR TITLE
bugfix/global_ens_envir

### DIFF
--- a/dev/drivers/scripts/global_ens/plots/jevs_global_ens_headline_gefs_grid2grid_plots.sh
+++ b/dev/drivers/scripts/global_ens/plots/jevs_global_ens_headline_gefs_grid2grid_plots.sh
@@ -14,6 +14,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=headline
 export STEP=plots

--- a/dev/drivers/scripts/global_ens/prep/jevs_global_ens_atmos_prep.sh
+++ b/dev/drivers/scripts/global_ens/prep/jevs_global_ens_atmos_prep.sh
@@ -18,6 +18,7 @@ export OMP_NUM_THREADS=1
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=prep

--- a/dev/drivers/scripts/global_ens/prep/jevs_global_ens_headline_prep.sh
+++ b/dev/drivers/scripts/global_ens/prep/jevs_global_ens_headline_prep.sh
@@ -13,6 +13,7 @@ export OMP_NUM_THREADS=1
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
+export envir=prod
 export NET=evs
 export RUN=headline
 export STEP=prep

--- a/dev/drivers/scripts/global_ens/prep/jevs_global_ens_naefs_atmos_prep.sh
+++ b/dev/drivers/scripts/global_ens/prep/jevs_global_ens_naefs_atmos_prep.sh
@@ -13,6 +13,7 @@ export OMP_NUM_THREADS=1
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=prep

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_grid2grid_stats.sh
@@ -17,6 +17,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_grid2obs_stats.sh
@@ -16,6 +16,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_precip_stats.sh
@@ -17,6 +17,7 @@ set -x
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_snowfall_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_atmos_snowfall_stats.sh
@@ -17,6 +17,7 @@ set -x
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_wmo_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_cmce_wmo_grid2grid_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=wmo
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_grid2grid_stats.sh
@@ -17,6 +17,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_grid2obs_stats.sh
@@ -16,6 +16,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_precip_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_snowfall_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_ecme_atmos_snowfall_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_cnv_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_cnv_stats.sh
@@ -16,6 +16,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_grid2grid_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_grid2obs_stats.sh
@@ -15,6 +15,7 @@ set -x
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_precip_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_sea_ice_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_sea_ice_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_snowfall_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_snowfall_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_sst_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_atmos_sst_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_headline_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_headline_grid2grid_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=headline
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_wmo_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gefs_wmo_grid2grid_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=wmo
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gfs_headline_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_gfs_headline_grid2grid_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=headline
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_atmos_grid2grid_stats.sh
@@ -17,6 +17,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_atmos_grid2obs_stats.sh
@@ -16,6 +16,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_atmos_precip_stats.sh
@@ -18,6 +18,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export STEP=stats

--- a/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_headline_grid2grid_stats.sh
+++ b/dev/drivers/scripts/global_ens/stats/jevs_global_ens_naefs_headline_grid2grid_stats.sh
@@ -17,6 +17,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 source $HOMEevs/versions/run.ver
 
+export envir=prod
 export NET=evs
 export RUN=headline
 export STEP=stats

--- a/jobs/global_ens/prep/JEVS_GLOBAL_ENS_PREP
+++ b/jobs/global_ens/prep/JEVS_GLOBAL_ENS_PREP
@@ -38,8 +38,8 @@ export COMINccpa=${COMINccpa:-$(compath.py $envir/com/ccpa/${ccpa_ver})}
 export COMINcmce=$COMINnaefs
 export COMINprepbufr=${COMINprepbufr:-$(compath.py $envir/com/obsproc/${obsproc_ver})}
 export COMINsnow=${DCOMIN}
-export COMINosi_saf=${COMINosi_saf:-/lfs/h1/ops/dev/dcom}
-export COMINsst=${COMINsst:-/lfs/h1/ops/dev/dcom} 
+export COMINosi_saf=${COMINosi_saf:-$DCOMROOT}
+export COMINsst=${COMINsst:-$DCOMROOT} 
 
 export COMINgefs_bc=${COMINgefs_bc:-$COMINnaefs}
 export COMINcmce_bc=${DCOMIN}

--- a/scripts/global_ens/prep/exevs_global_ens_gefs_atmos_prep.sh
+++ b/scripts/global_ens/prep/exevs_global_ens_gefs_atmos_prep.sh
@@ -123,7 +123,7 @@ if [ $get_osi_saf = yes ] ; then
  export COMINmetfra_precip=
  export COMINukmet=
  export COMINukmet_precip=
- export COMINosi_saf=${COMINosi_saf:-/lfs/h1/ops/dev/dcom}
+ export COMINosi_saf=${COMINosi_saf:-$DCOMROOT}
 
  $USHevs/${COMPONENT}/evs_get_gens_${RUN}_data.sh osi_saf
  export MODELNAME=gefs


### PR DESCRIPTION
## Pull Request Testing ##

- Add "export envir=prod" to driver scripts were needed
- Use DCOMROOT for OSI-SAF and GHRSST data

- [ ] Describe testing already performed for this Pull Request:</br>

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

> This is another PR where the changes touch a lot of the driver scripts. I would like dev/drivers/scripts/global_ens/prep/jevs_global_ens_atmos_prep.sh to be run to make sure the job is using the OSI-SAF and GHRSST data from prod/dcom and no lone dev/dcom.


- [ ] Has the code been checked to ensure that no errors occur during the execution? **No**

- [ ] Do these updates/additions include sufficient testing updates? **No**

- [ ] Please complete this pull request review by **10/13/2023**.</br>

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
