### PR TITLE
add screen airnow hourly and daily obs for AQM and GEFS

### DIFF
--- a/jobs/JEVS_AQM_PREP
+++ b/jobs/JEVS_AQM_PREP
@@ -78,6 +78,7 @@ mkdir -p ${COMOUT} ${COMOUTproc}
 # alternative choice is dan option different from aqons
 export airnow_hourly_type=${airnow_hourly_type:-aqobs}
 
+export DAILY_NCOL=${DAILY_NCOL:-13}
 
 #######################################################################
 # Execute the script.

--- a/parm/metplus_config/prep/aqm/grid2obs/Ascii2Nc_daily_obsAIRNOW.conf
+++ b/parm/metplus_config/prep/aqm/grid2obs/Ascii2Nc_daily_obsAIRNOW.conf
@@ -2,7 +2,7 @@
 
 OUTPUT_BASE = {ENV[DATA]}
 
-ASCII2NC_INPUT_DIR = {ENV[DCOMINairnow]}
+ASCII2NC_INPUT_DIR = {ENV[DATA]}
 ASCII2NC_OUTPUT_DIR = {ENV[PREP_SAVE_DIR]}
 
 LOG_DIR={OUTPUT_BASE}/logs
@@ -37,7 +37,7 @@ OBS_WINDOW_END = {ENV[INITDATE]}
 
 [filename_templates]
 
-ASCII2NC_INPUT_TEMPLATE={valid?fmt=%Y%m%d}/airnow/daily_data_v2.dat
+ASCII2NC_INPUT_TEMPLATE=checked_daily_data_v2.dat
 ASCII2NC_OUTPUT_TEMPLATE=airnow_daily_{valid?fmt=%Y%m%d}.nc
 
 [user_env_vars]

--- a/parm/metplus_config/prep/aqm/grid2obs/Ascii2Nc_hourly_obsAIRNOW.conf
+++ b/parm/metplus_config/prep/aqm/grid2obs/Ascii2Nc_hourly_obsAIRNOW.conf
@@ -2,7 +2,7 @@
 
 OUTPUT_BASE = {ENV[DATA]}
 
-ASCII2NC_INPUT_DIR = {ENV[DCOMINairnow]}
+ASCII2NC_INPUT_DIR = {ENV[DATA]}
 ASCII2NC_OUTPUT_DIR = {ENV[PREP_SAVE_DIR]}
 
 LOG_DIR={OUTPUT_BASE}/logs
@@ -46,7 +46,7 @@ OBS_WINDOW_END = 0
 
 [filename_templates]
 
-ASCII2NC_INPUT_TEMPLATE={valid?fmt=%Y%m%d}/airnow/{ENV[HOURLY_INPUT_TYPE]}_{valid?fmt=%Y%m%d%H}.dat
+ASCII2NC_INPUT_TEMPLATE=checked_{ENV[HOURLY_INPUT_TYPE]}_{valid?fmt=%Y%m%d%H}.dat
 ASCII2NC_OUTPUT_TEMPLATE=airnow_{ENV[HOURLY_OUTPUT_TYPE]}_{valid?fmt=%Y%m%d%H}.nc
 
 [user_env_vars]

--- a/parm/metplus_config/prep/global_ens/chem_grid2obs/ASCII2NC_obsAIRNOW.conf
+++ b/parm/metplus_config/prep/global_ens/chem_grid2obs/ASCII2NC_obsAIRNOW.conf
@@ -40,7 +40,7 @@ OBS_WINDOW_END = 0
 
 [dir]
 
-ASCII2NC_INPUT_DIR = {ENV[DCOMINairnow]}
+ASCII2NC_INPUT_DIR = {ENV[DATA]}
 
 ASCII2NC_OUTPUT_DIR = {ENV[finalprep]}
 
@@ -49,7 +49,7 @@ LOG_DIR={OUTPUT_BASE}/logs/{ENV[COMPONENT]}
 
 [filename_templates]
 
