### PR TITLE
Add module bufr to the ecf scripts

### DIFF
--- a/ecf/scripts/stats/cam/jevs_cam_href_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_href_grid2obs_stats.ecf
@@ -38,6 +38,7 @@ module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
+module load bufr/${bufr_ver}
 module list
    
 ############################################################

--- a/ecf/scripts/stats/cam/jevs_cam_href_spcoutlook_stats.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_href_spcoutlook_stats.ecf
@@ -38,6 +38,7 @@ module load grib_util/${grib_util_ver}
 module load wgrib2/${wgrib2_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
+module load bufr/${bufr_ver}
 module list
    
 ############################################################


### PR DESCRIPTION
Add the missing "module load bufr" to the gridobs and scpoutlook stat ecf scripts 
Since the ecf scripts are run by NCO, no test is needed for this PR