### PR TITLE
AQM EVS2.0 FIX Feature/fixplotcpu

### DIFF
--- a/dev/drivers/scripts/plots/aqm/jevs_aqm_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_aqm_grid2obs_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=02:00:00
-#PBS -l place=shared,select=1:ncpus=1:mem=500GB
+#PBS -l place=shared,select=1:ncpus=1:mem=20GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/aqm/jevs_aqm_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_aqm_grid2obs_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=02:00:00
-#PBS -l place=shared,select=1:ncpus=128:mem=500GB
+#PBS -l place=shared,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/plots/aqm/jevs_aqm_plots.ecf
+++ b/ecf/scripts/plots/aqm/jevs_aqm_plots.ecf
@@ -4,7 +4,8 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:mem=500GB
+###PBS -l place=vscatter:exclhost,select=1:ncpus=128:mem=500GB
+#PBS -l place=shared,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/aqm/jevs_aqm_plots.ecf
+++ b/ecf/scripts/plots/aqm/jevs_aqm_plots.ecf
@@ -4,7 +4,6 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
-###PBS -l place=vscatter:exclhost,select=1:ncpus=128:mem=500GB
 #PBS -l place=shared,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/aqm/jevs_aqm_plots.ecf
+++ b/ecf/scripts/plots/aqm/jevs_aqm_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
-#PBS -l place=shared,select=1:ncpus=1:mem=500GB
+#PBS -l place=shared,select=1:ncpus=1:mem=20GB
 #PBS -l debug=true
 
 export model=evs

--- a/scripts/plots/aqm/exevs_aqm_grid2obs_plots.sh
+++ b/scripts/plots/aqm/exevs_aqm_grid2obs_plots.sh
@@ -241,7 +241,7 @@ fi
 ##
 ## Headline Plots
 ##
-mkdir -p ${COMOUTplots}/headline
+mkdir -p ${COMOUTheadline}/headline
 for region in CONUS CONUS_East CONUS_West CONUS_South CONUS_Central; do
     export region
     case ${region} in
@@ -296,7 +296,7 @@ for region in CONUS CONUS_East CONUS_West CONUS_South CONUS_Central; do
             figtype=csi
 
             figfile=headline_${COMPONENT}.${figtype}_gt${select_headline_csi}.${smvar}.${smlev}.last31days.timeseries_init${inithr}z_f${flead}.buk_${smregion}.png
-            cpfile=${COMOUTplots}/headline/${figfile}
+            cpfile=${COMOUTheadline}/headline/${figfile}
             if [ ! -e ${cpfile} ]; then
                 ${PARMevs}/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/py_plotting_${smvar}_headline.config
                 export err=$?; err_chk
@@ -308,7 +308,7 @@ for region in CONUS CONUS_East CONUS_West CONUS_South CONUS_Central; do
             cpfile=${PLOTDIR_headline}/${figfile}
             if [ -e ${PLOTDIR_headline}/aq/*/evs*png ]; then
                 mv ${PLOTDIR_headline}/aq/*/evs*png ${cpfile}
-                cp -v ${cpfile} ${COMOUTplots}/headline
+                cp -v ${cpfile} ${COMOUTheadline}/headline
             elif [ ! -e ${cpfile} ]; then
                 echo "WARNING: NO HEADLINE PLOT FOR ${var} ${figtype} ${region}"
                 echo "WARNING: This is possible where there is no exceedance of the critical threshold in the last 31 days"


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

(1) Fix AQM plot script resource to 1 CPU
(2) mv headline directory from atmos.yyyymmdd to headline.yyyymmdd

## Developer Questions and Checklist
* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed for when the jobs are supposed to run?
NO 

- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
YES

- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
YES

- [ ] References the feature branch for `HOMEevs` are removed from the code.
YES

- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
YES

- [ ] Jobs over 15 minutes in runtime have restart capability.
YES

- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
YES

- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
NA

- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
YES

- [ ] Log is free of any ERRORs or WARNINGs.
YES, except where there are no stats for ozmax8 in fall and winter time.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Perform regular AQM plots step, and inspects  the log and output directories.