### PR TITLE
bugfix/ndbc_times

### DIFF
--- a/ush/global_det/global_det_wave_prep_trim_ndbc_files.py
+++ b/ush/global_det/global_det_wave_prep_trim_ndbc_files.py
@@ -28,6 +28,7 @@ FIXevs = os.environ['FIXevs']
 # Set up dates
 INITDATE_dt = datetime.datetime.strptime(INITDATE, '%Y%m%d')
 INITDATEp1_dt = datetime.datetime.strptime(INITDATEp1, '%Y%m%d')
+INITDATEm1_dt = INITDATE_dt - datetime.timedelta(days=1)
 
 # Assign header columns in NDBC individual buoy files
 ndbc_header1 = ("#YY  MM DD hh mm WDIR WSPD GST  WVHT   DPD   APD MWD   "
@@ -65,16 +66,24 @@ for ndbc_input_file in glob.glob(os.path.join(DCOMINndbc,
             keep_default_na=False, dtype='str', header=None,
             names=ndbc_header1[1:].split()
         )
-        trimmed_ndbc_input_file_df = ndbc_input_file_df[
+        INITDATE_ndbc_input_file_df = ndbc_input_file_df[
             (ndbc_input_file_df['YY'] == f"{INITDATE_dt:%Y}") \
              & (ndbc_input_file_df['MM'] == f"{INITDATE_dt:%m}") \
              & (ndbc_input_file_df['DD'] == f"{INITDATE_dt:%d}")
+        ]
+        INITDATEm1_ndbc_input_file_df = ndbc_input_file_df[
+            (ndbc_input_file_df['YY'] == f"{INITDATEm1_dt:%Y}") \
+             & (ndbc_input_file_df['MM'] == f"{INITDATEm1_dt:%m}") \
+             & (ndbc_input_file_df['DD'] == f"{INITDATEm1_dt:%d}")
         ]
         ndbc_tmp_file_data = open(ndbc_tmp_file, 'w')
         ndbc_tmp_file_data.write(ndbc_header1)
         ndbc_tmp_file_data.write(ndbc_header2)
         ndbc_tmp_file_data.close()
-        trimmed_ndbc_input_file_df.to_csv(
+        INITDATE_ndbc_input_file_df.to_csv(
+            ndbc_tmp_file, header=None, index=None, sep=' ', mode='a'
+        )
+        INITDATEm1_ndbc_input_file_df.to_csv(
             ndbc_tmp_file, header=None, index=None, sep=' ', mode='a'
         )
         if SENDCOM == 'YES':


### PR DESCRIPTION
## Pull Request Testing ##

The NDBC buoy files in dcom keep data for weeks, even months in the text files. In the current global_det wave prep step, the NDBC buoy files in dcom are trimmed down to keep only INITDATE so that ascii2nc and point_stat run faster (not processing data that is not used). When point_stat is run there is a +/- 30 min window around the observation time. For 00Z this goes into 30 minutes back into the previous day, and the trimming of the NDBC buoy data misses the observations from the -30 min period. 

This fix adds to the prep step the addition of the day previous to INITDATE's observations.

- [ ] Describe testing already performed for this Pull Request:</br>

> I ran global_det wave prep and checked the trimmed NDBC files have the previous day to INITDATE in there. I also ran GFS wave stats. I saw in the ascii2nc file from the NDBC output had the additional data in there, and observation counts for the NDBC in the final stat file changed.

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

###  **Set-up**
> 1. Clone my fork and checkout branch bugfix/ndbc_times
> 2. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`

### ✅ **global_det wave prep**
> 4.  `cd dev/drivers/scripts/prep/global_det`
> 5. In jevs_global_det_wave_prep.sh, set HOMEevs to the location of the clone. Run.

### ✅  **global_det wave stats**
> 4.  `cd dev/drivers/scripts/stats/global_det`
> 5. In jevs_global_det_wave_gfs_grid2obs_stats.sh, set HOMEevs to the location of the clone, set COMIN to the location of the prep data that was previously run for this PR. Run (please see notes prior to running though).
> **NOTE 1:** When I did my testing earlier I was using  MET v11.0.2 and METplus v5.0.1 (matching operations). As of thia writing, the current METplus version in develop is v6.0.0-beta3 which has a bug in the Ascii2nc wrapper causing that job to fail. It is fixed in METplus v6.0.0-beta4 though. Can run.ver be updated for this testing to use METplus v6.0.0-beta4?
>**NOTE 2:** It would be nice to also link the global_det wave prep output from com in the same output directory from the testing of prep so that the GFS files for all forecast hours are there. In needs to be linked rather than pointing COMIN to it because we need to use the corrected NDBC buoy files from prep!
> 6. Rerun for MET v11.0.2 and METplus v5.0.1.

- [ ] Has the code been checked to ensure that no errors occur during the execution? **Yes**

- [ ] Do these updates/additions include sufficient testing updates? **Yes**

- [ ] Please complete this pull request review by **05/17/2024 👼 🙏 **.</br>

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
