### PR TITLE
bugfix/subseasonal_plot_unit_fix_prod

### DIFF
--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -4143,6 +4143,7 @@ def build_df(logger, input_dir, output_dir, model_info_dict,
              fhr                    - forecast hour (string)
 
          Returns:
+             all_model_df           - dataframe of all the information
     """
     met_version_line_type_col_list = get_met_line_type_cols(
         logger, met_info_dict['root'], met_info_dict['version'], line_type
@@ -4337,6 +4338,71 @@ def build_df(logger, input_dir, output_dir, model_info_dict,
                         [model_stat_file_df_valid_date_idx_list[0]]\
                         [:]
                     )
+                # Do conversions if needed
+                #### K to F
+                if fcst_var_name in ['TMP_ANOM_WEEKLYAVG', 
+                                     'TMP_ANOM_DAYS6_10AVG',
+                                     'TMP_ANOM_WEEKS3_4AVG', 'SST_DAILYAVG',
+                                     'SST_WEEKLYAVG', 'SST_MONTHLYAVG'] \
+                        and fcst_var_level in ['Z0', 'Z2'] \
+                        and line_type in ['SL1L2', 'SAL1L2']:
+                    coef = np.divide(9., 5.)
+                    if fcst_var_name in ['TMP_ANOM_WEEKLYAVG',
+                                         'TMP_ANOM_DAYS6_10AVG',
+                                         'TMP_ANOM_WEEKS3_4AVG']:
+                        const = 0
+                    elif line_type == 'SAL1L2':
+                        const = 0
+                    else:
+                        const = ((-273.15)*9./5.)+32.
+                    convert = True
+                    units_old = 'K'
+                    units_new = 'F'
+                else:
+                    convert = False
+                if convert:
+                    if line_type == 'SL1L2':
+                        fcst_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'FBAR'
+                        ]
+                        obs_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'OBAR'
+                        ]
+                        col1_list = ['FBAR', 'OBAR']
+                        col2_list = ['FOBAR', 'FFBAR', 'OOBAR']
+                    elif line_type == 'SAL1L2':
+                        fcst_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'FABAR'
+                        ]
+                        obs_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'OABAR'
+                        ]
+                        col1_list = ['FABAR', 'OABAR']
+                        col2_list = ['FOABAR', 'FFABAR', 'OOABAR']
+                    for col in col1_list:
+                        model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, col
+                        ] = (coef
+                             * model_num_df.loc[model_num_df['FCST_UNITS'] \
+                                               == units_old, col]) \
+                            + const
+                    for col in col2_list:
+                        if col in ['FOBAR', 'FOABAR']:
+                            const2 =  ((coef * const * fcst_avg_old)
+                                       + (coef * const * obs_avg_old))
+                        elif col in ['FFBAR', 'FFABAR']:
+                            const2 = 2 * (coef * const * fcst_avg_old)
+                        elif col in ['OOBAR', 'OOABAR']:
+                            const2 = 2 * (coef * const * obs_avg_old)
+                        model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, col
+                        ] = (coef**2
+                             *model_num_df.loc[model_num_df['FCST_UNITS'] \
+                                               == units_old, col]) \
+                             + const2 + const**2
+                    model_num_df.loc[
+                        model_num_df['FCST_UNITS'] == units_old, 'FCST_UNITS'
+                    ] = units_new
             else:
                 logger.warning(f"{parsed_model_stat_file} does not exist")
         if model_num == 'model1':


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
subseasonal_util.py was edited to convert 2m temp anomalies and SST from Kelvin to Fahrenheit.
> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
#574 subseasonal: Fix plots unit conversion for operations
## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
* Yes, this needs to be delivered to NCO in a bugfix.
* Do you have any planned upcoming annual leave/PTO?
* No
* Are there any changes needed for when the jobs are supposed to run?
  No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Checkout this feature branch and make sure to link EVS_fix directory in driver scripts.
Make sure COMIN is set to the prod path (/lfs/h1/ops/prod/com/evs/v1.0), COMOUT to assignee ptmp space, and HOMEevs to assignee path in plots driver scripts. Then please run all of the driver scripts under /dev/drivers/scripts/plots/subseasonal. **Please wait to test this PR until all of the stats jobs are done running.** This is around 17Z I believe; I will let you know.