### PR TITLE
Firewxnest plot restart

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh
@@ -9,7 +9,7 @@
 
 export model=evs
 
-export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS_firewx_restart2/EVS
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
 source $HOMEevs/versions/run.ver
 
@@ -47,7 +47,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 # CALL executable job script here

--- a/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh
@@ -47,7 +47,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/NET/$evs_ver_2d
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 # CALL executable job script here

--- a/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh
@@ -3,13 +3,13 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=01:00:00
+#PBS -l walltime=00:50:00
 #PBS -l place=shared,select=1:ncpus=1:mem=100GB
 #PBS -l debug=true
 
 export model=evs
 
-export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS_firewx_restart2/EVS
 
 source $HOMEevs/versions/run.ver
 
@@ -47,7 +47,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 # CALL executable job script here

--- a/scripts/plots/cam/exevs_cam_nam_firewxnest_grid2obs_plots.sh
+++ b/scripts/plots/cam/exevs_cam_nam_firewxnest_grid2obs_plots.sh
@@ -57,6 +57,7 @@ done
 
 for varb in TMP DPT RH
 do
+	mkdir -p $COMOUTplots/$varb
 	export var=${varb}2m
 	export lev=Z2
 	export lev_obs=Z2
@@ -65,46 +66,101 @@ do
 	smvar=`echo $varb | tr A-Z a-z`
 	export plottyp=lead
 	export datetyp=VALID
+	if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+	then
         mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
+        echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+	fi
 
 	export plottyp=valid_hour
 	export datetyp=INIT
+        if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then	
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+	then
         mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+	fi
 
 	if [ $varb = DPT ]
 	then 
+		mkdir -p $COMOUTplots/$varb
 		export plottyp=threshold_average
 		export datetyp=INIT
 		export linetype=CTC
 		export stat=fbias
                 export thresh=">=277.594, >=283.15, >=288.706, >=294.261"
+		if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png ]
+		then
 		$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config_thresh
-        export err=$?; err_chk
+                export err=$?; err_chk
+          	else
+		echo "RESTART - plot exists; copying over to plot directory"
+		cp $COMOUTplots/$varb/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png $PLOTDIR
+		fi
 
+		if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+		then
 		mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png
+		cp ${PLOTDIR}/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png $COMOUTplots/$varb
+	        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png ]
+		then
+		echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+		fi
+
 	elif [ $varb = RH ]
 	then
+		mkdir -p $COMOUTplots/$varb
 		export plottyp=threshold_average
 		export datetyp=INIT
 		export linetype=CTC
 		export stat=fbias
 		export thresh="<=15, <=20, <=25, <=30"
+		if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png ]
+		then
 		$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config_thresh
-        export err=$?; err_chk
+                export err=$?; err_chk
+	        else
+		echo "RESTART - plot exists; copying over to plot directory"
+		cp $COMOUTplots/$varb/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png $PLOTDIR
+		fi
 
+		if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+		then
 		mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png
+		cp ${PLOTDIR}/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png $COMOUTplots/$varb
+	        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.fbias.${smvar}_${smlev}.last31days.threshmean.firewx.png ]
+		then
+		echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+		fi
 	fi
 done
 
-
 for varb in UGRD VGRD UGRD_VGRD WIND
 do
+	mkdir -p $COMOUTplots/$varb
 	export var=${varb}10m
 	export lev=Z10
 	export lev_obs=Z10
@@ -118,22 +174,49 @@ do
 	smvar=`echo $varb | tr A-Z a-z`
 	export plottyp=lead
 	export datetyp=VALID
+	if [ ! -e $COMOUTplots/$varb//evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+        echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+	then
         mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+	fi
 
 	export plottyp=valid_hour
 	export datetyp=INIT
+	if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+        then
 	mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+        fi
 
 done
 
 for varb in GUST
 do
+	mkdir -p $COMOUTplots/$varb
 	export var=${varb}sfc
 	export lev=Z0
 	export lev_obs=Z0
@@ -142,21 +225,48 @@ do
 	smvar=`echo $varb | tr A-Z a-z`
 	export plottyp=lead
 	export datetyp=VALID
+	if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+	then
         mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+	fi
 
 	export plottyp=valid_hour
 	export datetyp=INIT
+	if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+	then
 	mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+        fi
 done
 
 for varb in PBL
 do
+	mkdir -p $COMOUTplots/$varb
 	export var=${varb}
 	export lev=L0
 	export lev_obs=L0
@@ -165,17 +275,43 @@ do
 	smvar=`echo $varb | tr A-Z a-z`
 	export plottyp=lead
 	export datetyp=VALID
+	if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config_pbl
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+	then
 	mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.fhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+	fi
 
 	export plottyp=valid_hour
 	export datetyp=INIT
+	if [ ! -e $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
 	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/cam_nam_firewxnest_plots_py_plotting.config_pbl
-    export err=$?; err_chk
+        export err=$?; err_chk
+        else
+	echo "RESTART - plot exists; copying over to plot directory"
+	cp $COMOUTplots/$varb/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $PLOTDIR
+	fi
 
+	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
+        then
 	mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png
+	cp ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png $COMOUTplots/$varb
+        elif [ ! -e ${PLOTDIR}/evs.${MODELNAME}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.firewx.png ]
+	then
+	echo "WARNING: NO PLOT FOR",$varb,$plottyp,$datetyp
+        fi
 
 done
 


### PR DESCRIPTION
## Pull Request Testing ##

This PR adds restart to the nam-firewxnest plotting under cam, as well as adding warning messages if plots do not exist.  It has been tested numerous times.

The script to run is: dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots.sh.  Please set the COMIN to point to emc.vpppg, so it runs on emc.vpppg parallel stats output.  

The current wallclock is set to 50 minutes; the job usually runs in 30 minutes.  To test the restart, set the wallclock to 15 minutes.  Run one time.  Then set the wallclock back to 50 minutes and run a second time.  We'll have two separate .o files to look at; one job that did not run to completion, and a second job that completed all the plots.  The job saves png files in COMOUT in order to run restart.  

Once validated, we can also then test the warning statements.  