### PR TITLE
feature/update_obsproc_v1.3

### DIFF
--- a/dev/drivers/scripts/stats/cam/jevs_cam_href_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_href_grid2obs_stats.sh
@@ -3,7 +3,7 @@
 #PBS -q dev
 #PBS -S /bin/bash
 #PBS -A EVS-DEV
-#PBS -l walltime=04:30:00
+#PBS -l walltime=05:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=72:mem=500GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/stats/global_det/jevs_global_det_atmos_gfs_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_global_det_atmos_gfs_grid2obs_stats.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=01:30:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=275GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=300GB
 #PBS -l debug=true
 #PBS -V
 

--- a/dev/drivers/scripts/stats/global_det/jevs_global_det_wave_gfs_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_global_det_wave_gfs_grid2obs_stats.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=1:ncpus=25:mem=25GB
+#PBS -l place=vscatter,select=1:ncpus=25:mem=50GB
 #PBS -l debug=true
 #PBS -V
 

--- a/dev/drivers/scripts/stats/global_ens/jevs_global_ens_wave_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_global_ens_wave_grid2obs_stats.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=1:ncpus=36:mem=40G
+#PBS -l place=vscatter,select=1:ncpus=36:mem=50G
 #PBS -l debug=true
 #PBS -V
 

--- a/dev/drivers/scripts/stats/nfcens/jevs_nfcens_wave_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/nfcens/jevs_nfcens_wave_grid2obs_stats.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=36:mem=40G
+#PBS -l place=vscatter,select=1:ncpus=36:mem=50G
 #PBS -l debug=true
 #PBS -V
 

--- a/ecf/scripts/stats/cam/jevs_cam_href_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_href_grid2obs_stats.ecf
@@ -4,7 +4,6 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=05:30:00
-##PBS -l walltime=04:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=72:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats.ecf
@@ -5,7 +5,7 @@
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:45:00
 ##PBS -l walltime=01:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=250GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=300GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/global_det/jevs_global_det_gfs_wave_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/global_det/jevs_global_det_gfs_wave_grid2obs_stats.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter:shared,select=1:ncpus=25:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=25:mem=50GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/global_ens/jevs_global_ens_wave_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/global_ens/jevs_global_ens_wave_grid2obs_stats.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=1:ncpus=36:mem=40G
+#PBS -l place=vscatter:shared,select=1:ncpus=36:mem=50G
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/nfcens/jevs_nfcens_wave_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/nfcens/jevs_nfcens_wave_grid2obs_stats.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:shared,select=1:ncpus=36:mem=40G
+#PBS -l place=vscatter:shared,select=1:ncpus=36:mem=50G
 #PBS -l debug=true
 
 export model=evs

--- a/ush/global_det/lead_average.py
+++ b/ush/global_det/lead_average.py
@@ -1009,7 +1009,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         else:
             title2 = f'{level_string}{var_long_name} (unitless)'
     if obtype == 'SFCSHP':
-        title2 = title2+f'\nObservations: Surface Marine (Ship, Buoy, C-MAN Platform)'
+        title2 = title2+f'\nObservations: Surface Marine (Ship, Buoy, C-MAN Platform, Saildrone)'
     elif obtype == 'NDBC_STANDARD':
         title2 = title2+f'\nObservations: NDBC Buoys'
     title3 = (f'{str(date_type).capitalize()} {date_hours_string} '

--- a/ush/global_det/time_series.py
+++ b/ush/global_det/time_series.py
@@ -1015,7 +1015,7 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
         else:
             title2 = f'{level_string} {var_long_name} (unitless)'
     if obtype == 'SFCSHP':
-        title2 = title2+f'\nObservations: Surface Marine (Ship, Buoy, C-MAN Platform)'
+        title2 = title2+f'\nObservations: Surface Marine (Ship, Buoy, C-MAN Platform, Saildrone)'
     elif obtype == 'NDBC_STANDARD':
         title2 = title2+f'\nObservations: NDBC Buoys'
 #    title3 = f'{str(date_type).capitalize()} {date_hours_string} '


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This PR includes updates to support the EVS code delivery for obpsroc v1.3. It includes

1. Add 'Saildrone' into the title for SFCSHP obs for global_det wave plots.
2. Increase memory: global_det atmos stats GFS grid2obs, global_det wave stats GFS grid2obs, global_ens wave stats grid2obs, nfcens wave stats grid2obs,
3. Adjust walltimes: cam href grid2obs stats

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> Yes, the code delivery for obsproc v1.3 is 10/4.
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed for when the jobs are supposed to run?
> No

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

###  **Set-up**
1. Clone my fork and checkout branch feature/global_det_atmos_plots_units
2. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`
3. Uncomment `evs_ver` in `versions/run.ver`

### :heavy_check_mark:   **global_det plots**
4. `cd dev/drivers/scripts/plots/global_det`
5. Run `jevs_global_det_wave_grid2obs_plots_31days.sh` and `jevs_global_det_wave_grid2obs_plots_90days.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Set `COMIN=/lfs/h1/ops/prod/com/$NET/$evs_ver_2d`

### :heavy_check_mark:  **cam stats**
6. `cd dev/drivers/scripts/stats/cam`
7. Run `jevs_cam_href_grid2obs_stats.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Set `COMIN=/lfs/h1/ops/prod/com/$NET/$evs_ver_2d`
> - Set `COMINobsproc=/lfs/h2/emc/vpppg/noscrub/mallory.row/EVS_obsproc_v1.3_test/obsproc/${obsproc_ver}`

### :black_square_button:  **global_det stats**
6. `cd dev/drivers/scripts/stats/global_det`
7. Run `jevs_global_det_atmos_gfs_grid2obs_stats.sh` and `jevs_global_det_wave_gfs_grid2obs_stats.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Set `COMIN=/lfs/h1/ops/prod/com/$NET/$evs_ver_2d`
> - Set `COMINobsproc=/lfs/h2/emc/vpppg/noscrub/mallory.row/EVS_obsproc_v1.3_test/obsproc/${obsproc_ver}`

### :heavy_check_mark: **global_ens wave prep and stats**
6. `cd dev/drivers/scripts/prep/global_ens`
7. Run `jevs_global_ens_wave_grid2obs_prep.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Set `COMIN=/lfs/h1/ops/prod/com/$NET/$evs_ver_2d`
> - Set `COMINobsproc=/lfs/h2/emc/vpppg/noscrub/mallory.row/EVS_obsproc_v1.3_test/obsproc/${obsproc_ver}/gdas`
8. We will need to link the prod global_ens wave prep to where the prep output from the test was written. We can work on this when we get to this step.
9. Run `jevs_global_ens_wave_grid2obs_stats.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Maybe need to adjust `COMIN`

### :heavy_check_mark: **nfcens prep and stats**
10. `cd dev/drivers/scripts/prep/nfcens`
7. Run `jevs_nfcens_wave_grid2obs_prep.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Set `COMIN=/lfs/h1/ops/prod/com/$NET/$evs_ver_2d`
> - Set `COMINobsproc=/lfs/h2/emc/vpppg/noscrub/mallory.row/EVS_obsproc_v1.3_test/obsproc/${obsproc_ver}/gdas`
8. We will need to link the prod nfcens prep to where the prep output from the test was written. We can work on this when we get to this step.
9. Run `jevs_nfcens_wave_grid2obs_stats.sh`.
> - Set `HOMEevs` to the location of the clone.
> - Maybe need to adjust `COMIN`