### PR TITLE
Bugfix:  change depth to core in cpu-bind statements

### DIFF
--- a/scripts/plots/cam/exevs_cam_grid2obs_plots.sh
+++ b/scripts/plots/cam/exevs_cam_grid2obs_plots.sh
@@ -52,7 +52,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/cam/exevs_cam_headline_plots.sh
+++ b/scripts/plots/cam/exevs_cam_headline_plots.sh
@@ -52,7 +52,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/cam/exevs_cam_precip_plots.sh
+++ b/scripts/plots/cam/exevs_cam_precip_plots.sh
@@ -52,7 +52,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/cam/exevs_cam_snowfall_plots.sh
+++ b/scripts/plots/cam/exevs_cam_snowfall_plots.sh
@@ -52,7 +52,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/cam/exevs_href_grid2obs_cape_plots.sh
+++ b/scripts/plots/cam/exevs_href_grid2obs_cape_plots.sh
@@ -223,7 +223,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 768 -ppn 84 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 768 -ppn 84 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/cam/exevs_href_grid2obs_ctc_plots.sh
+++ b/scripts/plots/cam/exevs_href_grid2obs_ctc_plots.sh
@@ -222,7 +222,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 704 -ppn 82 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 704 -ppn 82 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/cam/exevs_href_grid2obs_ecnt_plots.sh
+++ b/scripts/plots/cam/exevs_href_grid2obs_ecnt_plots.sh
@@ -174,7 +174,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 72 -ppn 72 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 72 -ppn 72 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/cam/exevs_href_precip_plots.sh
+++ b/scripts/plots/cam/exevs_href_precip_plots.sh
@@ -202,7 +202,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 306 -ppn 77 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 306 -ppn 77 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/cam/exevs_href_profile_plots.sh
+++ b/scripts/plots/cam/exevs_href_profile_plots.sh
@@ -206,7 +206,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 90 -ppn 90 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 90 -ppn 90 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/cam/exevs_href_snowfall_plots.sh
+++ b/scripts/plots/cam/exevs_href_snowfall_plots.sh
@@ -182,7 +182,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 30 -ppn 30 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 30 -ppn 30 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/cam/exevs_href_spcoutlook_plots.sh
+++ b/scripts/plots/cam/exevs_href_spcoutlook_plots.sh
@@ -175,7 +175,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 6 -ppn 6 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 6 -ppn 6 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/global_det/exevs_global_det_atmos_grid2grid_plots.sh
+++ b/scripts/plots/global_det/exevs_global_det_atmos_grid2grid_plots.sh
@@ -57,7 +57,7 @@ for group in condense_stats filter_stats make_plots tar_images; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/global_det/exevs_global_det_atmos_grid2obs_plots.sh
+++ b/scripts/plots/global_det/exevs_global_det_atmos_grid2obs_plots.sh
@@ -57,7 +57,7 @@ for group in condense_stats filter_stats make_plots tar_images; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/global_det/exevs_global_det_wave_grid2obs_plots.sh
+++ b/scripts/plots/global_det/exevs_global_det_wave_grid2obs_plots.sh
@@ -83,7 +83,7 @@ if [[ $plot_ncount_job -gt 0 ]]; then
         export MP_CMDFILE=${poe_script}
         nselect=$(cat $PBS_NODEFILE | wc -l)
         nnp=$(($nselect * $nproc))