-ASCII2NC_INPUT_TEMPLATE={valid?fmt=%Y%m%d}/{ENV[OBTTYPE]}/{ENV[HOURLY_INPUT_TYPE]}_{valid?fmt=%Y%m%d%H}.dat
+ASCII2NC_INPUT_TEMPLATE=checked_{ENV[HOURLY_INPUT_TYPE]}_{valid?fmt=%Y%m%d%H}.dat
 
 ASCII2NC_OUTPUT_TEMPLATE={ENV[OBTTYPE]}_{ENV[HOURLY_OUTPUT_TYPE]}_{valid?fmt=%Y%m%d%H}.nc
 

--- a/scripts/prep/aqm/exevs_aqm_prep.sh
+++ b/scripts/prep/aqm/exevs_aqm_prep.sh
@@ -65,6 +65,7 @@ while [ ${ic} -le ${endvhr} ]; do
     if [ -s ${checkfile} ]; then
         screen_file=${DATA}/checked_${HOURLY_INPUT_TYPE}_${INITDATE}${vldhr}.dat
         python ${USHevs}/${COMPONENT}/screen_airnow_obs_hourly.py ${checkfile} ${screen_file}
+        export err=$?; err_chk
         number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
         ## There is 1 header lines 
         if [ ${number_of_record} -gt 1 ]; then
@@ -110,6 +111,7 @@ checkfile=${DCOMINairnow}/${INITDATE}/airnow/daily_data_v2.dat
 if [ -s ${checkfile} ]; then
     screen_file=${DATA}/checked_daily_data_v2.dat
     python ${USHevs}/${COMPONENT}/screen_airnow_obs_daily.py ${checkfile} ${screen_file}
+    export err=$?; err_chk
     number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
     if [ ${number_of_record} -gt 0 ]; then
         if [ -s ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf ]; then

--- a/scripts/prep/aqm/exevs_aqm_prep.sh
+++ b/scripts/prep/aqm/exevs_aqm_prep.sh
@@ -63,17 +63,32 @@ while [ ${ic} -le ${endvhr} ]; do
     vldhr=$(printf %2.2d ${ic})
     checkfile=${DCOMINairnow}/${INITDATE}/airnow/${HOURLY_INPUT_TYPE}_${INITDATE}${vldhr}.dat
     if [ -s ${checkfile} ]; then
-        export VHOUR=${vldhr}
-	if [ -s ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf ]; then
-            run_metplus.py ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf ${PARMevs}/metplus_config/machine.conf
-	    export err=$?; err_chk
-	    if [ ${SENDCOM} = "YES" ]; then
-                cpfile=${PREP_SAVE_DIR}/airnow_hourly_aqobs_${INITDATE}${VHOUR}.nc 
-                if [ -s ${cpfile} ]; then cp -v ${cpfile} ${COMOUTproc}; fi
-	    fi
+        screen_file=${DATA}/checked_${HOURLY_INPUT_TYPE}_${INITDATE}${vldhr}.dat
+        python ${USHevs}/${COMPONENT}/screen_airnow_obs_hourly.py ${checkfile} ${screen_file}
+        number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
+        ## There is 1 header lines 
+        if [ ${number_of_record} -gt 1 ]; then
+            export VHOUR=${vldhr}
+            if [ -s ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf ]; then
+                run_metplus.py ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf ${PARMevs}/metplus_config/machine.conf
+                export err=$?; err_chk
+                if [ ${SENDCOM} = "YES" ]; then
+                    cpfile=${PREP_SAVE_DIR}/airnow_hourly_aqobs_${INITDATE}${VHOUR}.nc 
+                    if [ -s ${cpfile} ]; then cp -v ${cpfile} ${COMOUTproc}; fi
+                fi
+            else
+                echo "WARNING: can not find ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf"
+            fi
         else
-            echo "WARNING: can not find ${conf_dir}/Ascii2Nc_hourly_obsAIRNOW.conf"
-	fi
+            if [ ${SENDMAIL} = "YES" ]; then
+                export subject="NO AIRNOW ASCII Hourly Data for EVS ${COMPONENT}"
+                echo "DEBUG : There is no valid record to be processed for ${checkfile}" >> mailmsg
+                echo "File in question is ${checkfile}" >> mailmsg
+                echo "Job ID: $jobid" >> mailmsg
+                cat mailmsg | mail -s "$subject" $MAILTO 
+            fi
+            echo "DEBUG : There is no valid record to be processed for ${checkfile}"
+        fi
     else
         if [ ${SENDMAIL} = "YES" ]; then
             export subject="AIRNOW ASCII Hourly Data Missing for EVS ${COMPONENT}"
