### PR TITLE
Bugfix/cam precip maps

### DIFF
--- a/parm/metplus_config/stats/cam/precip/PcpCombine_fcstHREF_APCP24h.conf
+++ b/parm/metplus_config/stats/cam/precip/PcpCombine_fcstHREF_APCP24h.conf
@@ -21,7 +21,7 @@ FCST_PCP_COMBINE_RUN = True
 FCST_PCP_COMBINE_METHOD = ADD
 
 FCST_PCP_COMBINE_INPUT_DIR = {ENV[modelpath]}
-FCST_PCP_COMBINE_INPUT_TEMPLATE = href.t{ENV[fcyc]}z.{ENV[domain]}.{ENV[prod]}.f{ENV[fhr]}.grib2
+FCST_PCP_COMBINE_INPUT_TEMPLATE = href.t{ENV[fcyc]}z.{ENV[domain]}.{ENV[prod]}.f{lead?fmt=%HH}.grib2
 
 FCST_PCP_COMBINE_OUTPUT_DIR = {OUTPUT_BASE}
 FCST_PCP_COMBINE_OUTPUT_TEMPLATE = href{ENV[prod]}.t{ENV[fcyc]}z.{ENV[grid]}.24h.f{ENV[fhr]}.nc

--- a/ush/cam/spatial_map.py
+++ b/ush/cam/spatial_map.py
@@ -50,7 +50,7 @@ RESTART_DIR = os.environ['RESTART_DIR']
 # Define Settings
 INPUT_DIR = STAT_OUTPUT_BASE_DIR
 OUTPUT_DIR = SAVE_DIR
-LOGO_DIR = FIXevs
+LOGO_DIR = os.path.join(FIXevs, 'logos')
 if VERIF_TYPE == 'ccpa':
     MODEL_INFO_DICT = {}
 else:

--- a/ush/mesoscale/spatial_map.py
+++ b/ush/mesoscale/spatial_map.py
@@ -49,7 +49,7 @@ VERIF_TYPE = os.environ['VERIF_TYPE']
 # Define Settings
 INPUT_DIR = STAT_OUTPUT_BASE_DIR
 OUTPUT_DIR = SAVE_DIR
-LOGO_DIR = FIXevs
+LOGO_DIR = os.path.join(FIXevs,'logos')
 if VERIF_TYPE == 'ccpa':
     MODEL_INFO_DICT = {}
 else:


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for this Pull Request:</br>

This PR addresses three small typos affecting cam and mesoscale spatial maps.  The first fix is to a part of the HREF file template used in PCPCombine processes, and corrects precip accumulations.  The second and third are to the paths used to point to logos in the FIXevs directory, and corrects the logo placement on spatial maps.

The stats and HREF spatial maps plots jobs were run successfully and output files were examined.

The other two plots jobs were not tested.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
**_Slightly different process compared to recent cam PRs_**:
### (1) Set up jobs 
•	symlink the EVS_fix directory locally as "fix"
•	In all driver scripts, point all exports of "HOMEevs" to your EVS test directory
•	In the _href precip spatial map plots_ driver script, make sure COMIN is set **to the test stats COMOUT directory** (e.g., `/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d`)
•	In all stats and remaining plots driver scripts, change COMIN to the parallel directory (`/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`)
•	Optional: In the stats driver script, change "MAILTO" to point to your email address
### (2) Test Jobs
Use the following... 
...to submit the stats and href spatial maps plots jobs: `qsub –v vhr=00 `
...to submit all other plots jobs: `qsub –v vhr=00,VDATE=$(date -d "-2 days" +"%Y%m%d") `
From your EVS testing directory, the following scripts should be run using the setup in step (1):
```
dev/drivers/scripts/stats/cam/jevs_cam_href_precip_stats.sh
```
```
dev/drivers/scripts/plots/cam/jevs_cam_href_precip_spatial_plots.sh
dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.sh
```

_[Total: 0 prep jobs, 1 stats jobs, 3 plots jobs]_

### (3) Timing
- jevs_cam_href_precip_spatial_plots may only run after jevs_cam_href_precip_stats has completed
- All other jobs can be run at any time

### (4) Review
- I'll check the spatial maps in the resulting COMOUTplots directories for (1) correct href maps and (2) logos on cam and mesoscale plots.
- I'll also check for red flags:
```
check="FATAL\|error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|empty\|failed\|unexpected\|exceeded"
grep "$check" $outfile
```

- [x] Has the code been checked to ensure that no errors occur during the execution? **YES**

- [x] Do these updates/additions include sufficient testing updates? **YES**

- [x] Please complete this pull request review by **ASAP**.</br>

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
