### PR TITLE
MET version was removed from the config file.

### DIFF
--- a/parm/metplus_config/plots/rtofs/grid2grid/verif_plotting.rtofs.conf
+++ b/parm/metplus_config/plots/rtofs/grid2grid/verif_plotting.rtofs.conf
@@ -28,7 +28,9 @@ export LOG_METPLUS="$DATA/logs/$COMPONENT/verif_plotting.`date '+%Y%m%d%H%M%S'`_
 export LOG_LEVEL="DEBUG"
 
 # Version of MET listed in the METplus stat files used to create graphics.
-export MET_VERSION="11.0"
+IFS='.' read -ra MET_VER <<< "$met_ver"
+printf -v MET_VERSION '%s.' "${MET_VER[@]:0:2}"
+export MET_VERSION="${MET_VERSION%.}"
 
 # Will use statistics for all comma-separated models. Names must match the
 # model naming convention in ${OUTPUT_BASE_DIR}.


### PR DESCRIPTION
## Pull Request Testing ##
 
- [ ] Describe testing already performed for this Pull Request:</br>
This PR removes the hardcoding of MET version from EVS-RTOFS.
After modifying the EVS-RTOFS config file for grid2grid plots, the test was performed with one of the RUNs: "aviso". The test generated expected results.

- [ ] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
For testing please follow this steps:
1- Clone my fork and checkout this branch: bugfix/rtofs_MET_version
2- For "plots" step: cd dev/driver/scripts/plots/rtofs/
3- Run all the plot scrips that include "grid2grid" in their names.

- [ ] Has the code been checked to ensure that no errors occur during the execution? **[Yes]**

- [ ] Do these updates/additions include sufficient testing updates? **[Yes]**

- [ ] Please complete this pull request review by **[05/22/2024]**.</br> 

## Pull Request Checklist ##

- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR description above.
- [ ] Ensure the PR title matches the feature branch name.
- [ ] Check the following:
- [ ]  Instructions provided on how to run
- [ ]  Developer's name is replaced by ${user} where necessary throughout the code
- [ ]  Check that the ecf file has all the proper definitions of variables
- [ ]  Check that the jobs file has all the proper settings of COMIN and COMOUT and other input variables
- [ ]  Check to see that the output directory structure is followed
- [ ]  Be sure that you are not using MET utilities outside the METplus wrapper structure

- [ ] After submitting the PR, select **Development** issue with the original issue number.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue.
