### PR TITLE
Add conditions to imports of plots scripts

### DIFF
--- a/ush/cam/cam_create_output_dirs.py
+++ b/ush/cam/cam_create_output_dirs.py
@@ -15,12 +15,17 @@
 import os
 import re
 from datetime import datetime, timedelta as td
-from cam_plots_grid2obs_graphx_defs import graphics as graphics_g2o
-from cam_plots_precip_last31days_graphx_defs import graphics as graphics_pcp31
-from cam_plots_precip_last90days_graphx_defs import graphics as graphics_pcp90
-from cam_plots_snowfall_graphx_defs import graphics as graphics_sno
-from cam_plots_headline_graphx_defs import graphics as graphics_hdl
 import cam_util as cutil
+if os.environ['STEP'] == 'plots':
+    if os.environ['VERIF_CASE'] == 'grid2obs':
+        from cam_plots_grid2obs_graphx_defs import graphics as graphics_g2o
+    if os.environ['VERIF_CASE'] == 'headline':
+        from cam_plots_headline_graphx_defs import graphics as graphics_hdl
+    if os.environ['VERIF_CASE'] == 'precip':
+        from cam_plots_precip_last31days_graphx_defs import graphics as graphics_pcp31
+        from cam_plots_precip_last90days_graphx_defs import graphics as graphics_pcp90
+    if os.environ['VERIF_CASE'] == 'snowfall':
+        from cam_plots_snowfall_graphx_defs import graphics as graphics_sno
 
 print(f"BEGIN: {os.path.basename(__file__)}")
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Changes merged from PR #529 exposed several imports of plots scripts that, since the change, trigger fatal errors during prep and stats steps.  This minor fix should prevent those imports from happening during prep, stats, and certain plots jobs.

## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?

**Yes**, some cam prep jobs have been failing in the EVS parallel due to this issue.  Other jobs that point to cam prep output have been reporting missing data and are unable to run completely.  Merge ASAP, however a production switch on 9/4 may affect when PR tests can occur or be properly reviewed.

* Do you have any planned upcoming annual leave/PTO?

**No**.
* Are there any changes needed for when the jobs are supposed to run?

**No**.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### (1) Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - (_stats/plots_) set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### (2) Running jobs

I recommend testing the following jobs:
```
jevs_cam_hrrr_precip_prep
```
```
jevs_cam_hrrr_precip_stats
```
```
jevs_cam_grid2obs_plots_last31days
jevs_cam_grid2obs_plots_last90days
jevs_cam_precip_plots_last31days
jevs_cam_precip_plots_last90days
jevs_cam_snowfall_plots
jevs_cam_headline_plots
```
[Total: 1 prep job; 1 stats job; 6 plots jobs]

- jevs_cam_hrrr_precip_stats can be submitted using `qsub -v vhr=19 $driver`
- All other driver scripts can be submitted using `qsub -v vhr=00 $driver`
- All jobs can be submitted at any time

#### (3) Checking jobs
Log files should be checked by the developer for the following keywords:

```
check="FATAL\|WARNING\|error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

_**Note:** jevs_cam_hrrr_precip_stats will likely have missing data warnings, but we are primarily looking for FATAL ERRORs, which have been occurring due to the issue this PR is addressing._