@@ -93,15 +108,29 @@ done
 ##
 checkfile=${DCOMINairnow}/${INITDATE}/airnow/daily_data_v2.dat
 if [ -s ${checkfile} ]; then
-    if [ -s ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf ]; then
-        run_metplus.py ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf ${PARMevs}/metplus_config/machine.conf
-        export err=$?; err_chk
-	if [ ${SENDCOM} = "YES" ]; then
-            cpfile=${PREP_SAVE_DIR}/airnow_daily_${INITDATE}.nc
-            if [ -s ${cpfile} ]; then cp -v ${cpfile} ${COMOUTproc};fi
-	fi
+    screen_file=${DATA}/checked_daily_data_v2.dat
+    python ${USHevs}/${COMPONENT}/screen_airnow_obs_daily.py ${checkfile} ${screen_file}
+    number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
+    if [ ${number_of_record} -gt 0 ]; then
+        if [ -s ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf ]; then
+            run_metplus.py ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf ${PARMevs}/metplus_config/machine.conf
+            export err=$?; err_chk
+            if [ ${SENDCOM} = "YES" ]; then
+                cpfile=${PREP_SAVE_DIR}/airnow_daily_${INITDATE}.nc
+                if [ -s ${cpfile} ]; then cp -v ${cpfile} ${COMOUTproc};fi
+            fi
+        else
+            echo "WARNING: can not find ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf"
+        fi
     else
-        echo "WARNING: can not find ${conf_dir}/Ascii2Nc_daily_obsAIRNOW.conf"
+        if [ ${SENDMAIL} = "YES" ]; then
+            export subject="NO AIRNOW ASCII Daily Data for EVS ${COMPONENT}"
+            echo "DEBUG : There is no valid record to be processed for ${checkfile}" >> mailmsg
+            echo "File in question is ${checkfile}" >> mailmsg
+            echo "Job ID: $jobid" >> mailmsg
+            cat mailmsg | mail -s "$subject" $MAILTO 
+        fi
+        echo "DEBUG : There is no valid record to be processed for ${checkfile}"
     fi
 else
     if [ ${SENDMAIL} = "YES" ]; then
@@ -143,11 +172,11 @@ for hour in 06 12; do
                 wgrib2 -d 1 ${ozmax8_file} -set_ftime "6-29 hour ave fcst"  -grib out1.grb2
                 wgrib2 -d 2 ${ozmax8_file} -set_ftime "30-53 hour ave fcst" -grib out2.grb2
                 wgrib2 -d 3 ${ozmax8_file} -set_ftime "54-77 hour ave fcst" -grib out3.grb2
-		comout_file=aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
+                comout_file=aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
                 cat out1.grb2 out2.grb2 out3.grb2 > ${comout_file}
-        	if [ ${SENDCOM} = "YES" ]; then
+                if [ ${SENDCOM} = "YES" ]; then
                     if [ -s ${comout_file} ]; then cp -v ${comout_file} ${COMOUTproc}; fi
-        	fi
+                fi
             else
                 if [ ${SENDMAIL} = "YES" ]; then
                     export subject="t${hour}z OZMAX8${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"
@@ -169,11 +198,11 @@ for hour in 06 12; do
                 wgrib2 -d 1 ${ozmax8_file} -set_ftime "0-23 hour ave fcst" -grib out1.grb2
                 wgrib2 -d 2 ${ozmax8_file} -set_ftime "24-47 hour ave fcst" -grib out2.grb2
                 wgrib2 -d 3 ${ozmax8_file} -set_ftime "48-71 hour ave fcst" -grib out3.grb2
-		comout_file=aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
+                comout_file=aqm.t${hour}z.max_8hr_o3${bctag}.${gridspec}.grib2
                 cat out1.grb2 out2.grb2 out3.grb2 > ${comout_file}
-        	if [ ${SENDCOM} = "YES" ]; then
+                if [ ${SENDCOM} = "YES" ]; then
                     if [ -s ${comout_file} ]; then cp -v ${comout_file} ${COMOUTproc}; fi
