### PR TITLE
Updating ecf scripts with over 80% of walltime as runtime

### DIFF
--- a/ecf/scripts/plots/global_det/jevs_global_det_atmos_grid2grid_precip_plots_90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_global_det_atmos_grid2grid_precip_plots_90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:05:00
+#PBS -l walltime=01:10:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_det/jevs_global_det_wave_grid2obs_plots_31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_global_det_wave_grid2obs_plots_31days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:35:00
 #PBS -l place=vscatter:shared,select=1:ncpus=15:mem=35GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_det/jevs_global_det_wave_grid2obs_plots_90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_global_det_wave_grid2obs_plots_90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:55:00
+#PBS -l walltime=01:00:00
 #PBS -l place=vscatter:shared,select=1:ncpus=15:mem=75GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_naefs_precip_past90days_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_naefs_precip_past90days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:35:00
+#PBS -l walltime=00:45:00
 #PBS -l place=vscatter:shared,select=1:ncpus=8:mem=200GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/narre/jevs_narre_past90days_plots.ecf
+++ b/ecf/scripts/plots/narre/jevs_narre_past90days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:25:00
+#PBS -l walltime=01:30:00
 #PBS -l place=vscatter:shared,select=1:ncpus=8:mem=8GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:00:00
+#PBS -l walltime=02:15:00
 ##PBS -l walltime=01:55:00
 #PBS -l place=vscatter:shared,select=1:ncpus=24:mem=100GB
 #PBS -l debug=true

--- a/ecf/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_cnv_stats.ecf
+++ b/ecf/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_cnv_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:45:00
+#PBS -l walltime=00:55:00
 #PBS -l place=vscatter:shared,select=1:ncpus=28:mem=100GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:30:00
+#PBS -l walltime=02:40:00
 ##PBS -l walltime=02:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=60:mem=500GB
 #PBS -l debug=true

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=04:00:00
+#PBS -l walltime=04:15:00
 ##PBS -l walltime=02:10:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=07:00:00
+#PBS -l walltime=08:00:00
 ##PBS -l walltime=04:15:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_sref_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_sref_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:30:00
+#PBS -l walltime=01:40:00
 ##PBS -l walltime=01:25:00
 #PBS -l place=vscatter:shared,select=1:ncpus=4:mem=100GB
 #PBS -l debug=true


### PR DESCRIPTION
## Pull Request Testing ##

NCO reported the percentage of walltime is taken up by walltime, and generally noted that 80% runtime to walltime is generally the highest accepted ratio to give enough cushion.  In the future, we need to monitor runtime and check to see when a job's maximum runtime is and calculate from there.

In the meantime, there are 7 scripts whose runtime is over 80% runtime:walltime ratio (and a few over 90%).  We are updating these specific runtimes.  Other runtimes may be changed in a future PR if we see higher runtimes based on time of year, availability of obs throughout the year, etc.  

There is no testing needed here.