### PR TITLE
feature/subseasonal_fixes_part1

### DIFF
--- a/jobs/JEVS_SUBSEASONAL_PLOTS
+++ b/jobs/JEVS_SUBSEASONAL_PLOTS
@@ -22,7 +22,6 @@ export NET=${NET:-evs}
 export STEP=${STEP:-plots}
 export COMPONENT=${COMPONENT:-subseasonal}
 export RUN=${RUN:-atmos}
-export VERIF_CASE=${VERIF_CASE:-grid2grid}
 export machine=${machine:-WCOSS2}
 
 ################################################################

--- a/jobs/JEVS_SUBSEASONAL_PREP
+++ b/jobs/JEVS_SUBSEASONAL_PREP
@@ -8,16 +8,24 @@ set -x
 export PS4='$SECONDS + ' 
 date
 
-export machine="WCOSS2"
-
 ###########################################################
 # obtain unique LSF id (jobid) and make temp directories
 ###########################################################
 export DATA=${DATA:-${DATAROOT:?}/${jobid:?}}
 mkdir -p $DATA
-cd $DATA 
+cd $DATA
+
+####################################
+### Define NET/RUN variables
+######################################
+export NET=${NET:-evs}
+export STEP=${STEP:-prep}
+export COMPONENT=${COMPONENT:-subseasonal}
+export RUN=${RUN:-atmos}
+export machine=${machine:-WCOSS2}
 
 ################################################################
+# Set data directives
 # SENDCOM=YES--Copy files from TMPDIR to $COMOUT
 # SENDMAIL=YES--Send missing data emails
 # SENDECF=YES--Flag events on ecflow
@@ -28,8 +36,9 @@ export SENDMAIL=${SENDMAIL:-NO}
 export SENDDBN=${SENDDBN:-YES}       # need to set to NO for testing
 export SENDECF=${SENDECF:-YES}
 export SENDDBN_NTC=${SENDDBN_NTC:-NO}
+
 ################################################################
-# Specify Execution Areas
+# Set EVS directories
 ################################################################
 export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
 export EXECevs=${EXECevs:-$HOMEevs/exec}
@@ -41,7 +50,9 @@ export gefs_members="30"
 
 export cfs_members="4"
 
+################################################################
 # Run setpdy and initialize PDY variables
+################################################################
 export vhr=${vhr:-00}
 export cycle=${cycle:-t${vhr}z}
 setpdy.sh
@@ -59,16 +70,12 @@ export DCOMINecmwf=${DCOMINecmwf:-$DCOMROOT}
 export DCOMINosi=${DCOMINosi:-$DCOMROOT}
 export DCOMINghrsst=${DCOMINghrsst:-$DCOMROOT}
 export DCOMINumd=${DCOMINumd:-$DCOMROOT}
-export COMINnam=${COMINnam:-$(compath.py ${envir}/com/obsproc/${obsproc_ver})}
+export COMINobsproc=${COMINobsproc:-$(compath.py ${envir}/com/obsproc/${obsproc_ver})}
 export COMINccpa=${COMINccpa:-$(compath.py ${envir}/com/ccpa/${ccpa_ver})}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/$evs_ver/$STEP/$COMPONENT/$RUN)}
 
-
-echo Actual output starts here
-
-
 #######################################################################
-# Execute the script.
+# Execute the script
 #######################################################################
 $HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${PREP_TYPE}_${STEP}.sh
 export err=$?; err_chk

--- a/jobs/JEVS_SUBSEASONAL_STATS
+++ b/jobs/JEVS_SUBSEASONAL_STATS
@@ -8,16 +8,24 @@ set -x
 export PS4='$SECONDS + ' 
 date
 
-export machine="WCOSS2"
-
 ###########################################################
 # obtain unique LSF id (jobid) and make temp directories
 ###########################################################
 export DATA=${DATA:-${DATAROOT:?}/${jobid:?}}
 mkdir -p $DATA
-cd $DATA 
+cd $DATA
+
+####################################
+### Define NET/RUN variables
+######################################
+export NET=${NET:-evs}
+export STEP=${STEP:-stats}
+export COMPONENT=${COMPONENT:-subseasonal}
+export RUN=${RUN:-atmos}
+export machine=${machine:-WCOSS2}
 
 ################################################################
