### PR TITLE
Removing NAEFS para directory from run.ver

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -63,4 +63,3 @@ export sref_ver=v7.1
 export st4_ver=v4.1
 export urma_ver=v2.10
 
-export COMPATH=/lfs/h1/ops/para/com/naefs/


### PR DESCRIPTION
## Pull Request Testing ##

- [ ] Describe testing already performed for this Pull Request:</br>

This PR simply removes the COMPATH directory from run.ver that fixed the NAEFS location to the NCO para directory.  NCO told us that we should be using the prod directory.  Removing the COMPATH line allows EVS to default to the NCO prod directory.  

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

No testing should be needed, but you could run the stats driver just to check to see that the correct NAEFS directory is being accessed.  

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes or No]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes or No]**

- [ ] Please complete this pull request review by **[Fill in date]**.</br>
ASAP

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
