### PR TITLE
Bugfix/correct subseasonal OSI and GHRSST averaging

### DIFF
--- a/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats.sh
@@ -59,5 +59,6 @@ $HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal verification grid-to-grid statistics for the GEFS model#          and create the stat files in the databases.
+#          subseasonal verification grid-to-grid statistics for the GEFS model
+#          and create the stat files in the databases.
 ######################################################################

--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -829,15 +829,17 @@ def weekly_osi_saf_file(weekly_source_file_list, weekly_dest_file,
     weekly_prepped_file = os.path.join(os.getcwd(), 'atmos.'
                                        +weekly_dest_file.rpartition('/')[2])
     # Prep weekly file
+    ncea_weekly_source_file_list = []
     for weekly_source_file in weekly_source_file_list:
-        if not os.path.exists(weekly_source_file):
+        if os.path.exists(weekly_source_file):
+            ncea_weekly_source_file_list.append(weekly_source_file)
+        else:
             print(f"WARNING: {weekly_source_file} does not exist, "
                   +"not using in weekly average file")
-            weekly_source_file_list.remove(weekly_source_file)
     # 80% file check from expected 7
-    if len(weekly_source_file_list) >= 6:
+    if len(ncea_weekly_source_file_list) >= 6:
         ncea_cmd_list = ['ncea']
-        for weekly_source_file in weekly_source_file_list:
+        for weekly_source_file in ncea_weekly_source_file_list:
             ncea_cmd_list.append(weekly_source_file)
         ncea_cmd_list.append('-o')
         ncea_cmd_list.append(weekly_prepped_file)
@@ -858,9 +860,10 @@ def weekly_osi_saf_file(weekly_source_file_list, weekly_dest_file,
             weekly_data.close()
     else:
         print("WARNING: Not enough files to make "+weekly_prepped_file
-              +": "+' '.join(weekly_source_file_list))
-    print("Linking "+weekly_prepped_file+" to "+weekly_dest_file)
-    os.symlink(weekly_prepped_file, weekly_dest_file)
+              +": "+' '.join(ncea_weekly_source_file_list))
+    if os.path.exists(weekly_prepped_file):
+        print("Linking "+weekly_prepped_file+" to "+weekly_dest_file)
+        os.symlink(weekly_prepped_file, weekly_dest_file)
 
 def monthly_osi_saf_file(monthly_source_file_list,
                          monthly_dest_file,
@@ -878,15 +881,17 @@ def monthly_osi_saf_file(monthly_source_file_list,
     monthly_prepped_file = os.path.join(os.getcwd(), 'atmos.'
                                         +monthly_dest_file.rpartition('/')[2])
     # Prep monthly file
+    ncea_monthly_source_file_list = []
     for monthly_source_file in monthly_source_file_list:
-        if not os.path.exists(monthly_source_file):
+        if os.path.exists(monthly_source_file):
+            ncea_monthly_source_file_list.append(monthly_source_file)
+        else:
             print(f"WARNING: {monthly_source_file} does not exist, "
                   +"not using in monthly average file")
-            monthly_source_file_list.remove(monthly_source_file)
     # 80% file check from expected 30
-    if len(monthly_source_file_list) >= 24:
+    if len(ncea_monthly_source_file_list) >= 24:
         ncea_cmd_list = ['ncea']
-        for monthly_source_file in monthly_source_file_list:
+        for monthly_source_file in ncea_monthly_source_file_list:
             ncea_cmd_list.append(monthly_source_file)
         ncea_cmd_list.append('-o')
         ncea_cmd_list.append(monthly_prepped_file)
@@ -907,9 +912,10 @@ def monthly_osi_saf_file(monthly_source_file_list,
             monthly_data.close()
     else:
         print("WARNING: Not enough files to make "+monthly_prepped_file
-              +": "+' '.join(monthly_source_file_list))
-    print("Linking "+monthly_prepped_file+" to "+monthly_dest_file)
-    os.symlink(monthly_prepped_file, monthly_dest_file)
+              +": "+' '.join(ncea_monthly_source_file_list))
+    if os.path.exists(monthly_prepped_file):
+        print("Linking "+monthly_prepped_file+" to "+monthly_dest_file)
+        os.symlink(monthly_prepped_file, monthly_dest_file)
 
 def weekly_ghrsst_ospo_file(weekly_source_file_list, weekly_dest_file,
                             weekly_dates):
@@ -927,15 +933,17 @@ def weekly_ghrsst_ospo_file(weekly_source_file_list, weekly_dest_file,
     weekly_prepped_file = os.path.join(os.getcwd(), 'atmos.'
                                        +weekly_dest_file.rpartition('/')[2])
     # Prep weekly file
+    ncea_weekly_source_file_list = []
     for weekly_source_file in weekly_source_file_list:
-        if not os.path.exists(weekly_source_file):
+        if os.path.exists(weekly_source_file):
+            ncea_weekly_source_file_list.append(weekly_source_file)
+        else:
             print(f"WARNING: {weekly_source_file} does not exist, "
                   +"not using in weekly average file")
-            weekly_source_file_list.remove(weekly_source_file)
     # 80% file check from expected 7
-    if len(weekly_source_file_list) >= 6:
+    if len(ncea_weekly_source_file_list) >= 6:
         ncea_cmd_list = ['ncea']
-        for weekly_source_file in weekly_source_file_list:
+        for weekly_source_file in ncea_weekly_source_file_list:
             ncea_cmd_list.append(weekly_source_file)
         ncea_cmd_list.append('-o')
         ncea_cmd_list.append(weekly_prepped_file)
@@ -961,9 +969,10 @@ def weekly_ghrsst_ospo_file(weekly_source_file_list, weekly_dest_file,
             weekly_data.close()
     else:
         print("WARNING: Not enough files to make "+weekly_prepped_file
-              +": "+' '.join(weekly_source_file_list))
-    print("Linking "+weekly_prepped_file+" to "+weekly_dest_file)
-    os.symlink(weekly_prepped_file, weekly_dest_file)
+              +": "+' '.join(ncea_weekly_source_file_list))
+    if os.path.exists(weekly_prepped_file):
+        print("Linking "+weekly_prepped_file+" to "+weekly_dest_file)
+        os.symlink(weekly_prepped_file, weekly_dest_file)
 
 def monthly_ghrsst_ospo_file(monthly_source_file_list,
                              monthly_dest_file,
@@ -981,15 +990,17 @@ def monthly_ghrsst_ospo_file(monthly_source_file_list,
     monthly_prepped_file = os.path.join(os.getcwd(), 'atmos.'
                                         +monthly_dest_file.rpartition('/')[2])
     # Prep monthly file
+    ncea_monthly_source_file_list = []
     for monthly_source_file in monthly_source_file_list:
-        if not os.path.exists(monthly_source_file):
+        if os.path.exists(monthly_source_file):
+            ncea_monthly_source_file_list.append(monthly_source_file)
+        else:
             print(f"WARNING: {monthly_source_file} does not exist, "
                   +"not using in monthly average file")
-            monthly_source_file_list.remove(monthly_source_file)
     # 80% file check from expected 30
-    if len(monthly_source_file_list) >= 24:
+    if len(ncea_monthly_source_file_list) >= 24:
         ncea_cmd_list = ['ncea']
-        for monthly_source_file in monthly_source_file_list:
+        for monthly_source_file in ncea_monthly_source_file_list:
             ncea_cmd_list.append(monthly_source_file)
         ncea_cmd_list.append('-o')
         ncea_cmd_list.append(monthly_prepped_file)
@@ -1015,9 +1026,10 @@ def monthly_ghrsst_ospo_file(monthly_source_file_list,
             monthly_data.close()
     else:
         print("WARNING: Not enough files to make "+monthly_prepped_file
-              +": "+' '.join(monthly_source_file_list))
-    print("Linking "+monthly_prepped_file+" to "+monthly_dest_file)
-    os.symlink(monthly_prepped_file, monthly_dest_file)
+              +": "+' '.join(ncea_monthly_source_file_list))
+    if os.path.exists(monthly_prepped_file):
+        print("Linking "+monthly_prepped_file+" to "+monthly_dest_file)
+        os.symlink(monthly_prepped_file, monthly_dest_file)
 
 
 def get_model_file(valid_time_dt, init_time_dt, forecast_hour,


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
The ush/subseasonal/subseasonal_util.py script was edited to fix an ops issue/failure related to weekly and monthly OSI-SAF and GHRSST-OSPO averaging. Issue #548.
## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
* Yes, as grid-to-grid jobs will continue to fail without this bugfix. ASAP.
* Do you have any planned upcoming annual leave/PTO?
* No
* Are there any changes needed for when the jobs are supposed to run?
* No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Clone my fork and checkout branch bugfix/subseasonal_osi_ghrsst_avg
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix (link EVS_fix dir)
cd dev/drivers/scripts/stats/subseasonal
For the following: jevs_subseasonal_cfs_grid2grid_stats.sh, jevs_subseasonal_gefs_grid2grid_stats.sh:
Set HOMEevs to the location of the clone.
Set COMIN to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/subseasonal/atmos
Run jobs
