### PR TITLE
bugfix/global_det_units

### DIFF
--- a/ush/global_det/global_det_atmos_plots_specs.py
+++ b/ush/global_det/global_det_atmos_plots_specs.py
@@ -682,14 +682,6 @@ class PlotSpecs:
         if plot_info_dict['fcst_var_name'] == 'ICEEX_DAILYAVG' \
                 and units == '10^6_km^2':
             units = 'x'+units.replace('_', ' ')
-        elif plot_info_dict['fcst_var_name'] \
-                in ['UGRD', 'VGRD', 'UGRD_VGRD', 'WNDSHR', 'GUST']:
-            units = 'kt'
-        elif plot_info_dict['fcst_var_name'] \
-                in ['TMP', 'DPT', 'TMP_ANOM_DAILYAVG', 'SST_DAILYAVG',
-                    'TSOIL'] \
-                and plot_info_dict['fcst_var_level'] in ['Z0', 'Z2', 'Z0.1-0']:
-            units = 'F'
         plot_title = plot_title+' '+'('+units+')'
         if var_thresh_for_title != 'NA':
             plot_title = plot_title+', '+var_thresh_for_title+' '+units

--- a/ush/global_det/global_det_atmos_plots_threshold_average.py
+++ b/ush/global_det/global_det_atmos_plots_threshold_average.py
@@ -306,6 +306,10 @@ class ThresholdAverage:
                                        figsize=(plot_specs_ta.fig_size[0],
                                                 plot_specs_ta.fig_size[1]),
                                        sharex=True)
+        if self.plot_info_dict['fcst_var_name'] == 'DPT' \
+                and self.plot_info_dict['fcst_var_level'] == 'Z2':
+            plot_title = plot_title.replace('2 meter Dewpoint (K)',
+                                            '2 meter Dewpoint (F)')
         fig.suptitle(plot_title)
         ax1.grid(True)
         ax1.set_ylabel(stat_plot_name)

--- a/ush/global_det/global_det_atmos_plots_time_series.py
+++ b/ush/global_det/global_det_atmos_plots_time_series.py
@@ -387,27 +387,6 @@ class TimeSeries:
                         obar_model_num_avg_label = format(
                             round(obar_model_num_avg, 3), '.3f'
                         )