-        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         $launcher $MP_CMDFILE
         export err=$?; err_chk
     else

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2grid_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2grid_plots.sh
@@ -219,7 +219,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 192 -ppn 96 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 192 -ppn 96 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_plots.sh
@@ -212,7 +212,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 84 -ppn 84 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 84 -ppn 84 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_separate_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_separate_plots.sh
@@ -257,7 +257,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 154 -ppn 77 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 154 -ppn 77 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_precip_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_precip_plots.sh
@@ -230,7 +230,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 32 -ppn 32 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile1_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile1_plots.sh
@@ -188,7 +188,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 440 -ppn 88 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 440 -ppn 88 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile2_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile2_plots.sh
@@ -188,7 +188,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 212 -ppn 53 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 212 -ppn 53 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
@@ -176,7 +176,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 320 -ppn 64 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 320 -ppn 64 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile4_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile4_plots.sh
@@ -176,7 +176,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 160 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 160 -ppn 32 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_sea_ice_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_sea_ice_plots.sh
@@ -205,7 +205,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 32 -ppn 32 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_snowfall_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_snowfall_plots.sh
@@ -218,7 +218,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 32 -ppn 32 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2grid_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2grid_plots.sh
@@ -193,7 +193,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 12 -ppn 12 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 12 -ppn 12 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2obs_plots.sh
@@ -204,7 +204,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 32 -ppn 32 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_precip_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_precip_plots.sh
@@ -220,7 +220,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 8 -ppn 8 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 8 -ppn 8 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -61,8 +61,8 @@ if [ $USE_CFP = YES ]; then
         if [ $machine = WCOSS2 ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
-	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
+            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
 	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0

--- a/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
@@ -60,8 +60,8 @@ if [ $USE_CFP = YES ]; then
         if [ $machine = WCOSS2 ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
-	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
+            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
 	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0

--- a/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
@@ -61,8 +61,8 @@ if [ $USE_CFP = YES ]; then
         if [ $machine = WCOSS2 ]; then
 	    nselect=$(cat $PBS_NODEFILE | wc -l)
     	    nnp=$(($nselect * $nproc))
-       	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+       	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
+            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
 	    # ---
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0

--- a/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
@@ -61,8 +61,8 @@ if [ $USE_CFP = YES ]; then
         if [ $machine = WCOSS2 ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
-	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
+            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
 	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0

--- a/scripts/plots/mesoscale/exevs_mesoscale_sref_cape_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_sref_cape_plots.sh
@@ -199,7 +199,7 @@ chmod +x run_all_poe.sh
 # **************************************************************************
 
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 80 -ppn 80 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 80 -ppn 80 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
    export err=$?; err_chk
 else
    ${DATA}/run_all_poe.sh

--- a/scripts/plots/mesoscale/exevs_mesoscale_sref_cloud_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_sref_cloud_plots.sh
@@ -196,7 +196,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 # **************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 112 -ppn 112 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 112 -ppn 112 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
    export err=$?; err_chk
 else
    ${DATA}/run_all_poe.sh

--- a/scripts/plots/mesoscale/exevs_mesoscale_sref_cnv_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_sref_cnv_plots.sh
@@ -213,7 +213,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 # **************************************************************************
 if [ $run_mpi = yes ] ; then
-  mpiexec -np 176 -ppn 88 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 176 -ppn 88 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 else
    ${DATA}/run_all_poe.sh

--- a/scripts/plots/mesoscale/exevs_mesoscale_sref_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_sref_grid2obs_plots.sh
@@ -215,7 +215,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 # **************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 216 -ppn 72 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 216 -ppn 72 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
    export err=$?; err_chk
 else
    ${DATA}/run_all_poe.sh

--- a/scripts/plots/mesoscale/exevs_mesoscale_sref_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_sref_precip_plots.sh
@@ -226,7 +226,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 # **************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 100 -ppn 100 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 100 -ppn 100 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
    export err=$?; err_chk
 else
   ${DATA}/run_all_poe.sh

--- a/scripts/plots/mesoscale/exevs_mesoscale_sref_td2m_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_sref_td2m_plots.sh
@@ -197,7 +197,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 # **************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 80 -ppn 80 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 80 -ppn 80 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
    export err=$?; err_chk
 else
    ${DATA}/run_all_poe.sh

--- a/scripts/plots/narre/exevs_narre_plots.sh
+++ b/scripts/plots/narre/exevs_narre_plots.sh
@@ -180,7 +180,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 # **************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 4 -ppn 4 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 4 -ppn 4 --cpu-bind verbose,core cfp ${DATA}/run_all_poe.sh
    export err=$?; err_chk
 else
   ${DATA}/run_all_poe.sh

--- a/scripts/plots/subseasonal/exevs_subseasonal_grid2grid_plots.sh
+++ b/scripts/plots/subseasonal/exevs_subseasonal_grid2grid_plots.sh
@@ -58,7 +58,7 @@ for group in condense_stats filter_stats make_plots tar_images; do
 	    if [ $machine = WCOSS2 ]; then
 	        nselect=$(cat $PBS_NODEFILE | wc -l)
 	        nnp=$(($nselect * $nproc))
-	        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+	        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	    elif [ $machine = HERA -o $machine = ORION ]; then
 	        export SLURM_KILL_BAD_EXIT=0
 	        launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/subseasonal/exevs_subseasonal_grid2obs_plots.sh
+++ b/scripts/plots/subseasonal/exevs_subseasonal_grid2obs_plots.sh
@@ -58,7 +58,7 @@ for group in condense_stats filter_stats make_plots tar_images; do
 	    if [ $machine = WCOSS2 ]; then
 	        nselect=$(cat $PBS_NODEFILE | wc -l)
 	        nnp=$(($nselect * $nproc))
-	        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+	        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	    elif [ $machine = HERA -o $machine = ORION ]; then
 	        export SLURM_KILL_BAD_EXIT=0
 	        launcher="srun --export=ALL --multi-prog"

--- a/scripts/prep/cam/exevs_hireswarw_precip_prep.sh
+++ b/scripts/prep/cam/exevs_hireswarw_precip_prep.sh
@@ -55,7 +55,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/prep/cam/exevs_hireswarwmem2_precip_prep.sh
+++ b/scripts/prep/cam/exevs_hireswarwmem2_precip_prep.sh
@@ -55,7 +55,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/prep/cam/exevs_hireswfv3_precip_prep.sh
+++ b/scripts/prep/cam/exevs_hireswfv3_precip_prep.sh
@@ -55,7 +55,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/prep/cam/exevs_hrrr_precip_prep.sh
+++ b/scripts/prep/cam/exevs_hrrr_precip_prep.sh
@@ -54,7 +54,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/prep/cam/exevs_namnest_precip_prep.sh
+++ b/scripts/prep/cam/exevs_namnest_precip_prep.sh
@@ -54,7 +54,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/prep/subseasonal/exevs_subseasonal_gefs_prep.sh
+++ b/scripts/prep/subseasonal/exevs_subseasonal_gefs_prep.sh
@@ -45,7 +45,7 @@ if [ $USE_CFP = YES ]; then
 	export MP_PGMMODEL=mpmd
 	export MP_CMDFILE=${poe_script}
 	if [ $machine = WCOSS2 ]; then
-	    launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+	    launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	elif [ $machine = HERA -o $machine = ORION ]; then
 	    export SLURM_KILL_BAD_EXIT=0
 	    launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswarw_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_hireswarw_grid2obs_stats.sh
@@ -77,7 +77,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -146,7 +146,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -204,7 +204,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -259,7 +259,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -324,7 +324,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswarw_precip_stats.sh
+++ b/scripts/stats/cam/exevs_hireswarw_precip_stats.sh
@@ -86,7 +86,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -166,7 +166,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -220,7 +220,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -272,7 +272,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -347,7 +347,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswarw_snowfall_stats.sh
+++ b/scripts/stats/cam/exevs_hireswarw_snowfall_stats.sh
@@ -87,7 +87,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -164,7 +164,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -216,7 +216,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -265,7 +265,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -327,7 +327,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswarwmem2_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_hireswarwmem2_grid2obs_stats.sh
@@ -77,7 +77,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -146,7 +146,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -204,7 +204,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -260,7 +260,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -325,7 +325,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswarwmem2_precip_stats.sh
+++ b/scripts/stats/cam/exevs_hireswarwmem2_precip_stats.sh
@@ -86,7 +86,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -166,7 +166,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -220,7 +220,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -271,7 +271,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -346,7 +346,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswarwmem2_snowfall_stats.sh
+++ b/scripts/stats/cam/exevs_hireswarwmem2_snowfall_stats.sh
@@ -87,7 +87,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -164,7 +164,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -216,7 +216,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -265,7 +265,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -327,7 +327,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswfv3_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_hireswfv3_grid2obs_stats.sh
@@ -77,7 +77,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -146,7 +146,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -204,7 +204,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -260,7 +260,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -325,7 +325,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswfv3_precip_stats.sh
+++ b/scripts/stats/cam/exevs_hireswfv3_precip_stats.sh
@@ -86,7 +86,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -166,7 +166,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -220,7 +220,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -271,7 +271,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -346,7 +346,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hireswfv3_snowfall_stats.sh
+++ b/scripts/stats/cam/exevs_hireswfv3_snowfall_stats.sh
@@ -87,7 +87,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -164,7 +164,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -216,7 +216,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -265,7 +265,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -327,7 +327,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_href_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_href_grid2obs_stats.sh
@@ -106,7 +106,7 @@ chmod 775 run_href_all_grid2obs_poe
 # Run the POE script to generate small stat files
 #*************************************************
 if [ $run_mpi = yes ] ; then
-    mpiexec -np 36 -ppn 36 --cpu-bind verbose,depth cfp  ${DATA}/run_href_all_grid2obs_poe
+    mpiexec -np 36 -ppn 36 --cpu-bind verbose,core cfp  ${DATA}/run_href_all_grid2obs_poe
     export err=$?; err_chk
 else
     ${DATA}/run_href_all_grid2obs_poe

--- a/scripts/stats/cam/exevs_href_spcoutlook_stats.sh
+++ b/scripts/stats/cam/exevs_href_spcoutlook_stats.sh
@@ -78,7 +78,7 @@ chmod 775 run_href_all_grid2obs_poe
 # Run POE script to get small stat files
 # ***************************************
 if [ $run_mpi = yes ] ; then
-    mpiexec -np 2 -ppn 2 --cpu-bind verbose,depth cfp  ${DATA}/run_href_all_grid2obs_poe
+    mpiexec -np 2 -ppn 2 --cpu-bind verbose,core cfp  ${DATA}/run_href_all_grid2obs_poe
     export err=$?; err_chk
 else
     ${DATA}/run_href_all_grid2obs_poe

--- a/scripts/stats/cam/exevs_hrrr_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_hrrr_grid2obs_stats.sh
@@ -77,7 +77,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -146,7 +146,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -204,7 +204,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -260,7 +260,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -325,7 +325,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hrrr_precip_stats.sh
+++ b/scripts/stats/cam/exevs_hrrr_precip_stats.sh
@@ -86,7 +86,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -165,7 +165,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -220,7 +220,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -272,7 +272,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -347,7 +347,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_hrrr_snowfall_stats.sh
+++ b/scripts/stats/cam/exevs_hrrr_snowfall_stats.sh
@@ -87,7 +87,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -164,7 +164,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -216,7 +216,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -265,7 +265,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -327,7 +327,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_namnest_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_namnest_grid2obs_stats.sh
@@ -77,7 +77,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -146,7 +146,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -204,7 +204,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -260,7 +260,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -325,7 +325,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_namnest_precip_stats.sh
+++ b/scripts/stats/cam/exevs_namnest_precip_stats.sh
@@ -87,7 +87,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -168,7 +168,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -222,7 +222,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -273,7 +273,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -348,7 +348,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/cam/exevs_namnest_snowfall_stats.sh
+++ b/scripts/stats/cam/exevs_namnest_snowfall_stats.sh
@@ -87,7 +87,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -164,7 +164,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -216,7 +216,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -265,7 +265,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"
@@ -327,7 +327,7 @@ if [ "$vhr" -ge "$last_cyc" ]; then
                 export MP_PGMMODEL=mpmd
                 export MP_CMDFILE=${poe_script}
                 if [ $machine = WCOSS2 ]; then
-                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
+                    launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,core cfp"
                 elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                     export SLURM_KILL_BAD_EXIT=0
                     launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/global_det/exevs_global_det_atmos_grid2grid_stats.sh
+++ b/scripts/stats/global_det/exevs_global_det_atmos_grid2grid_stats.sh
@@ -58,7 +58,7 @@ for group in reformat_data assemble_data generate_stats gather_stats; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/global_det/exevs_global_det_atmos_grid2obs_stats.sh
+++ b/scripts/stats/global_det/exevs_global_det_atmos_grid2obs_stats.sh
@@ -59,7 +59,7 @@ for group in reformat_data assemble_data generate_stats gather_stats; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/global_det/exevs_global_det_wave_grid2obs_stats.sh
+++ b/scripts/stats/global_det/exevs_global_det_wave_grid2obs_stats.sh
@@ -118,7 +118,7 @@ if [[ $ncount_job -gt 0 ]]; then
         export MP_CMDFILE=${poe_script}
         nselect=$(cat $PBS_NODEFILE | wc -l)
         nnp=$(($nselect * $nproc))
-        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         $launcher $MP_CMDFILE
         export err=$?; err_chk
     else
@@ -229,7 +229,7 @@ if [[ $ncount_job -gt 0 ]]; then
         export MP_CMDFILE=${poe_script}
         nselect=$(cat $PBS_NODEFILE | wc -l)
         nnp=$(($nselect * $nproc))
-        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         $launcher $MP_CMDFILE
         export err=$?; err_chk
     else

--- a/scripts/stats/mesoscale/exevs_mesoscale_nam_grid2obs_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_nam_grid2obs_stats.sh
@@ -110,7 +110,7 @@ echo "*****************************"
         if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
            export SLURM_KILL_BAD_EXIT=0
 	   launcher="srun --export=ALL --multi-prog"
@@ -192,7 +192,7 @@ echo "*****************************"
         if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
            export SLURM_KILL_BAD_EXIT=0
            launcher="srun --export=ALL --multi-prog"
@@ -259,7 +259,7 @@ echo "*****************************"
 	if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
 	   export SLURM_KILL_BAD_EXIT=0
 	   launcher="srun --export=ALL --multi-prog"
@@ -335,7 +335,7 @@ echo "*****************************"
         if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
            export SLURM_KILL_BAD_EXIT=0
            launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/mesoscale/exevs_mesoscale_nam_precip_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_nam_precip_stats.sh
@@ -66,7 +66,7 @@ for group in $JOB_GROUP_list; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/mesoscale/exevs_mesoscale_nam_snowfall_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_nam_snowfall_stats.sh
@@ -66,7 +66,7 @@ for group in $JOB_GROUP_list; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/mesoscale/exevs_mesoscale_rap_grid2obs_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_rap_grid2obs_stats.sh
@@ -113,7 +113,7 @@ echo "*****************************"
         if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
            export SLURM_KILL_BAD_EXIT=0
 	   launcher="srun --export=ALL --multi-prog"
@@ -195,7 +195,7 @@ echo "*****************************"
         if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
            export SLURM_KILL_BAD_EXIT=0
            launcher="srun --export=ALL --multi-prog"
@@ -262,7 +262,7 @@ echo "*****************************"
 	if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
 	   export SLURM_KILL_BAD_EXIT=0
 	   launcher="srun --export=ALL --multi-prog"
@@ -338,7 +338,7 @@ echo "*****************************"
         if [ $machine = WCOSS2 ]; then
            nselect=$(cat $PBS_NODEFILE | wc -l)
            nnp=$(($nselect * $nproc))
-           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+           launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
         elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
            export SLURM_KILL_BAD_EXIT=0
            launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/mesoscale/exevs_mesoscale_rap_precip_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_rap_precip_stats.sh
@@ -66,7 +66,7 @@ for group in $JOB_GROUP_list; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/mesoscale/exevs_mesoscale_rap_snowfall_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_rap_snowfall_stats.sh
@@ -66,7 +66,7 @@ for group in $JOB_GROUP_list; do
             if [ $machine = WCOSS2 ]; then
                 nselect=$(cat $PBS_NODEFILE | wc -l)
                 nnp=$(($nselect * $nproc))
-                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+                launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,core cfp"
             elif [ $machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
                 export SLURM_KILL_BAD_EXIT=0
                 launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/subseasonal/exevs_subseasonal_grid2grid_stats.sh
+++ b/scripts/stats/subseasonal/exevs_subseasonal_grid2grid_stats.sh
@@ -243,7 +243,7 @@ for group in reformat_data assemble_data generate_stats gather_stats; do
 	    export MP_PGMMODEL=mpmd
 	    export MP_CMDFILE=${poe_script}
 	    if [ $machine = WCOSS2 ]; then
-	        launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+	        launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	    elif [ $machine = HERA -o $machine = ORION ]; then
 		export SLURM_KILL_BAD_EXIT=0
 	        launcher="srun --export=ALL --multi-prog"

--- a/scripts/stats/subseasonal/exevs_subseasonal_grid2obs_stats.sh
+++ b/scripts/stats/subseasonal/exevs_subseasonal_grid2obs_stats.sh
@@ -160,7 +160,7 @@ for group in reformat_data assemble_data generate_stats gather_stats; do
 	    export MP_PGMMODEL=mpmd
 	    export MP_CMDFILE=${poe_script}
 	    if [ $machine = WCOSS2 ]; then
-	        launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+	        launcher="mpiexec -np ${nproc} -ppn ${nproc} --cpu-bind verbose,core cfp"
 	    elif [ $machine = HERA -o $machine = ORION ]; then
 		export SLURM_KILL_BAD_EXIT=0
 	        launcher="srun --export=ALL --multi-prog"

--- a/ush/global_ens/evs_global_ens_atmos_cnv.sh
+++ b/ush/global_ens/evs_global_ens_atmos_cnv.sh
@@ -130,7 +130,7 @@ done # end of validhours
 #********************************
 chmod 775 run_all_gens_cnv_poe.sh
 if [ $run_mpi = yes ] ; then
-  mpiexec -n 28 -ppn 28 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_cnv_poe.sh
+  mpiexec -n 28 -ppn 28 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_cnv_poe.sh
   export err=$?; err_chk
 else
     ${DATA}/run_all_gens_cnv_poe.sh
@@ -166,7 +166,7 @@ done
 #**************************
 chmod 775 run_all_gens_cnv_poe2.sh
 if [ $run_mpi = yes ] ; then
-  mpiexec -n 14 -ppn 14 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_cnv_poe2.sh
+  mpiexec -n 14 -ppn 14 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_cnv_poe2.sh
   export err=$?; err_chk
 else
     ${DATA}/run_all_gens_cnv_poe2.sh

--- a/ush/global_ens/evs_global_ens_atmos_grid2grid.sh
+++ b/ush/global_ens/evs_global_ens_atmos_grid2grid.sh
@@ -242,10 +242,10 @@ if [ $verify = upper ] ; then
     if [ -s run_all_gens_g2g_${metplus_job}_poe.sh ] ; then
       if [ $run_mpi = yes ] ; then
         if [ ${modnam} = gefs ] ; then
-          mpiexec  -n 4 -ppn 4 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_g2g_${metplus_job}_poe.sh
+          mpiexec  -n 4 -ppn 4 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_g2g_${metplus_job}_poe.sh
           export err=$?; err_chk
         else
-          mpiexec  -n 2 -ppn 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_g2g_${metplus_job}_poe.sh
+          mpiexec  -n 2 -ppn 2 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_g2g_${metplus_job}_poe.sh
           export err=$?; err_chk
         fi
       else
@@ -443,10 +443,10 @@ if [ $verify = precip ] ; then
     if [ -s run_all_gens_precip_${metplus_job}_poe.sh ]; then
       if [ $run_mpi = yes ] ; then
         if [ ${modnam} = gefs ] ; then
-          mpiexec  -n 5 -ppn 5 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_precip_${metplus_job}_poe.sh
+          mpiexec  -n 5 -ppn 5 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_precip_${metplus_job}_poe.sh
           export err=$?; err_chk
         else
-          mpiexec  -n 1 -ppn 1 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_precip_${metplus_job}_poe.sh
+          mpiexec  -n 1 -ppn 1 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_precip_${metplus_job}_poe.sh
           export err=$?; err_chk
         fi
       else

--- a/ush/global_ens/evs_global_ens_atmos_grid2obs.sh
+++ b/ush/global_ens/evs_global_ens_atmos_grid2obs.sh
@@ -334,13 +334,13 @@ for field in $fields ; do
     #**********************************************
     if [ $run_mpi = yes ] ; then
       if [ ${modnam} = gefs ] ; then
-        mpiexec -n 60 -ppn 60 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_${field}_${metplus_job}_g2o_poe.sh
+        mpiexec -n 60 -ppn 60 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_${field}_${metplus_job}_g2o_poe.sh
         export err=$?; err_chk
       elif [ ${modnam} = cmce ] || [ ${modnam} = ecme ] ; then
-        mpiexec -n 24 -ppn 24 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_${field}_${metplus_job}_g2o_poe.sh
+        mpiexec -n 24 -ppn 24 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_${field}_${metplus_job}_g2o_poe.sh
         export err=$?; err_chk
       else
-        mpiexec -n 12 -ppn 12 --cpu-bind verbose,depth cfp ${DATA}/run_all_gens_${field}_${metplus_job}_g2o_poe.sh
+        mpiexec -n 12 -ppn 12 --cpu-bind verbose,core cfp ${DATA}/run_all_gens_${field}_${metplus_job}_g2o_poe.sh
         export err=$?; err_chk
       fi
     else

--- a/ush/global_ens/evs_global_ens_atmos_prep.sh
+++ b/ush/global_ens/evs_global_ens_atmos_prep.sh
@@ -266,7 +266,7 @@ if [ $run_mpi = yes ] ; then
 
  if [ -s run_get_all_gens_atmos_poe.sh ] ; then
    chmod +x run_get_all_gens_atmos_poe.sh 
-   mpiexec  -n 83 -ppn 83 --cpu-bind verbose,depth cfp ${DATA}/run_get_all_gens_atmos_poe.sh
+   mpiexec  -n 83 -ppn 83 --cpu-bind verbose,core cfp ${DATA}/run_get_all_gens_atmos_poe.sh
    export err=$?; err_chk
  fi
  

--- a/ush/global_ens/evs_naefs_atmos_prep.sh
+++ b/ush/global_ens/evs_naefs_atmos_prep.sh
@@ -72,7 +72,7 @@ fi
 if [ $run_mpi = yes ] ; then
  if [ -s run_get_all_naefs_atmos_poe.sh ] ; then
    chmod +x run_get_all_naefs_atmos_poe.sh 
-   mpiexec  -n 34 -ppn 34 --cpu-bind verbose,depth cfp  ${DATA}/run_get_all_naefs_atmos_poe.sh
+   mpiexec  -n 34 -ppn 34 --cpu-bind verbose,core cfp  ${DATA}/run_get_all_naefs_atmos_poe.sh
    export err=$?; err_chk
  fi
 else


### PR DESCRIPTION
## Pull Request Testing ##

This PR addresses item #3 in Wei Wei's EVS finding document:

Change “-cpu-bind verbose,depth” to “-cpu-bind verbose,core” in /scripts and /ush

- [ ] Describe testing already performed for this Pull Request:</br>

No testing was done.  

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

Tests recommended to see how well this change works.  Recommend 1 prep job, 1 stats job, and 1 plots job, and also a fourth test where the change was made in ush in global_ens, prep I think.  

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes or No]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes or No]**

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

ASAP

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