+# Set data directives
 # SENDCOM=YES--Copy files from TMPDIR to $COMOUT
 # SENDECF=YES--Flag events on ecflow
 # SENDDBN=YES--Issue DBNet Client Calls
@@ -26,8 +34,9 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}       # need to set to NO for testing
 export SENDECF=${SENDECF:-YES}
 export SENDDBN_NTC=${SENDDBN_NTC:-NO}
+
 ################################################################
-# Specify Execution Areas
+# Set EVS directories
 ################################################################
 export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
 export EXECevs=${EXECevs:-$HOMEevs/exec}
@@ -42,15 +51,15 @@ if [ $MODELNAME = cfs ] ; then
     export members="4"
 fi
 
-
+################################################################
 # Run setpdy and initialize PDY variables
+################################################################
 export vhr=${vhr:-00}
 export cycle=${cycle:-t${vhr}z}
 setpdy.sh 40
 . ./PDY
 
 export VDATE=${VDATE:-$PDYm2}
-
 
 #################################################
 # Set up the INPUT and OUTPUT directories
@@ -63,11 +72,8 @@ export COMOUTfinal=$COMOUT/$MODELNAME.$VDATE
 
 mkdir -p $COMOUT $COMOUTfinal
 
-echo Actual output starts here
-
-
 #######################################################################
-# Execute the script.
+# Execute the script
 #######################################################################
 $HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${VERIF_CASE}_${STEP}.sh
 export err=$?; err_chk

--- a/ush/subseasonal/subseasonal_prep_obs.py
+++ b/ush/subseasonal/subseasonal_prep_obs.py
@@ -26,7 +26,7 @@ DCOMINecmwf = os.environ['DCOMINecmwf']
 DCOMINosi = os.environ['DCOMINosi']
 DCOMINghrsst = os.environ['DCOMINghrsst']
 DCOMINumd = os.environ['DCOMINumd']
-COMINnam = os.environ['COMINnam']
+COMINobsproc = os.environ['COMINobsproc']
 COMINccpa = os.environ['COMINccpa']
 COMOUT = os.environ['COMOUT']
 SENDCOM = os.environ['SENDCOM']
@@ -162,7 +162,7 @@ for OBS in OBSNAME:
             offset_CDATE_dt = (
                 CDATE_dt + datetime.timedelta(hours=int(offset_hr))
             )
-            prod_file_format = os.path.join(COMINnam, 'nam.'
+            prod_file_format = os.path.join(COMINobsproc, 'nam.'
                                             +'{init?fmt=%Y%m%d}',
                                             'nam.t{init?fmt=%2H}z.'
                                             +'prepbufr.tm'+offset_hr)

--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -4475,13 +4475,13 @@ def condense_model_stat_files(logger, input_dir, output_file, model, obs,
             )
             for model_stat_file in model_stat_files:
                 logger.debug(f"Getting data from {model_stat_file}")
-                ps = subprocess.Popen(
+                ps = subprocess.run(
                     'grep -R "'+model+' " '+model_stat_file+grep_opts,
                     shell=True, stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT, encoding='UTF-8'
                 )
                 logger.debug(f"Ran {ps.args}")
-                all_grep_output = all_grep_output+ps.communicate()[0]
+                all_grep_output = all_grep_output+ps.stdout
             logger.debug(f"Condensed {model} .stat file at "
                          +f"{output_file}")
             with open(output_file, 'w') as f:


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
 
> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
For obs prep, COMINnam was changed to COMINobsproc in j-job and subseasonal_prep_obs.py.
In subseasonal_util.py, subprocess.Popen was changed to subprocess.run and ps.communicate ()[0} was changed to ps.stdout.
$NET was defined before $HOMEevs in the prep, stats, and plots j-jobs.
## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
* No
* Do you have any planned upcoming annual leave/PTO?
* No
* Are there any changes needed for when the jobs are supposed to run?
  No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Checkout this feature branch and link FIXevs directory.
Set COMIN and COMOUT to respective assignee path and/or beta 5 parallel prep and stats.
Please run the following scripts for testing the described changes:
dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_obs_prep.sh
dev/drivers/scripts/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats.sh (Make sure to link to parallel prep path and wait until current day's prep jobs are done)
dev/drivers/scripts/plots/subseasonal/jevs_subseasonal_*.sh (Make sure to link to parallel stats path and wait until current day's stats jobs are done, then run all plots drivers)