-                ############################################################
-                # For FBAR stats, do the following unit conversions:
-                #     TMP/Z2: K to F
-                #     TSOIL/Z0.1-0: K to F
-                #     UGRD/Z10: m/s to kt
-                #     VGRD/Z10: m/s to kt
-                if self.plot_info_dict['stat'] == 'FBAR':
-                    if self.plot_info_dict['fcst_var_name'] \
-                            in ['TMP', 'TSOIL'] \
-                            and self.plot_info_dict['fcst_var_level'] \
-                            in ['Z2', 'Z0.1-0']:
-                        masked_model_num_data = (
-                            (((masked_model_num_data-273.15)*9)/5)+32
-                        )
-                    elif self.plot_info_dict['fcst_var_name'] \
-                            in ['UGRD', 'VGRD'] \
-                            and self.plot_info_dict['fcst_var_level'] == 'Z10':
-                        masked_model_num_data = (
-                            masked_model_num_data * 1.94384449412
-                        )
-                ############################################################
                 ax.plot_date(
                     np.ma.compressed(masked_plot_dates),
                     np.ma.compressed(masked_model_num_data),

--- a/ush/global_det/global_det_atmos_util.py
+++ b/ush/global_det/global_det_atmos_util.py
@@ -2959,6 +2959,117 @@ def build_df(logger, input_dir, output_dir, model_info_dict,
                         [model_stat_file_df_valid_date_idx_list[0]]\
                         [:]
                     )
+                # Do conversions if needed
+                #### K to F
+                if fcst_var_name in ['TMP', 'DPT', 'TMP_ANOM_DAILYAVG',
+                                     'SST_DAILYAVG', 'TSOIL'] \
+                        and fcst_var_level in ['Z0', 'Z2', 'Z0.1-0'] \
+                        and line_type in ['SL1L2', 'SAL1L2']:
+                    coef = np.divide(9., 5.)
+                    if fcst_var_name == 'TMP_ANOM_DAILYAVG':
+                        const = 0
+                    elif line_type == 'SAL1L2':
+                        const = 0
+                    else:
+                        const = ((-273.15)*9./5.)+32.
+                    convert = True
+                    units_old = 'K'
+                    units_new = 'F'
+                #### m/s to knots
+                elif fcst_var_name in ['UGRD', 'VGRD', 'UGRD_VGRD',
+                                       'WNDSHR', 'GUST'] \
+                        and line_type in ['SL1L2', 'SAL1L2',
+                                          'VL1L2', 'VAL1L2']:
+                    coef = 1.94384449412
+                    const = 0
+                    convert = True
+                    units_old = 'm/s'
+                    units_new = 'kt'
+                else:
+                    convert = False
+                if convert:
+                    if line_type == 'SL1L2':
+                        fcst_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'FBAR'
+                        ]
+                        obs_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'OBAR'
+                        ]
+                        col1_list = ['FBAR', 'OBAR']
+                        col2_list = ['FOBAR', 'FFBAR', 'OOBAR']
+                    elif line_type == 'SAL1L2':
+                        fcst_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'FABAR'
+                        ]
+                        obs_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'OABAR'
+                        ]
+                        col1_list = ['FABAR', 'OABAR']
+                        col2_list = ['FOABAR', 'FFABAR', 'OOABAR']
+                    elif line_type == 'VL1L2':
+                        uf_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'UFBAR'
+                        ]
+                        vf_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'VFBAR'
+                        ]
+                        uo_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'UOBAR'
+                        ]
+                        vo_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'VOBAR'
+                        ]
+                        col1_list = ['UFBAR', 'VFBAR', 'UOBAR', 'VOBAR']
+                        col2_list = ['UVFOBAR', 'UVFFBAR', 'UVOOBAR']
+                    elif line_type == 'VAL1L2':
+                        uf_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'UFABAR'
+                        ]
+                        vf_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'VFABAR'
+                        ]
+                        uo_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'UOABAR'
+                        ]
+                        vo_avg_old = model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, 'VOABAR'
+                        ]
+                        col1_list = ['UFABAR', 'VFABAR', 'UOABAR', 'VOABAR']
+                        col2_list = ['UVFOABAR', 'UVFFABAR', 'UVOOABAR']
+                    for col in col1_list:
+                        model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, col
+                        ] = (coef
+                             * model_num_df.loc[model_num_df['FCST_UNITS'] \
+                                               == units_old, col]) \
+                            + const
+                    for col in col2_list:
+                        if col in ['FOBAR', 'FOABAR']:
+                            const2 =  ((coef * const * fcst_avg_old)
+                                       + (coef * const * obs_avg_old))
+                        elif col in ['FFBAR', 'FFABAR']:
+                            const2 = 2 * (coef * const * fcst_avg_old)
+                        elif col in ['OOBAR', 'OOABAR']:
+                            const2 = 2 * (coef * const * obs_avg_old)
+                        elif col in ['UVFOBAR', 'UVFOABAR']:
+                            const2 = (coef * const \
+                                      * (uf_avg_old+vf_avg_old
+                                         +uo_avg_old+vo_avg_old))
+                        elif col in ['UVFFBAR', 'UVFFABAR']:
+                            const2 = 2 * (coef * const * \
+                                          (uf_avg_old+vf_avg_old))
+                        elif col in ['UVOOBAR', 'UVOOABAR']:
+                            const2 = 2 * (coef * const * \
+                                          (uo_avg_old+vo_avg_old))
+                        model_num_df.loc[
+                            model_num_df['FCST_UNITS'] == units_old, col
+                        ] = (coef**2
+                             *model_num_df.loc[model_num_df['FCST_UNITS'] \
+                                               == units_old, col]) \
+                             + const2 + const**2
+                    model_num_df.loc[
+                        model_num_df['FCST_UNITS'] == units_old, 'FCST_UNITS'
+                    ] = units_new
             else:
                 logger.debug(f"{parsed_model_stat_file} does not exist")
         if model_num == 'model1':


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This contains the fixes in #526 to a release branch for operations. Closes #573.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> Somewhat. The faster this gets merge in the sooner we can deliver to NCO
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed for when the jobs are supposed to run?
> No

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

###  **Set-up**
1. Clone my fork and checkout branch bugfix/global_det_units
2. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`
3. Uncomment `evs_ver` in versions/run.ver.

### ✅  **global_det atmos plots**
 4. `cd dev/drivers/scripts/plots/global_det`
 5. Run the following: `jevs_global_det_atmos_grid2grid_means_plots_31days.sh`, `jevs_global_det_atmos_grid2grid_precip_plots_31days.sh`,  `jevs_global_det_atmos_grid2grid_pres_levs_plots_31days.sh`, `jevs_global_det_atmos_grid2grid_sea_ice_plots_31days.sh`, `jevs_global_det_atmos_grid2grid_snow_plots_31days.sh`, `jevs_global_det_atmos_grid2grid_sst_plots_31days.sh`,  `jevs_global_det_atmos_grid2obs_pres_levs_plots_31days.sh`, `jevs_global_det_atmos_grid2obs_ptype_plots_31days.sh`, `jevs_global_det_atmos_grid2obs_sfc_plots_31days.sh`, and `jevs_global_det_atmos_headline_plots.sh`. 
> - Set `HOMEevs` to the location of the clone.
> - Set `COMIN` to `/lfs/h1/ops/prod/com/$NET/$evs_ver_2d`
> - Let me know when you are about to run and we can adjust `VDATE_END` if needed 