-        	fi
+                fi
             else
                 if [ ${SENDMAIL} = "YES" ]; then
                     export subject="t${hour}z OZMAX8${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"

--- a/scripts/prep/global_ens/exevs_global_ens_gefs_chem_grid2obs_prep.sh
+++ b/scripts/prep/global_ens/exevs_global_ens_gefs_chem_grid2obs_prep.sh
@@ -40,11 +40,12 @@ for OBTTYPE in ${obstype}; do
         checkfile=${DCOMINaeronet}/${INITDATE}/validation_data/aq/${OBTTYPE}/${INITDATE}.lev15
         if [ -s ${checkfile} ]; then
             screen_file=${DATA}/checked_${OBTTYPE}_${INITDATE}.lev15
-	    python ${USHevs}/${COMPONENT}/screen_aeronet_aod_lev15.py ${checkfile} ${screen_file}
-	    number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
-	    ## There is 6 comment and header lines 
+            python ${USHevs}/${COMPONENT}/screen_aeronet_aod_lev15.py ${checkfile} ${screen_file}
+            export err=$?; err_chk
+            number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
+            ## There is 6 comment and header lines 
             if [ ${number_of_record} -gt 6 ]; then
-		if [ -s ${prep_config_file} ]; then
+                if [ -s ${prep_config_file} ]; then
                     run_metplus.py ${prep_config_file} ${config_common}
                     export err=$?; err_chk
                     if [ ${SENDCOM} = "YES" ]; then
@@ -98,9 +99,10 @@ for OBTTYPE in ${obstype}; do
             checkfile=${DCOMINairnow}/${INITDATE}/${OBTTYPE}/${HOURLY_INPUT_TYPE}_${INITDATE}${vldhr}.dat
             if [ -s ${checkfile} ]; then
                 screen_file=${DATA}/checked_${HOURLY_INPUT_TYPE}_${INITDATE}${vldhr}.dat
-	        python ${USHevs}/${COMPONENT}/screen_airnow_obs_hourly.py ${checkfile} ${screen_file}
-	        number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
-	        ## There is 1 header lines 
+                python ${USHevs}/${COMPONENT}/screen_airnow_obs_hourly.py ${checkfile} ${screen_file}
+                export err=$?; err_chk
+                number_of_record=$(wc -l ${screen_file} | awk -F" " '{print $1}')
+                ## There is 1 header lines 
                 if [ ${number_of_record} -gt 1 ]; then
                     export VHOUR=${vldhr}
                     if [ -s ${prep_config_file} ]; then

