### PR TITLE
feature/update_mailto

### DIFF
--- a/dev/drivers/scripts/plots/analyses/jevs_analyses_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_analyses_grid2obs_plots.sh
@@ -56,7 +56,7 @@ export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}
 export vhr=00
 echo $vhr
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_PLOTS

--- a/dev/drivers/scripts/plots/aqm/jevs_aqm_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_aqm_grid2obs_plots.sh
@@ -54,7 +54,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 
-export MAILTO=${MAILTO:-'perry.shafran@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_radar_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_radar_plots.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_severe_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_severe_plots.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/aqm/jevs_aqm_prep.sh
+++ b/dev/drivers/scripts/prep/aqm/jevs_aqm_prep.sh
@@ -50,7 +50,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
 export KEEPDATA=YES
 export SENDMAIL=YES
 #
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_severe_prep.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_severe_prep.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_severe_prep.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'binbin.zhou@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'binbin.zhou@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_severe_prep.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_namnest_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_namnest_severe_prep.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_radar_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_radar_prep.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_severe_prep.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/global_ens/jevs_global_ens_atmos_prep.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_global_ens_atmos_prep.sh
@@ -40,7 +40,7 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov' 
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov' 
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_global_ens_headline_prep.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_global_ens_headline_prep.sh
@@ -41,7 +41,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export run_mpi=no
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_global_ens_naefs_atmos_prep.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_global_ens_naefs_atmos_prep.sh
@@ -43,7 +43,7 @@ export get_gefs_bc_apcp24h=yes
 export get_model_bc=yes
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_global_ens_wave_grid2obs_prep.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_global_ens_wave_grid2obs_prep.sh
@@ -42,7 +42,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export KEEPDATA=${KEEPDATA:-YES}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ## developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
@@ -58,7 +58,7 @@ export mod_ver=${ccpa_ver}
 export modsys=ccpa
 export MODELNAME=ccpa
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_grid2obs_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_precip_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats.sh
@@ -55,7 +55,7 @@ export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma_ru
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_grid2obs_stats.sh
@@ -56,7 +56,7 @@ export MODELNAME=urma
 export modsys=urma
 export mod_ver=${urma_ver}
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_precip_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${urma_ver}
 export modsys=urma
 export MODELNAME=urma
 
-export MAILTO="perry.shafran@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/aqm/jevs_aqm_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/aqm/jevs_aqm_grid2obs_stats.sh
@@ -51,7 +51,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 ########################################################################
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_grid2obs_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_precip_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_radar_stats.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_severe_stats.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarw_snowfall_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_grid2obs_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_precip_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_radar_stats.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_severe_stats.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswarwmem2_snowfall_stats.sh
@@ -50,7 +50,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_grid2obs_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_precip_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_radar_stats.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_severe_stats.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hireswfv3_snowfall_stats.sh
@@ -50,7 +50,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_grid2obs_stats.sh
@@ -41,7 +41,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO='alicia.bentley@noaa.gov,binbin.zhou@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'
 if [ -z "$MAILTO" ]; then
 
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_precip_stats.sh
@@ -47,7 +47,7 @@ export verif_snowfall=yes
 
 export gather=yes
 
-export MAILTO='alicia.bentley@noaa.gov,binbin.zhou@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_radar_stats.sh
@@ -58,7 +58,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'binbin.zhou@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_radar_stats.sh
@@ -58,7 +58,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'binbin.zhou@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_severe_stats.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'binbin.zhou@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_severe_stats.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'binbin.zhou@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_spcoutlook_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_spcoutlook_stats.sh
@@ -41,7 +41,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export jobid=$job.${PBS_JOBID:-$$}
 
 
-export MAILTO='alicia.bentley@noaa.gov,binbin.zhou@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'
 if [ -z "$MAILTO" ]; then
 
   echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_radar_stats.sh
@@ -60,7 +60,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_severe_stats.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_snowfall_stats.sh
@@ -50,7 +50,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_nam_firewxnest_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_nam_firewxnest_grid2obs_stats.sh
@@ -47,7 +47,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
-export MAILTO=${MAILTO:-'perry.shafran@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'perry.shafran@noaa.gov,andrew.benjamin@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_grid2obs_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_precip_stats.sh
@@ -51,7 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_radar_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_radar_stats.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_severe_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_severe_stats.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_snowfall_stats.sh
@@ -50,7 +50,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="alicia.bentley@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats.sh
@@ -39,6 +39,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
 export run_mpi=no
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_atmos_snowfall_stats.sh
@@ -38,6 +38,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_wmo_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_cmce_wmo_grid2grid_stats.sh
@@ -42,6 +42,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_wmo_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_grid2grid_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_precip_stats.sh
@@ -40,6 +40,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
 export run_mpi=no
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_ecme_atmos_snowfall_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_cnv_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_cnv_stats.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats.sh
@@ -40,6 +40,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats.sh
@@ -37,6 +37,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_sea_ice_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_sea_ice_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_snowfall_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_sst_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_atmos_sst_stats.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_headline_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_headline_grid2grid_stats.sh
@@ -41,6 +41,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_wmo_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_wmo_grid2grid_stats.sh
@@ -42,6 +42,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_wmo_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gfs_headline_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gfs_headline_grid2grid_stats.sh
@@ -41,6 +41,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_atmos_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_atmos_grid2grid_stats.sh
@@ -41,6 +41,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_atmos_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_atmos_grid2obs_stats.sh
@@ -39,6 +39,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_atmos_precip_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_atmos_precip_stats.sh
@@ -42,6 +42,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_headline_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_naefs_headline_grid2grid_stats.sh
@@ -43,6 +43,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 export run_mpi=no
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,steven.simon@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_GLOBAL_ENS_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -59,7 +59,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}
-  export MAILTO="roshan.shrestha@noaa.gov,alicia.bentley@noaa.gov"
+  export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
   # export MAILTO="firstname.lastname@noaa.gov"
 
 # Job Settings and Run

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="roshan.shrestha@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 # export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="roshan.shrestha@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 # export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -59,7 +59,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}
-  export MAILTO="roshan.shrestha@noaa.gov,alicia.bentley@noaa.gov"
+  export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
   # export MAILTO="firstname.lastname@noaa.gov"
 
 # Job Settings and Run

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="roshan.shrestha@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 # export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="roshan.shrestha@noaa.gov,alicia.bentley@noaa.gov"
+export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
 # export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_sref_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_sref_grid2obs_stats.sh
@@ -40,7 +40,7 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 
-export MAILTO='alicia.bentley@noaa.gov,binbin.zhou@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_sref_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_sref_precip_stats.sh
@@ -39,7 +39,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=yes
 
-export MAILTO='alicia.bentley@noaa.gov,binbin.zhou@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/narre/jevs_narre_stats.sh
+++ b/dev/drivers/scripts/stats/narre/jevs_narre_stats.sh
@@ -41,7 +41,7 @@ export vhr=${vhr:-00}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export MAILTO='alicia.bentley@noaa.gov,binbin.zhou@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'
 
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}

