### PR TITLE
Bugfix/cam rev11

### DIFF
--- a/scripts/plots/cam/exevs_href_grid2obs_ctc_plots.sh
+++ b/scripts/plots/cam/exevs_href_grid2obs_ctc_plots.sh
@@ -90,8 +90,7 @@ for stats in $stats_list ; do
        #VARs='VISsfc HGTcldceil'
        score_types='performance_diagram'   
     else
-     echo $stats is wrong stat
-     exit
+     err_exit "$stats is not a valid stat for vhr $fcst_valid_hour"
     fi   
  elif [ "$fcst_valid_hour" -eq "06" ] || [ "$fcst_valid_hour" -eq "18" ] ; then
     if [ $stats = csi_fbias ] ; then
@@ -109,8 +108,7 @@ for stats in $stats_list ; do
        #VARs='VISsfc HGTcldceil TCDC'
        score_types='performance_diagram'   
     else
-     echo $stats is wrong stat
-     exit
+     err_exit "$stats is not a valid stat for vhr $fcst_valid_hour"
     fi   
  else
     if [ $stats = csi_fbias ] ; then
@@ -128,8 +126,7 @@ for stats in $stats_list ; do
        #VARs='VISsfc HGTcldceil TCDC'
        score_types='performance_diagram'   
     else
-     echo $stats is wrong stat
-     exit
+     err_exit "$stats is not a valid stat for vhr $fcst_valid_hour"
     fi   
  fi
  for score_type in $score_types ; do

--- a/scripts/plots/cam/exevs_href_grid2obs_ecnt_plots.sh
+++ b/scripts/plots/cam/exevs_href_grid2obs_ecnt_plots.sh
@@ -80,8 +80,7 @@ for fcst_valid_hour in 00 03 06 09 12 15 18 21 ; do
      fi
      score_types='lead_average'
    else
-     echo $stats is wrong stat
-     exit
+     err_exit "$stats is not a valid stat"
    fi   
 
  for score_type in $score_types ; do

--- a/scripts/plots/cam/exevs_href_precip_plots.sh
+++ b/scripts/plots/cam/exevs_href_precip_plots.sh
@@ -86,8 +86,7 @@ for stats in ets_fbias ratio_pod_csi fss ; do
     interp_pnts='1,9,25,49,91,121'
     score_types='threshold_average' 
  else
-  echo $stats is wrong stat
-  exit
+  err_exit "$stats is not a valid stat"
  fi   
 
  for score_type in $score_types ; do

--- a/scripts/plots/cam/exevs_href_profile_plots.sh
+++ b/scripts/plots/cam/exevs_href_profile_plots.sh
@@ -82,8 +82,7 @@ elif [ $stats = bss ] ; then
   score_types='lead_average'
   VARS='TMP_lt0C WIND_ge30kt WIND_ge40kt'
 else
-  echo $stats is wrong stat
-  exit
+  err_exit "$stats is not a valid stat"
 fi   
 
  for fcst_valid_hour in 00 12 ; do

--- a/scripts/plots/cam/exevs_href_snowfall_plots.sh
+++ b/scripts/plots/cam/exevs_href_snowfall_plots.sh
@@ -86,8 +86,7 @@ for stats in ets_fbias ratio_pod_csi fss ; do
     interp_pnts='1,9,25,49,91,121'
     score_types='threshold_average' 
  else
-  echo $stats is wrong stat
-  exit
+  err_exit "$stats is not a valid stat"
  fi   
 
  for score_type in $score_types ; do

--- a/scripts/plots/cam/exevs_href_spcoutlook_plots.sh
+++ b/scripts/plots/cam/exevs_href_spcoutlook_plots.sh
@@ -86,8 +86,7 @@ for stats in csi_fbias ratio_pod_csi ; do
     VARs='CAPEsfc MLCAPE'
     score_types='performance_diagram'   
  else
-  echo $stats is wrong stat
-  exit
+  err_exit "$stats is not a valid stat"
  fi   
 
  for score_type in $score_types ; do

--- a/scripts/stats/cam/exevs_href_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_href_grid2obs_stats.sh
@@ -65,7 +65,9 @@ if [ $prepare = yes ] ; then
        echo Missing file is $COMINobsproc/rap.${VDATE}/rap.t12z.prepbufr.tm00 or $COMINobsproc/gdas.${vday}/00/atmos/gdas.t00z.prepbufr  >> mailmsg
        echo "Job ID: $jobid" >> mailmsg
        cat mailmsg | mail -s "$subject" $MAILTO