--- a/ush/aqm/screen_airnow_obs_daily.py
+++ b/ush/aqm/screen_airnow_obs_daily.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+###############################################################################
+# Name of Script: 
+# Contact(s):     Ho-Chun Huang (ho-chun.huang@noaa.gov)
+# Purpose of Script: Read AERONET AOD file and remove bad records with
+#                    inconsistent columns number as header
+#
+# History Log:
+###############################################################################
+
+import os
+import sys
+
+print(f'Python Script: {sys.argv[0]}')
+# input and output file specified on the command line
+
+if len(sys.argv) < 2:
+    script_name = os.path.basename(sys.argv[0])
+    print(f"FATAL ERROR: {script_name} -> Must specify input and output files.")
+    sys.exit(1)
+
+# Read the input file as the first argument
+input_file = os.path.expandvars(sys.argv[1])
+print(f'Input Original Aeronet File:  {input_file}')
+
+# Read the Output file as the second argument
+output_file = os.path.expandvars(sys.argv[2])
+print(f'Output screened Aeronet File: {output_file}')
+
+if not os.path.exists(input_file):
+    print(f"DEBUG :: Can not find input Aeronet file - {input_file}")
+    print(f"DEBUG :: Check the existence of input file before calling {sys.argv[0]}")
+    sys.exit()
+
+rfile=open(input_file, 'r')
+wfile=open(output_file,'w')
+
+#
+## Check first 3 line for number of column or use the default column 'DAILY_NCOL' defined in ~/job
+#
+count=0
+flag_data=False
+for line in rfile:
+    if not flag_data:
+        if count == 0:
+            line1=line
+        elif count == 1:
+            line2=line
+        elif count == 2:
+            line3=line
+        line=line.rstrip("\n")
+        hdr=line.split("|")
+        if count == 0:
+            num_hdr1=len(hdr)
+        elif count == 1:
+            num_hdr2=len(hdr)
+            if num_hdr1 == num_hdr2:
+                num_hdr = num_hdr1
+                wfile.write(line1)
+                wfile.write(line2)
+                flag_data=True
+        elif count == 2:
+            num_hdr3=len(hdr)
+            if num_hdr3 == num_hdr1:
+                num_hdr = num_hdr1
+                wfile.write(line1)
+                wfile.write(line3)
+                print(f"DEBUG :: Line 2 has different columns number {num_hdr2} vs standard {num_hdr}")
+                flag_data=True
+            elif num_hdr3 == num_hdr2:
+                num_hdr = num_hdr2
+                wfile.write(line2)
+                wfile.write(line3)
+                print(f"DEBUG :: Line 1 has different columns number {num_hdr1} vs standard {num_hdr}")
+                flag_data=True
+            else:   ## USE DEFAULT Column number
+                print(f"DEBUG :: First 3 lines of {input_file} have different column number")
+                try:
+                    str_num_hdr=os.environ['DAILY_NCOL']
+                    num_hdr=int(str_num_hdr)
+                    print(f"DEBUG :: Use default {num_hdr} as reference column number")
+                    if num_hdr1 == num_hdr:
+                        wfile.write(line1)
+                    else:
+                        print(f"DEBUG :: Line 1 has different columns number {num_hdr1} vs standard {num_hdr}")
+                    if num_hdr2 == num_hdr:
+                        wfile.write(line2)
+                    else:
+                        print(f"DEBUG :: Line 2 has different columns number {num_hdr2} vs standard {num_hdr}")
+                    if num_hdr3 == num_hdr:
+                        wfile.write(line3)
+                    else:
+                        print(f"DEBUG :: Line 3 has different columns number {num_hdr3} vs standard {num_hdr}")
+                    flag_data=True
+                except KeyError:
+                    print(f"WARNING ::  no reference DAILY_NCOL daily column number has been defined")
+                    sys.exit()
+        count += 1
+    else:
+        count += 1
+        line=line.rstrip("\n")
+        var=[]
+        var=line.split("|")
+        num_var=len(var)
+        if num_var == num_hdr:
+            wfile.write(line+"\n")
+        else:
+            print(f"DEBUG :: Line {count} has different columns number {num_var} vs standard {num_hdr}")
+wfile.close()

--- a/ush/aqm/screen_airnow_obs_hourly.py
+++ b/ush/aqm/screen_airnow_obs_hourly.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+###############################################################################
+# Name of Script: 
+# Contact(s):     Ho-Chun Huang (ho-chun.huang@noaa.gov)
+# Purpose of Script: Read AERONET AOD file and remove bad records with
+#                    inconsistent columns number as header
+#
+# History Log:
+###############################################################################
+
+import os
+import sys
+
+print(f'Python Script: {sys.argv[0]}')
+# input and output file specified on the command line
+
+if len(sys.argv) < 2:
+    script_name = os.path.basename(sys.argv[0])
+    print(f"FATAL ERROR: {script_name} -> Must specify input and output files.")
+    sys.exit(1)
+
+# Read the input file as the first argument
+input_file = os.path.expandvars(sys.argv[1])
+print(f'Input Original Aeronet File:  {input_file}')
+
+# Read the Output file as the second argument
+output_file = os.path.expandvars(sys.argv[2])
+print(f'Output screened Aeronet File: {output_file}')
+
+if not os.path.exists(input_file):
+    print(f"DEBUG :: Can not find input Aeronet file - {input_file}")
+    print(f"DEBUG :: Check the existence of input file before calling {sys.argv[0]}")
+    sys.exit()
+
+rfile=open(input_file, 'r')
+wfile=open(output_file,'w')
+
+count=0
+flag_data=False
+for line in rfile:
+    if not flag_data:
+        if line[1:6] != "AQSID":
+            wfile.write(line)
+        else:
+            wfile.write(line)
+            line=line.rstrip("\n")
+            hdr=line.split('","')
+            num_hdr=len(hdr)
+            print(f"header len {num_hdr}")
+            flag_data=True
+        count += 1
+    else:
+        count += 1
+        line=line.rstrip("\n")
+        var=[]
+        var=line.split('","')
+        num_var=len(var)
+        if num_var == num_hdr:
+            wfile.write(line+"\n")
+        else:
+            print(f"DEBUG :: Line {count} has different columns number {num_var} vs standard {num_hdr}")
+wfile.close()

