### PR TITLE
Feature/bugfix href missing files

### DIFF
--- a/ush/cam/evs_href_gather.sh
+++ b/ush/cam/evs_href_gather.sh
@@ -11,6 +11,8 @@ export regrid='NONE'
 modnam=href
 verify=$1
 
+get_gather=no
+
 if [ $verify = precip ] ; then
  if [ "$verif_precip" = "no" ] ; then
   MODELS='HREF_SNOW'
@@ -19,11 +21,24 @@ if [ $verify = precip ] ; then
  else
   MODELS='HREF HREF_MEAN HREF_PMMN HREF_LPMM HREF_AVRG  HREF_PROB HREF_EAS HREF_SNOW'
  fi
+  for MODL in $MODELS ; do
+    if [ -s $COMOUTsmall/${MODL}/*.stat ] ; then
+      get_gather=yes
+    fi
+  done
 elif [ $verify = grid2obs ] ; then
  MODELS='HREF HREF_MEAN HREF_PROB'
+ if [ -s $COMOUTsmall/*.stat ] ; then
+    get_gather=yes
+ fi
 elif [ $verify = spcoutlook ] ; then
  MODELS='HREF_MEAN'
+ if [ -s $COMOUTsmall/*.stat ] ; then
+    get_gather=yes
+ fi
 fi 
+
+if [ $get_gather = yes ] ; then
 
 #****************************************
 # Build a POE script to collect sub-jobs
@@ -72,3 +87,8 @@ chmod 775 run_gather_all_poe.sh
 #*****************************
 ${DATA}/run_gather_all_poe.sh
 export err=$?; err_chk
+
+else
+  echo "NO stat files exsist in $COMOUTsmall directory" 
+fi 
+

--- a/ush/cam/evs_href_grid2obs_product.sh
+++ b/ush/cam/evs_href_grid2obs_product.sh
@@ -107,7 +107,7 @@ for prod in mean prob ; do
 
          echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF${prod}_obsPREPBUFR_SFC.conf " >> run_href_${model}.${dom}.${valid_run}_product.sh
 
-  	 echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${model}.${dom}.${valid_run}_product.sh
+	 echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${model}.${dom}.${valid_run}_product.sh
 
        chmod +x run_href_${model}.${dom}.${valid_run}_product.sh
        echo "${DATA}/run_href_${model}.${dom}.${valid_run}_product.sh" >> run_all_href_product_poe.sh
@@ -174,7 +174,9 @@ for prod in mean prob ; do
 
  
        echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF${prod}_obsPREPBUFR_SFC.conf " >> run_href_${model}.${dom}.${valid_run}_product.sh
-       echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${model}.${dom}.${valid_run}_product.sh
+
+       echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${model}.${dom}.${valid_run}_product.sh
+
        chmod +x run_href_${model}.${dom}.${valid_run}_product.sh
        echo "${DATA}/run_href_${model}.${dom}.${valid_run}_product.sh" >> run_all_href_product_poe.sh
 

--- a/ush/cam/evs_href_grid2obs_profile.sh
+++ b/ush/cam/evs_href_grid2obs_profile.sh
@@ -102,7 +102,8 @@ for dom in $domains ; do
 	echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/EnsembleStat_fcstHREF_obsPREPBUFR_PROFILE.conf " >>  run_href_${domain}.${valid_at}.${fhr}_profile.sh 
 
 	echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF_obsPREPBUFR_PROFILE_prob.conf " >>  run_href_${domain}.${valid_at}.${fhr}_profile.sh
-	echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
+	
+	echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
 
        chmod +x run_href_${domain}.${valid_at}.${fhr}_profile.sh
        echo "${DATA}/run_href_${domain}.${valid_at}.${fhr}_profile.sh" >> run_all_href_profile_poe.sh
@@ -164,7 +165,7 @@ for dom in $domains ; do
 
 	echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF_obsPREPBUFR_PROFILE_prob.conf " >>  run_href_${domain}.${valid_at}.${fhr}_profile.sh
 
-	echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
+        echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
 
 	chmod +x run_href_${domain}.${valid_at}.${fhr}_profile.sh
         echo "${DATA}/run_href_${domain}.${valid_at}.${fhr}_profile.sh" >> run_all_href_profile_poe.sh
@@ -223,7 +224,8 @@ for dom in $domains ; do
 
         echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF_obsPREPBUFR_PROFILE_prob.conf " >>  run_href_${domain}.${valid_at}.${fhr}_profile.sh
 
-        echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
+	echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
+
         chmod +x run_href_${domain}.${valid_at}.${fhr}_profile.sh
         echo "${DATA}/run_href_${domain}.${valid_at}.${fhr}_profile.sh" >> run_all_href_profile_poe.sh
 
@@ -281,8 +283,9 @@ for dom in $domains ; do
 
         echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF_obsPREPBUFR_PROFILE_prob.conf " >>  run_href_${domain}.${valid_at}.${fhr}_profile.sh
 
-        echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
-        chmod +x run_href_${domain}.${valid_at}.${fhr}_profile.sh
+	echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${domain}.${valid_at}.${fhr}_profile.sh
+
+	chmod +x run_href_${domain}.${valid_at}.${fhr}_profile.sh
         echo "${DATA}/run_href_${domain}.${valid_at}.${fhr}_profile.sh" >> run_all_href_profile_poe.sh
 
        done

--- a/ush/cam/evs_href_grid2obs_system.sh
+++ b/ush/cam/evs_href_grid2obs_system.sh
@@ -105,7 +105,7 @@ for dom in CONUS Alaska ; do
          echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/EnsembleStat_fcstHREF_obsPREPBUFR_SFC.conf " >> run_href_${domain}.${valid_at}_system.sh
          echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF_obsPREPBUFR_SFC_prob.conf " >> run_href_${domain}.${valid_at}_system.sh
 
-         echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${domain}.${valid_at}_system.sh
+	 echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${domain}.${valid_at}_system.sh
 
          chmod +x run_href_${domain}.${valid_at}_system.sh
          echo "${DATA}/run_href_${domain}.${valid_at}_system.sh" >> run_all_href_system_poe.sh
@@ -163,7 +163,8 @@ for dom in CONUS Alaska ; do
 
 	 echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF_obsPREPBUFR_SFC_prob.conf " >> run_href_${domain}.${valid_at}_system.sh
 
-	 echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${domain}.${valid_at}_system.sh
+	 echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$FILEn $COMOUTsmall; fi; done" >> run_href_${domain}.${valid_at}_system.sh
+
          chmod +x run_href_${domain}.${valid_at}_system.sh
          echo "${DATA}/run_href_${domain}.${valid_at}_system.sh" >> run_all_href_system_poe.sh
 

--- a/ush/cam/evs_href_spcoutlook.sh
+++ b/ush/cam/evs_href_spcoutlook.sh
@@ -138,7 +138,7 @@ for prod in mean ; do
 
        echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/PointStat_fcstHREF${prod}_obsPREPBUFR_SPCoutlook.conf " >> run_href_${model}.${dom}.${valid}_spcoutlook.sh
 
-       echo "cp \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall" >> run_href_${model}.${dom}.${valid}_spcoutlook.sh
+       echo  "for FILEn in \$output_base/stat/\${MODEL}/*.stat; do if [ -f \"\$FILEn\" ]; then cp -v \$output_base/stat/\${MODEL}/*.stat $COMOUTsmall; fi; done" >> run_href_${model}.${dom}.${valid}_spcoutlook.sh
 
        chmod +x run_href_${model}.${dom}.${valid}_spcoutlook.sh
        echo "${DATA}/run_href_${model}.${dom}.${valid}_spcoutlook.sh" >> run_all_href_spcoutlook_poe.sh


### PR DESCRIPTION
Note:

  This PR is for fixing the HREF job failure in case the older HREF forecast files are dropped off  

Testing procedure:

In the driver directory  ../EVS/dev/drivers/scripts/stats/cam:

qsub jevs_cam_href_grid2obs_stats.sh
qsub jevs_cam_href_precip_stats.sh
qsub jevs_cam_href_spcoutlook_stats.sh 