-       exit
+       export verif_system=no
+       export verif_profile=no
+       export verif_product=no
   fi
 
 fi 

--- a/scripts/stats/cam/exevs_href_precip_stats.sh
+++ b/scripts/stats/cam/exevs_href_precip_stats.sh
@@ -21,6 +21,9 @@ export run_mpi=${run_mpi:-'yes'}
 export prepare=${prepare:-'yes'}
 export verif_precip=${verif_precip:-'yes'}
 export verif_snowfall=${verif_snowfall:-'yes'}
+if [ "$verif_precip" = "no" ] && [ "$verif_snowfall" = "no" ] ; then
+    export gather='no'
+fi
 export gather=${gather:-'yes'}
 export verify='precip'
 

--- a/scripts/stats/cam/exevs_href_precip_stats.sh
+++ b/scripts/stats/cam/exevs_href_precip_stats.sh
@@ -18,12 +18,13 @@ export WORK=$DATA
 cd $WORK
 
 export run_mpi=${run_mpi:-'yes'}
-export prepare=${prepare:-'yes'}
 export verif_precip=${verif_precip:-'yes'}
 export verif_snowfall=${verif_snowfall:-'yes'}
 if [ "$verif_precip" = "no" ] && [ "$verif_snowfall" = "no" ] ; then
     export gather='no'
+    export prepare='no'
 fi
+export prepare=${prepare:-'yes'}
 export gather=${gather:-'yes'}
 export verify='precip'
 

--- a/scripts/stats/cam/exevs_href_spcoutlook_stats.sh
+++ b/scripts/stats/cam/exevs_href_spcoutlook_stats.sh
@@ -25,9 +25,9 @@ export lvl='both'
 export verify_all=${verify_all:-'yes'}
 
 export prepare='yes'
-export verif_system='es'
-export verif_profile='es'
-export verif_product='es'
+export verif_system='yes'
+export verif_profile='yes'
+export verif_product='yes'
 export verif_spcoutlook='yes'
 export gather=${gather:-'yes'}
 export verify=$VERIF_CASE

