### PR TITLE
Adding transfer directory and removing PBS -V from ecf scripts

### DIFF
--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=11:50:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 export model=evs
 %include <head.h>

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 export model=evs
 %include <head.h>

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=06:50:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 export model=evs
 %include <head.h>

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=10:15:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 export model=evs
 %include <head.h>

--- a/ecf/scripts/stats/analyses/jevs_analyses_rtma_grid2obs_stats_vhr_master.ecf
+++ b/ecf/scripts/stats/analyses/jevs_analyses_rtma_grid2obs_stats_vhr_master.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:25:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 export model=evs
 %include <head.h>

--- a/parm/transfer/transfer_evs_plots.list
+++ b/parm/transfer/transfer_evs_plots.list
@@ -1,0 +1,65 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/evs/_SHORTVER_/plots/
++ /analyses/
++ /analyses/atmos._PDYm3_/***
++ /analyses/atmos._PDYm2_/***
++ /aqm/
++ /aqm/*._PDYm5_/***
++ /aqm/*._PDYm4_/***
++ /cam/
++ /cam/*._PDYm4_/***
++ /cam/*._PDYm3_/***
++ /cam/*._PDYm2_/***
++ /cam/*._PDYm1_/***
++ /global_det/
++ /global_det/*._PDYm2_/
++ /global_det/*._PDYm2_/*.tar
++ /global_det/*._PDYm1_/
++ /global_det/*._PDYm1_/*.tar
++ /global_ens/
++ /global_ens/*._PDYm2_/***
++ /global_ens/*._PDYm1_/***
++ /mesoscale/
++ /mesoscale/*._PDYm3_/***
++ /mesoscale/*._PDYm2_/***
++ /mesoscale/*._PDYm1_/***
++ /narre/
++ /narre/atmos._PDYm2_/***
++ /narre/atmos._PDYm1_/***
++ /nfcens/
++ /nfcens/wave._PDYm2_/***
++ /nfcens/wave._PDYm1_/***
++ /rtofs/
++ /rtofs/*._PDYm4_/***
++ /rtofs/*._PDYm3_/***
++ /subseasonal/
++ /subseasonal/atmos._PDYm3_/***
++ /subseasonal/atmos._PDYm2_/***
+- *
+B 100000
+

--- a/parm/transfer/transfer_evs_prep.list
+++ b/parm/transfer/transfer_evs_prep.list
@@ -1,0 +1,58 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/evs/_SHORTVER_/prep/
++ /aqm/
++ /aqm/atmos._PDYm4_/***
++ /aqm/atmos._PDYm3_/***
++ /cam/
++ /cam/*._PDYm2_/***
++ /cam/*._PDYm1_/***
++ /global_det/
++ /global_det/*._PDYm2_/***
++ /global_det/*._PDYm1_/***
++ /global_ens/
++ /global_ens/*._PDYm3_/***
++ /global_ens/*._PDYm2_/***
++ /global_ens/*._PDYm1_/***
++ /nfcens/
++ /nfcens/wave._PDYm2_/***
++ /nfcens/wave._PDYm1_/***
++ /subseasonal/
++ /subseasonal/atmos._PDYm3_/***
++ /subseasonal/atmos._PDYm2_/***
++ /rtofs/
++ /rtofs/rtofs._PDYm10_/***
++ /rtofs/rtofs._PDYm9_/***
++ /rtofs/rtofs._PDYm8_/***
++ /rtofs/rtofs._PDYm7_/***
++ /rtofs/rtofs._PDYm6_/***
++ /rtofs/rtofs._PDYm5_/***
++ /rtofs/rtofs._PDYm4_/***
++ /rtofs/rtofs._PDYm3_/***
++ /rtofs/rtofs._PDYm2_/***
+- *
+B 100000

--- a/parm/transfer/transfer_evs_stats_1.list
+++ b/parm/transfer/transfer_evs_stats_1.list
@@ -1,0 +1,63 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/evs/_SHORTVER_/stats/
++ /analyses/
++ /analyses/*._PDYm2_/***
++ /analyses/*._PDYm1_/***
++ /aqm/
++ /aqm/*._PDYm4_/***
++ /aqm/*._PDYm3_/***
++ /global_det/
++ /global_det/*._PDYm2_/***
++ /global_det/*._PDYm1_/***
++ /mesoscale/
++ /mesoscale/*._PDYm3_/***
++ /mesoscale/*._PDYm2_/***
++ /mesoscale/*._PDYm1_/***
++ /narre/
++ /narre/*._PDYm2_/***
++ /narre/*._PDYm1_/***
++ /nfcens/
++ /nfcens/*._PDYm2_/***
++ /nfcens/*._PDYm1_/***
++ /rtofs/
++ /rtofs/rtofs._PDYm4_/***
++ /rtofs/*._PDYm3_/***
++ /rtofs/*._PDYm2_/***
++ /subseasonal/
++ /subseasonal/*._PDYm3_/***
++ /subseasonal/*._PDYm2_/***
++ /wafs/
++ /wafs/*._PDYm3_/***
++ /wafs/*._PDYm2_/***
++ /wafs/*._PDYm1_/***
++ /cam/
++ /cam/atmos._PDYm2_/***
++ /cam/atmos._PDYm1_/***
+- *
+B 100000
+

--- a/parm/transfer/transfer_evs_stats_2.list
+++ b/parm/transfer/transfer_evs_stats_2.list
@@ -1,0 +1,64 @@
+# This file specifies the directories to be tranatmfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the tranatmfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  W  whole files, copy whole files rather than use delta-xfer algorithm (takes no arg)  (v2.2.3+)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# tranatmferred.
+
+_COMROOT_/evs/_SHORTVER_/stats/
++ /cam/
++ /cam/hireswarw*._PDYm8_/***
++ /cam/hireswarw*._PDYm7_/***
++ /cam/hireswarw*._PDYm3_/***
++ /cam/hireswarw*._PDYm2_/***
++ /cam/hireswarw*._PDYm1_/***
++ /cam/hireswarw*._PDY_/***
++ /cam/hireswfv3._PDYm8_/***
++ /cam/hireswfv3._PDYm7_/***
++ /cam/hireswfv3._PDYm3_/***
++ /cam/hireswfv3._PDYm2_/***
++ /cam/hireswfv3._PDYm1_/***
++ /cam/hireswfv3._PDY_/***
++ /cam/hrrr._PDYm8_/***
++ /cam/hrrr._PDYm7_/***
++ /cam/hrrr._PDYm3_/***
++ /cam/hrrr._PDYm2_/***
++ /cam/hrrr._PDYm1_/***
++ /cam/href._PDYm8_/***
++ /cam/href._PDYm7_/***
++ /cam/href._PDYm3_/***
++ /cam/href._PDYm2_/***
++ /cam/href._PDYm1_/***
++ /cam/nam_firewxnest._PDYm2_/***
++ /cam/nam_firewxnest._PDYm1_/***
++ /cam/namnest._PDYm8_/***
++ /cam/namnest._PDYm7_/***
++ /cam/namnest._PDYm3_/***
++ /cam/namnest._PDYm2_/***
++ /cam/namnest._PDYm1_/***
++ /global_ens/
++ /global_ens/*._PDYm3_/***
++ /global_ens/*._PDYm2_/***
++ /global_ens/*._PDYm1_/***
+- *
+B 100000
+


### PR DESCRIPTION
## Pull Request Testing ##

NCO has added a transfer directory under parm, for mirror jobs between the two machines.  They also removed the #PBS -V option from several ecf scripts.  The transfer directory has been added, and the PBS option has been removed.  

- [ ] Describe testing already performed for this Pull Request:</br>

Done by NCO.  

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

No testing needed.  

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes or No]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes or No]**

- [ ] Please complete this pull request review by **[Fill in date]**.</br>

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
