### PR TITLE
feature/rm_PBS_V

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_grid2obs_plots.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=12:00:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=300GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/cam/jevs_cam_headline_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_headline_plots.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=05:30:00
 #PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=250GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/cam/jevs_cam_radar_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_radar_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=1:50:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=64
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_severe_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_severe_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=64
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_snowfall_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_snowfall_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=05:30:00
 #PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_det_tcgen_plots.sh
+++ b/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_det_tcgen_plots.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_det_tropcyc_plots.sh
+++ b/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_det_tropcyc_plots.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_ens_spread_plots.sh
+++ b/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_ens_spread_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l select=1:ncpus=1:mem=4GB
 #PBS -l walltime=01:00:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_ens_tropcyc_plots.sh
+++ b/dev/drivers/scripts/plots/hurricane/jevs_hurricane_global_ens_tropcyc_plots.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/hurricane/jevs_hurricane_regional_tropcyc_plots.sh
+++ b/dev/drivers/scripts/plots/hurricane/jevs_hurricane_regional_tropcyc_plots.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=4:00:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:mem=150GB:ompthreads=1
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=04:00:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=3:00:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_pres_lvls_plots_31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_pres_lvls_plots_31days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_pres_lvls_plots_90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_pres_lvls_plots_90days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sea_ice_plots_31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sea_ice_plots_31days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=34:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sea_ice_plots_90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sea_ice_plots_90days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=34:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sst_plots_31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sst_plots_31days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sst_plots_90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_sst_plots_90days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_temp_plots_31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_temp_plots_31days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_temp_plots_90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2grid_temp_plots_90days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2obs_prepbufr_plots_31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2obs_prepbufr_plots_31days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2obs_prepbufr_plots_90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_grid2obs_prepbufr_plots_90days.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_precip_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_precip_prep.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_precip_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_precip_prep.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_precip_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_precip_prep.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_precip_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_precip_prep.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_namnest_precip_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_namnest_precip_prep.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/prep/cam/jevs_cam_namnest_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_namnest_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_radar_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_radar_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:45:00
 #PBS -l place=shared,select=1:ncpus=1:mem=25GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_cam_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_severe_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:15:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/prep/global_ens/jevs_global_ens_wave_grid2obs_prep.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_global_ens_wave_grid2obs_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=02:00:00
 #PBS -l place=shared,select=1:ncpus=1:mem=15GB
 #PBS -l debug=true
-#PBS -V
 
 set -x 
 

--- a/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_cfs_prep.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_cfs_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:20:00
 #PBS -l place=shared,select=1:ncpus=1:mem=15GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_gefs_prep.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_gefs_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=02:00:00
 #PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=260GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_obs_prep.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_obs_prep.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:10:00
 #PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_grid2obs_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_precip_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_radar_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=3:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_severe_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=exclhost,select=1:ncpus=5:mem=500MB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_snowfall_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_grid2obs_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_precip_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_radar_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=3:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_severe_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=exclhost,select=1:ncpus=5:mem=500MB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_snowfall_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_grid2obs_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_precip_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_radar_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=3:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_severe_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=exclhost,select=1:ncpus=5:mem=500MB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_snowfall_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_radar_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=9:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_severe_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=exclhost,select=1:ncpus=5:mem=500MB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=02:20:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=02:00:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_radar_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=3:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_severe_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=0:30:00
 #PBS -l place=exclhost,select=1:ncpus=5:mem=500MB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_snowfall_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=02:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_grid2obs_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=01:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_precip_stats.sh
@@ -7,7 +7,6 @@
 #PBS -l walltime=01:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_radar_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=3:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_severe_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:30:00
 #PBS -l place=exclhost,select=1:ncpus=5:mem=500MB
 #PBS -l debug=true
-#PBS -V
 
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_snowfall_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=01:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 export model=evs

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_wave_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_wave_grid2obs_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:ncpus=36:mem=40G
 #PBS -l debug=true
-#PBS -V
 
 set -x 
 

--- a/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_det_tcgen_stats.sh
+++ b/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_det_tcgen_stats.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_det_tropcyc_stats.sh
+++ b/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_det_tropcyc_stats.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_ens_spread_stats.sh
+++ b/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_ens_spread_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l select=1:ncpus=1:mem=4GB
 #PBS -l walltime=06:00:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_ens_tropcyc_stats.sh
+++ b/dev/drivers/scripts/stats/hurricane/jevs_hurricane_global_ens_tropcyc_stats.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/hurricane/jevs_hurricane_regional_tropcyc_stats.sh
+++ b/dev/drivers/scripts/stats/hurricane/jevs_hurricane_regional_tropcyc_stats.sh
@@ -7,7 +7,6 @@
 ##PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1
 #PBS -l walltime=00:30:00
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=4:59:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
   export model=evs

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=7:00:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
   export model=evs

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/narre/jevs_narre_stats.sh
+++ b/dev/drivers/scripts/stats/narre/jevs_narre_stats.sh
@@ -8,7 +8,6 @@
 #PBS -l walltime=00:45:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=16:mem=500GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=1:ncpus=59:ompthreads=1:mem=70GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_cfs_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_cfs_grid2obs_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:40:00
 #PBS -l place=vscatter,select=1:ncpus=8:ompthreads=1:mem=60GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=1:ncpus=59:ompthreads=1:mem=70GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_gefs_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_gefs_grid2obs_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:40:00
 #PBS -l place=vscatter,select=1:ncpus=8:ompthreads=1:mem=60GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/dev/drivers/scripts/stats/wafs/jevs_wafs_atmos_stats.sh
+++ b/dev/drivers/scripts/stats/wafs/jevs_wafs_atmos_stats.sh
@@ -6,7 +6,6 @@
 #PBS -l walltime=00:25:00
 #PBS -l place=shared,select=1:ncpus=4:mem=10GB
 #PBS -l debug=true
-#PBS -V
 
 set -x
 

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_chem_gefs_grid2obs_airnow_plots_last90days.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_chem_gefs_grid2obs_airnow_plots_last90days.ecf
@@ -6,7 +6,6 @@
 #PBS -l walltime=01:00:00
 #PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=275GB
 #PBS -l debug=true
-#PBS -V
 
 export model=evs
 %include <head.h>


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> NCO does not want jobs running with `#PBS -V`. Some developers have removed it from their dev driver scripts, and this PR removes the remaining instances. Closes #464. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> No
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed for when the jobs are supposed to run?
 > No
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> I don't think any testing is necessary but we can test a few jobs if desired.