--- a/ush/cam/df_preprocessing.py
+++ b/ush/cam/df_preprocessing.py
@@ -184,12 +184,11 @@ def create_df(logger, stats_dir, pruned_data_dir, line_type, date_range,
             df.reset_index(drop=True, inplace=True)
             return df
     except UnboundLocalError as e:
-        logger.error(e)
-        logger.error(
-            "FATAL ERROR: Nonexistent dataframe. Check the logfile for more details."
+        logger.warning(e)
+        logger.warning(
+            "Nonexistent dataframe. Stats directory may be empty. Check the logfile for more details."
         )
-        logger.error("Quitting ...")
-        sys.exit(1)
+        return None
 
 def filter_by_level_type(df, logger, verif_type):
     if df is None:

--- a/ush/cam/evs_check_href_files.sh
+++ b/ush/cam/evs_check_href_files.sh
@@ -24,8 +24,6 @@ if [ $VERIF_CASE = grid2obs ] || [ $VERIF_CASE = spcoutlook ] ; then
    if [ $missing -eq 24  ] ; then
       echo "WARNING: All of the preppbufr files are missing."
       export verif_all=no
-      export err=$?
-      exit $err
    fi
 
 fi
@@ -64,8 +62,6 @@ if [ $VERIF_CASE = precip ] ; then
    if [ $missing -eq 24  ] ; then
       echo "WARNING: All of the ccpa files are missing"
       export verif_precip=no
-      export err=$?
-      exit $err
    fi                 
 
    missing=0
@@ -96,8 +92,6 @@ if [ $VERIF_CASE = precip ] ; then
    if [ $missing -eq 8  ] ; then
       echo "WARNING: All of the ccpa03h files are missing"
       export verif_precip=no
-      export err=$?
-      exit $err
    fi
 
    missing=0
@@ -120,8 +114,6 @@ if [ $VERIF_CASE = precip ] ; then
    if [ $missing -ge 1  ] ; then
       echo "WARNING: At least one of the ccpa06h files are missing"
       export verif_precip=no
-      export err=$?
-      exit $err
    fi
 
    accum=01
@@ -137,8 +129,6 @@ if [ $VERIF_CASE = precip ] ; then
    if [ $missing -eq 24  ] ; then
       echo "WARNING: All of mrms01h files are missing"
       export verif_precip=no
-      export err=$?
-      exit $err
    fi
 
    accum=03
@@ -154,8 +144,6 @@ if [ $VERIF_CASE = precip ] ; then
    if [ $missing -eq 8  ] ; then
       echo "WARNING: All of mrms03h files are missing"
       export verif_precip=no
-      export err=$?
-      exit $err
    fi
 
    accum=24
@@ -171,8 +159,6 @@ if [ $VERIF_CASE = precip ] ; then
    if [ $missing -eq 4  ] ; then
       echo "WARNING: All of the mrms24h files are missing"   
       export verif_precip=no
-      export err=$?
-      exit $err
    fi
 fi
 
@@ -206,8 +192,6 @@ for obsv_cyc in 00 03 06 09 12 15 18 21 ; do
             export verif_precip=no
             export verif_snowfall=no
             export verif_all=no
-            export err=$?
-            exit $err
          fi
       fi
    done
@@ -242,8 +226,6 @@ for obsv_cyc in 00 03 06 09 12 15 18 21 ; do
             export verif_precip=no
             export verif_snowfall=no
             export verif_all=no
-            export err=$?
-            exit $err
          fi
       fi
    done
@@ -274,8 +256,6 @@ for obsv_cyc in 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 2
             export verif_precip=no
             export verif_snowfall=no
             export verif_all=no
-            export err=$?
-            exit $err
           fi
       fi
       fhr=$((fhr+1))  
@@ -307,8 +287,6 @@ for obsv_cyc in 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 2
             export verif_precip=no
             export verif_snowfall=no
             export verif_all=no
-            export err=$?
-            exit $err
          fi
       fi
       fhr=$((fhr+1))  

--- a/ush/cam/evs_href_gather.sh
+++ b/ush/cam/evs_href_gather.sh
@@ -66,6 +66,3 @@ chmod 775 run_gather_all_poe.sh
 #*****************************
 ${DATA}/run_gather_all_poe.sh
 export err=$?; err_chk
-
-exit
-

--- a/ush/cam/evs_href_grid2obs_product.sh
+++ b/ush/cam/evs_href_grid2obs_product.sh
@@ -182,7 +182,7 @@ for prod in mean prob ; do
 
    else
 
-    exit
+    err_exit "$dom is not a valid domain"
 
    fi   
 
@@ -191,7 +191,3 @@ for prod in mean prob ; do
 done #end of prod loop
 
 chmod 775 run_all_href_product_poe.sh
-
-
-exit
-

--- a/ush/cam/evs_href_grid2obs_profile.sh
+++ b/ush/cam/evs_href_grid2obs_profile.sh
@@ -294,7 +294,3 @@ for dom in $domains ; do
 
 
 chmod 775 run_all_href_profile_poe.sh
-
-exit
-
-

--- a/ush/cam/evs_href_grid2obs_system.sh
+++ b/ush/cam/evs_href_grid2obs_system.sh
@@ -172,6 +172,3 @@ for dom in CONUS Alaska ; do
     fi 
 
 done #end of dom
-
-exit
-

--- a/ush/cam/evs_href_precip.sh
+++ b/ush/cam/evs_href_precip.sh
@@ -409,6 +409,4 @@ for obsvtype in ccpa mrms ; do
    done  #end of obsv
 
 done # end of domain 
-
 export err=$?; err_chk
-exit

--- a/ush/cam/evs_href_prepare.sh
+++ b/ush/cam/evs_href_prepare.sh
@@ -121,8 +121,6 @@ if [ "$data" = "ccpa01h03h" ] ; then
       echo -e "`cat $DATA/job${data}${domain}_missing_ccpa_list`" >> mailmsg
       echo "Job ID: $jobid" >> mailmsg
       cat mailmsg | mail -s "$subject" $MAILTO
-      export err=$?; err_chk
-      exit
     fi
    fi
 fi
@@ -174,8 +172,6 @@ if [ "$data" = "ccpa24h" ] ; then
             echo -e "`cat $DATA/job${data}${domain}_missing_24hrccpa_list`" >> mailmsg
             echo "Job ID: $jobid" >> mailmsg
             cat mailmsg | mail -s "$subject" $MAILTO
-            export err=$?; err_chk
-            exit
          fi
       fi
    done
@@ -307,8 +303,6 @@ if [ "$data" = "prepbufr" ] ; then
          echo Missing file is $COMINobsproc/rap.${VDATE}/rap.t12z.prepbufr.tm00  >> mailmsg
          echo "Job ID: $jobid" >> mailmsg
          cat mailmsg | mail -s "$subject" $MAILTO
-         export err=$?; err_chk
-         exit 
       fi
    fi
 fi
@@ -349,8 +343,6 @@ if [ "$data" = "gfs_prepbufr" ] ; then
          echo Missing file is $COMINobsproc/gdas.${vday}/18/atmos/gdas.t18z.prepbufr  >> mailmsg
          echo "Job ID: $jobid" >> mailmsg
          cat mailmsg | mail -s "$subject" $MAILTO
-         export err=$?; err_chk
-         exit
       fi
    fi
 fi
@@ -412,8 +404,6 @@ if [ "$data" = "mrms" ] ; then
          echo Missing file is $DCOMINmrms/MultiSensor_QPE_*.grib2.gz  >> mailmsg
          echo "Job ID: $jobid" >> mailmsg
          cat mailmsg | mail -s "$subject" $MAILTO
-         export err=$?; err_chk
-         exit
       fi
    fi
 fi 

--- a/ush/cam/evs_href_snowfall.sh
+++ b/ush/cam/evs_href_snowfall.sh
@@ -9,6 +9,7 @@ set -x
 # Build POE script to collect sub-jobs 
 #******************************************
 export members=10
+export write_job_cards=yes
 >run_all_href_snowfall_poe.sh
 
 mkdir -p $COMOUTsmall/HREF_SNOW
@@ -23,10 +24,10 @@ if [ ! -s $COMSNOW/${VDATE}/wgrbbul/nohrsc_snowfall/sfav2_CONUS_24h_${VDATE}12_g
    cat mailmsg | mail -s "$subject" $MAILTO
   fi
   echo "WARNING:  No NOHRSC data $COMSNOW/${VDATE}/wgrbbul/nohrsc_snowfall/sfav2_CONUS_24h_${VDATE}12_grid184.grb2 available for ${VDATE}! Terminate snowfall verification"
-  exit
+  export write_job_cards=no
 fi
 
-
+if [ "$write_job_cards" = "yes" ] ; then
 for obsv in 6h 24h  ; do
 
     #*****************************
@@ -130,7 +131,5 @@ for obsv in 6h 24h  ; do
         done #end of vhr
     done #end of fhr
 done  #end of obsv
-
+fi
 chmod 775 run_all_href_snowfall_poe.sh
-
-

--- a/ush/cam/evs_href_spcoutlook.sh
+++ b/ush/cam/evs_href_spcoutlook.sh
@@ -22,7 +22,7 @@ mask_day1=${EVSINspcotlk:0:$index}/cam/spc_otlk.$day1
 mask_day2=${EVSINspcotlk:0:$index}/cam/spc_otlk.$day2
 mask_day3=${EVSINspcotlk:0:$index}/cam/spc_otlk.$day3
 
-
+write_job_cards=yes
 if ([ ! -d  $mask_day1 ] || (! ls $mask_day1/spc_otlk.day1_*G227.nc 1> /dev/null 2>&1)) \
   && ([ ! -d  $mask_day2 ] || (! ls $mask_day2/spc_otlk.day2_*G227.nc 1> /dev/null 2>&1)) \
   && ([ ! -d  $mask_day3 ] || (! ls $mask_day3/spc_otlk.day3_*G227.nc 1> /dev/null 2>&1)) ; then
@@ -38,7 +38,7 @@ if ([ ! -d  $mask_day1 ] || (! ls $mask_day1/spc_otlk.day1_*G227.nc 1> /dev/null
     echo "Missing mask files are $mask_day1/spc_otlk.day1_*G227.nc , $mask_day2/spc_otlk.day2_*G227.nc and $mask_day3/spc_otlk.day3_*G227.nc"
     echo "This will occur if no outlooks were issued on ${VDATE}."
   fi
-  exit
+  write_job_cards=no
 fi
 
 
@@ -90,7 +90,7 @@ cd $WORK
 >run_all_href_spcoutlook_poe.sh
 
 obsv='prepbufr'
-
+if [ "$write_job_cards" = "yes" ] ; then
 for prod in mean ; do
 
  PROD=`echo $prod | tr '[a-z]' '[A-Z]'`
@@ -148,9 +148,7 @@ for prod in mean ; do
   done #end of dom loop
 
 done #end of prod loop
+fi
 
 chmod 775 run_all_href_spcoutlook_poe.sh
-
 export err=$?; err_chk
-exit
-

--- a/ush/cam/evs_href_spcoutlook_cape.sh
+++ b/ush/cam/evs_href_spcoutlook_cape.sh
@@ -99,6 +99,3 @@ for prod in mean ; do
 done #end of prod loop
 
 chmod 775 run_all_href_spcoutlook_poe.sh
-
-exit
-

--- a/ush/cam/ush_href_plot_py/df_preprocessing.py
+++ b/ush/cam/ush_href_plot_py/df_preprocessing.py
@@ -169,12 +169,11 @@ def create_df(logger, stats_dir, pruned_data_dir, line_type, date_range,
             df.reset_index(drop=True, inplace=True)
             return df
     except UnboundLocalError as e:
-        logger.error(e)
-        logger.error(
-            "FATAL ERROR: Nonexistent dataframe. Check the logfile for more details."
+        logger.warning(e)
+        logger.warning(
+            "Nonexistent dataframe. Stats directory may be empty.  Check the logfile for more details."
         )
-        logger.error("Quitting ...")
-        sys.exit(1)
+        return None
 
 def filter_by_level_type(df, logger, verif_type):
     if df is None:


### PR DESCRIPTION
## Pull Request Testing ##

- [x] Describe testing already performed for this Pull Request:</br>

This PR removes exit statements and, where appropriate, replaces them with boolean variables that are used to determine the condition for proceeding with verification.

The affected jobs were not tested.

---
- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

### (1) Set up jobs 
•	symlink the EVS_fix directory locally as "fix"
•	In all driver scripts, point all exports of "HOMEevs" to your EVS test directory
•	In all driver scripts, change COMIN to the parallel directory (`/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`)
•	For data denial tests: in all driver scripts, set SENDMAIL to "NO"
•	For data denial tests: in all driver scripts, set envir to "pppp"
•	For data denial tests: in all driver scripts, add the following line: `export DCOMROOT=/lfs/h1/ops/pppp/dcom`

### (2) Test Jobs
Use the following to submit all jobs: `qsub –v vhr=00 `

From your EVS testing directory, the following scripts should be run using the setup in step (1):
```
dev/drivers/scripts/stats/cam/jevs_cam_href_grid2obs_stats.sh
dev/drivers/scripts/stats/cam/jevs_cam_href_precip_stats.sh
dev/drivers/scripts/stats/cam/jevs_cam_href_spcoutlook_stats.sh
```
```
dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ctc_past31days_plots.sh
dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.sh
dev/drivers/scripts/plots/cam/jevs_cam_href_precip_past31days_plots.sh
dev/drivers/scripts/plots/cam/jevs_cam_href_profile_past31days_plots.sh
dev/drivers/scripts/plots/cam/jevs_cam_href_snowfall_past31days_plots.sh
dev/drivers/scripts/plots/cam/jevs_cam_href_spcoutlook_past31days_plots.sh
```
_[Total: 3 stats jobs; 6 plots jobs]_


### (3) Review

Data denial runs can use the following check:
- check for FATAL ERROR: `grep -l "FATAL ERROR" $outfile`
- check for no WARNINGs: `grep -L "WARNING" $outfile`

Neither job should output any FATAL ERRORs.  Both jobs should output WARNINGs indicating missing files.

Nominal runs can use the following check:
```
check="FATAL\|WARNING\|error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $outfile
```

---
- [x] Has the code been checked to ensure that no errors occur during the execution? **YES**

---
- [x] Do these updates/additions include sufficient testing updates? **YES**

---
- [x] Please complete this pull request review by **02/14/2024**.</br>

---
## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
