### PR TITLE
ops changes for post WCOSS changes

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=66:mem=500GB
+#PBS -l place=vscatter:shared,select=2:ncpus=66:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=72:mem=100GB
+#PBS -l place=vscatter,select=2:ncpus=66:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past90days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=66:mem=500GB
+#PBS -l place=vscatter:shared,select=2:ncpus=66:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past90days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=72:mem=100GB
+#PBS -l place=vscatter,select=2:ncpus=66:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
@@ -5,7 +5,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=05:30:00
-#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=250GB
+#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=500GB
 #PBS -l debug=true
 #PBS -V
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots.sh
@@ -5,7 +5,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=05:30:00
-#PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=250GB
+#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=250GB
 #PBS -l debug=true
 #PBS -V
 
@@ -24,7 +24,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export SITE=$(cat /etc/cluster_name)
 export USE_CFP=YES
 export nproc=512
-export ncpu=128
+export ncpu=64
 
 # General Verification Settings
 export NET="evs"

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=84:mem=85GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=88:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=2:ncpus=77:mpiprocs=77:mem=80GB
+#PBS -l place=vscatter,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=2:ncpus=108:mem=500GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=84:mem=100GB
+#PBS -l place=vscatter,select=2:ncpus=88:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=88:mem=500GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=88:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=77:mpiprocs=77:mem=125GB
+#PBS -l place=vscatter,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=108:mem=500GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.sh
@@ -24,7 +24,7 @@ export job=${PBS_JOBNAME:-jevs_mesoscale_grid2obs_plots}
 export jobid=$job.${PBS_JOBID:-$$}
 export SITE=$(cat /etc/cluster_name)
 export USE_CFP=YES
-export nproc=128
+export nproc=64
 export evs_run_mode="production"
 
 # General Verification Settings

--- a/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past31days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=1:ncpus=72:mem=100GB
+#PBS -l place=vscatter:shared,select=2:ncpus=66:mem=500GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past90days_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_past90days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter:shared,select=1:ncpus=72:mem=100GB
+#PBS -l place=vscatter:shared,select=2:ncpus=66:mem=500GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ecf/scripts/plots/cam/jevs_cam_precip_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_precip_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=05:40:00
-#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=250GB
+#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=500GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ecf/scripts/plots/cam/jevs_cam_precip_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_precip_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=05:40:00
-#PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=250GB
+#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=250GB
 #PBS -l debug=true
 
 export model=evs 
@@ -52,7 +52,7 @@ else
 fi
 export USE_CFP=YES
 export nproc=512
-export ncpu=128
+export ncpu=64
 export NET="evs"
 export RUN="atmos"
 export VERIF_CASE="precip"

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=84:mem=85GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=88:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=2:ncpus=77:mpiprocs=77:mem=80GB
+#PBS -l place=vscatter:shared,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past31days_separate_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=2:ncpus=108:mem=500GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=84:mem=100GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=88:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:shared,select=2:ncpus=77:mpiprocs=77:mem=125GB
+#PBS -l place=vscatter:shared,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:shared,select=2:ncpus=108:mem=500GB
+#PBS -l place=vscatter:exclhost,select=2:ncpus=108:mem=500GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_grid2obs_plots.ecf
@@ -50,7 +50,7 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=128
+export nproc=64
 export evs_run_mode="production"
 export USE_CFP=YES
 export NET=evs

--- a/scripts/plots/cam/exevs_cam_precip_plots.sh
+++ b/scripts/plots/cam/exevs_cam_precip_plots.sh
@@ -52,7 +52,7 @@ if [ $USE_CFP = YES ]; then
         export MP_PGMMODEL=mpmd
         export MP_CMDFILE=${poe_script}
         if [ $machine = WCOSS2 ]; then
-            launcher="mpiexec -np $nproc -ppn $ncpu --cpu-bind verbose,depth cfp"
+            launcher="mpiexec -np $nproc -ppn $ncpu -depth 2 --cpu-bind verbose,depth cfp"
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/cam/exevs_href_grid2obs_ecnt_plots.sh
+++ b/scripts/plots/cam/exevs_href_grid2obs_ecnt_plots.sh
@@ -176,7 +176,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 72 -ppn 72 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 66 -ppn 33 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
 fi

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_plots.sh
@@ -217,7 +217,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 84 -ppn 84 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 88 -ppn 44 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_separate_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_separate_plots.sh
@@ -261,7 +261,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 154 -ppn 77 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 108 -ppn 54 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -61,7 +61,7 @@ if [ $USE_CFP = YES ]; then
         if [ $machine = WCOSS2 ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
-	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+	    launcher="mpiexec -np ${nnp} -ppn ${nproc} -depth 2 --cpu-bind verbose,depth cfp"
             # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
 	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This brings in the changes from the WCOSS2 changes into a release branch for the emergency, accelerated change for EVS v1.0.13. See the changes in https://docs.google.com/document/d/1Kwd6WoDRYOE2n5ZbkoPkoFofRuAbWM572hdDdXli-qo/edit?tab=t.0.


## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> We aren't running this release branch but it be good to have a release branch consistent with operations.
* Do you have any planned upcoming annual leave/PTO?
> Leave 11/27, 11/29; Federal Holiday 11/28 
* Are there any changes needed for when the jobs are supposed to run?
> No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

NCO tested these changes. There will be another PR that brings the changes into develop that we can test. I can provide testing instructions if we wish to test this release branch.
