### PR TITLE
Fix unit conversion logic

### DIFF
--- a/ush/analyses/plot_util.py
+++ b/ush/analyses/plot_util.py
@@ -702,22 +702,24 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -755,23 +757,27 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1445,22 +1451,24 @@ def calculate_stat(logger, model_data, stat, conversion):
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1496,23 +1504,27 @@ def calculate_stat(logger, model_data, stat, conversion):
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 

--- a/ush/aqm/plot_util.py
+++ b/ush/aqm/plot_util.py
@@ -702,22 +702,24 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -755,23 +757,27 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1445,22 +1451,24 @@ def calculate_stat(logger, model_data, stat, conversion):
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1496,23 +1504,27 @@ def calculate_stat(logger, model_data, stat, conversion):
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 

--- a/ush/cam/plot_util.py
+++ b/ush/cam/plot_util.py
@@ -836,22 +836,24 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -889,23 +891,27 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1608,22 +1614,24 @@ def calculate_stat(logger, model_data, stat, conversion):
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1659,23 +1667,27 @@ def calculate_stat(logger, model_data, stat, conversion):
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 

--- a/ush/global_ens/ush_gens_plot_py/plot_util.py
+++ b/ush/global_ens/ush_gens_plot_py/plot_util.py
@@ -745,22 +745,24 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar
-                + coef*const*fbar
-                + coef*const*obar
+                + coef*const*fbar_og
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar
-                + 2.*coef*const*fbar
+                + 2.*coef*const*fbar_og
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -798,23 +800,27 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar
-                + coef*const*(ufbar + uobar + vfbar + vobar)
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og)
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar
-                + 2.*coef*const*(ufbar + vfbar)
+                + 2.*coef*const*(ufbar_og + vfbar_og)
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar
-                + 2.*coef*const*(uobar + vobar)
+                + 2.*coef*const*(uobar_og + vobar_og)
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1591,22 +1597,24 @@ def calculate_stat(logger, model_data, stat, conversion):
          mae   = model_data.loc[:]['MAE']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar
-                + coef*const*fbar
-                + coef*const*obar
+                + coef*const*fbar_og
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar
-                + 2.*coef*const*fbar
+                + 2.*coef*const*fbar_og
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1642,23 +1650,27 @@ def calculate_stat(logger, model_data, stat, conversion):
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar
-                + coef*const*(ufbar + uobar + vfbar + vobar)
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og)
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar
-                + 2.*coef*const*(ufbar + vfbar)
+                + 2.*coef*const*(ufbar_og + vfbar_og)
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar
-                + 2.*coef*const*(uobar + vobar)
+                + 2.*coef*const*(uobar_og + vobar_og)
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 

--- a/ush/mesoscale/plot_util.py
+++ b/ush/mesoscale/plot_util.py
@@ -781,22 +781,24 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -834,23 +836,27 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1553,22 +1559,24 @@ def calculate_stat(logger, model_data, stat, conversion):
          oobar = model_data.loc[:]['OOBAR']
          if bool_convert:
              coef, const = conversion
-             fbar = coef*fbar+const
-             obar = coef*obar+const
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
              fobar = (
                 np.power(coef, 2)*fobar 
-                + coef*const*fbar 
-                + coef*const*obar
+                + coef*const*fbar_og 
+                + coef*const*obar_og
                 + np.power(const, 2)
              )
              ffbar = (
                 np.power(coef, 2)*ffbar 
-                + 2.*coef*const*fbar 
+                + 2.*coef*const*fbar_og 
                 + np.power(const, 2)
              )
              oobar = (
                 np.power(coef, 2)*oobar 
-                + 2.*coef*const*obar
+                + 2.*coef*const*obar_og
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 
@@ -1604,23 +1612,27 @@ def calculate_stat(logger, model_data, stat, conversion):
          uvoobar = model_data.loc[:]['UVOOBAR']
          if bool_convert:
              coef, const = conversion
-             ufbar = coef*ufbar+const
-             vfbar = coef*vfbar+const
-             uobar = coef*uobar+const
-             vobar = coef*vobar+const
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
              uvfobar = (
                 np.power(coef, 2)*uvfobar 
-                + coef*const*(ufbar + uobar + vfbar + vobar) 
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og) 
                 + np.power(const, 2)
              )
              uvffbar = (
                 np.power(coef, 2)*uvffbar 
-                + 2.*coef*const*(ufbar + vfbar) 
+                + 2.*coef*const*(ufbar_og + vfbar_og) 
                 + np.power(const, 2)
              )
              uvoobar = (
                 np.power(coef, 2)*uvoobar 
-                + 2.*coef*const*(uobar + vobar) 
+                + 2.*coef*const*(uobar_og + vobar_og) 
                 + np.power(const, 2)
              )
       elif all(elem in model_data_columns for elem in 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This fix matches the fix made in PR #521.  It addresses a logic error affecting plotting output for five EVS components.  The details are reprinted here.

The logic error was found in several instances of code used for converting the units of certain METplus summary statistics. Values of these stats were already converted before being used in follow-up conversion equations (incorrect). As a result, some output plots were displaying incorrect "doubly converted" values of verification metrics.

In this fix, METplus summary statistics are first stored as new variables prior to conversion, and these new variables are used when performing unit conversion and are never overwritten. As a result, all EVS plots affected by the issue should display correct converted values of verification metrics.

## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?

**Yes**.  Currently, some EVS plots are inaccurate if they display SL1L2- or VL1L2-based metrics and apply unit conversion. The issue affects five EVS components.

* Do you have any planned upcoming annual leave/PTO?

No.  My work schedule may be impacted by the Hurricane Helene recovery timeline (will edit when this is no longer the case).
* Are there any changes needed for when the jobs are supposed to run?

No.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### (1) Set up jobs

* symlink the EVS_fix directory locally as "fix"
* In each driver script, edit the following environment variables:
HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h1/ops/prod/com/$NET/$evs_ver_2d
COMOUT - set to your test output directory
SENDMAIL - (optional) set to "NO"

#### (2) Running jobs
* I recommend testing the following jobs:
```
jevs_cam_grid2obs_plots
jevs_mesoscale_grid2obs_plots
jevs_global_ens_atmos_gefs_grid2obs_past31days_plots
jevs_analyses_grid2obs_plots
jevs_aqm_grid2obs_plots
```
[Total: 5 plots jobs]

* All driver scripts can be submitted using `qsub -v vhr=00 $driver`
* All jobs can be submitted at any time

#### (3) Checking jobs
Log files should be checked by the developer for the following keywords:
```
check="FATAL\|WARNING\|error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

Additionally, a sample of test output plots should be compared to EVS prod output.

_Note: The changes in this PR affect unit conversion, so plots with no unit conversion will look the same.  Whether or not a plot is affected also depends on the metric shown; metrics computed with ffbar, oobar, or fobar are affected (e.g., rmse), but metrics computed with only fbar and obar are not (e.g., bias)._