--- a/scripts/prep/global_ens/exevs_global_ens_gefs_atmos_prep.sh
+++ b/scripts/prep/global_ens/exevs_global_ens_gefs_atmos_prep.sh
@@ -111,7 +111,7 @@ if [ $get_ghrsst = yes ] ; then
     echo "WARNING: $DCOMINghrsst/$vdaym1/validation_data/marine/ghrsst/${vdaym1}_OSPO_L4_GHRSST.nc is not available"
     if [ $SENDMAIL = YES ]; then
      export subject="GHRSST OSPO Data Missing for EVS ${COMPONENT}"
-     export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,steven.simon@noaa.gov'}
+     export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'}
      echo "Warning: No GHRSST OSPO data was available for valid date ${vday}" > mailmsg
      echo Missing file is  $DCOMINghrsst/$vdaym1/validation_data/marine/ghrsst/${vdaym1}_OSPO_L4_GHRSST.nc >> mailmsg
      echo "Job ID: $jobid" >> mailmsg

--- a/scripts/stats/cam/exevs_href_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_href_grid2obs_stats.sh
@@ -71,7 +71,7 @@ if [ $prepare = yes ] ; then
 
   else
        export subject="GFS or RAP Prepbufr Data Missing for EVS ${COMPONENT}"
-       export MAILTO=${MAILTO:-'geoffrey.manikin@noaa.gov,binbin.zhou@noaa.gov'}
+       export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,binbin.zhou@noaa.gov'}
        echo "Warning:  No GFS or RAP Prepbufr data available for ${VDATE}" > mailmsg
        echo Missing file is $COMINobsproc/rap.${VDATE}/rap.t12z.prepbufr.tm00 or $COMINobsproc/gdas.${vday}/00/atmos/gdas.t00z.prepbufr  >> mailmsg
        echo "Job ID: $jobid" >> mailmsg


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This updates `MAILTO` to reflect the current state of EVS developers and project leads.

Closes #542.

## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
> No
* Do you have any planned upcoming annual leave/PTO?
> Full day 9/13, half day afternoon 9/16, and full day 9/20
* Are there any changes needed for when the jobs are supposed to run?
> N/A
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Not sure if we want to test anything with this. We could test doing fake path for something to see the emails work, but I don't want to send anyone emails unnecessarily about missing data when it is fake. @AndrewBenjamin-NOAA is also on leave and I don't know if we want to clog up his inbox more. We could also wait till he returns to do a test to make sure he gets the emails.