--- a/ush/global_ens/screen_airnow_obs_hourly.py
+++ b/ush/global_ens/screen_airnow_obs_hourly.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+###############################################################################
+# Name of Script: 
+# Contact(s):     Ho-Chun Huang (ho-chun.huang@noaa.gov)
+# Purpose of Script: Read AERONET AOD file and remove bad records with
+#                    inconsistent columns number as header
+#
+# History Log:
+###############################################################################
+
+import os
+import sys
+
+print(f'Python Script: {sys.argv[0]}')
+# input and output file specified on the command line
+
+if len(sys.argv) < 2:
+    script_name = os.path.basename(sys.argv[0])
+    print(f"FATAL ERROR: {script_name} -> Must specify input and output files.")
+    sys.exit(1)
+
+# Read the input file as the first argument
+input_file = os.path.expandvars(sys.argv[1])
+print(f'Input Original Aeronet File:  {input_file}')
+
+# Read the Output file as the second argument
+output_file = os.path.expandvars(sys.argv[2])
+print(f'Output screened Aeronet File: {output_file}')
+
+if not os.path.exists(input_file):
+    print(f"DEBUG :: Can not find input Aeronet file - {input_file}")
+    print(f"DEBUG :: Check the existence of input file before calling {sys.argv[0]}")
+    sys.exit()
+
+rfile=open(input_file, 'r')
+wfile=open(output_file,'w')
+
+count=0
+flag_data=False
+for line in rfile:
+    if not flag_data:
+        if line[1:6] != "AQSID":
+            wfile.write(line)
+        else:
+            wfile.write(line)
+            line=line.rstrip("\n")
+            hdr=line.split('","')
+            num_hdr=len(hdr)
+            print(f"header len {num_hdr}")
+            flag_data=True
+        count += 1
+    else:
+        count += 1
+        line=line.rstrip("\n")
+        var=[]
+        var=line.split('","')
+        num_var=len(var)
+        if num_var == num_hdr:
+            wfile.write(line+"\n")
+        else:
+            print(f"DEBUG :: Line {count} has different columns number {num_var} vs standard {num_hdr}")
+wfile.close()


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Screen airnow hourly and daily ascii file for inconsistent column.  If the column number of first 3 records of daily airnow are different, use the default defined in ~/job/JEVS_AQM_PREP.

This fix impacts both AQM and GEFS-CHEM grib2obs.

## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed for when the jobs are supposed to run?
NO
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
YES

- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
YES

- [ ] References the feature branch for `HOMEevs` are removed from the code.
YES

- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
YES

- [ ] Jobs over 15 minutes in runtime have restart capability.
NA

- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
NA

- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
YES

- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
YES

- [ ] Log is free of any ERRORs or WARNINGs.
YES


## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Run today's prep for both AQM and GEFS to test free of error in normal condition.

Run AQM and GEFS prep for
INITDATE=20241015 and
export DCOMINairnow=/lfs/h2/emc/vpppg/noscrub/ho-chun.huang/dcom/prod/airnow

Look for the message output for vldhr 02, 07, and 10. for AQM and GEFS output, and daily airnow for AQM log output

vdlhr=02
DEBUG :: Line 6 has different columns number 23 vs standard 34
DEBUG :: Line 8 has different columns number 39 vs standard 34

vldhr=07
DEBUG :: Line 2 has different columns number 21 vs standard 34
DEBUG :: Line 3 has different columns number 14 vs standard 34
DEBUG :: Line 4 has different columns number 46 vs standard 34
DEBUG :: Line 5 has different columns number 46 vs standard 34

vldhr=10
DEBUG :: Line 2 has different columns number 26 vs standard 34
DEBUG :: Line 3 has different columns number 23 vs standard 34
DEBUG :: Line 4 has different columns number 133 vs standard 34

daily airnow
DEBUG :: Line 2 has different columns number 7 vs standard 13