### PR TITLE
ops_wcoss2_update_part2

### DIFF
--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past31days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past31days_plots.sh
@@ -4,12 +4,12 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=5:ncpus=64:mpiprocs=64:mem=100GB
+#PBS -l place=vscatter:exclhost,select=6:ncpus=128:mpiprocs=55:mem=175GB
 #PBS -l debug=true
 
 set -x
 
-export OMP_NUM_THREADS=1
+export OMP_NUM_THREADS=2
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past90days_plots.sh
@@ -4,12 +4,12 @@
 #PBS -q dev
 #PBS -A EVS-DEV
 #PBS -l walltime=00:45:00
-#PBS -l place=vscatter,select=5:ncpus=64:mpiprocs=64:mem=175GB
+#PBS -l place=vscatter:exclhost,select=6:ncpus=128:mpiprocs=55:mem=175GB
 #PBS -l debug=true
 
 set -x
 
-export OMP_NUM_THREADS=1
+export OMP_NUM_THREADS=2
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past31days_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past31days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=5:ncpus=64:mpiprocs=64:mem=100GB
+#PBS -l place=vscatter:exclhost,select=6:ncpus=128:mpiprocs=55:mem=175GB
 #PBS -l debug=true
 
 export model=evs
@@ -44,7 +44,7 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export OMP_NUM_THREADS=1
+export OMP_NUM_THREADS=2
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=profile3

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past90days_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past90days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:shared,select=5:ncpus=64:mpiprocs=64:mem=175GB
+#PBS -l place=vscatter:exclhost,select=6:ncpus=128:mpiprocs=55:mem=175GB
 #PBS -l debug=true
 
 export model=evs
@@ -44,7 +44,7 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export OMP_NUM_THREADS=1
+export OMP_NUM_THREADS=2
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=profile3

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
@@ -179,7 +179,7 @@ chmod +x run_all_poe.sh
 # Run the POE script in parallel or in sequence order to generate png files
 #**************************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 320 -ppn 64 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+   mpiexec -np 330 -ppn 55 --cpu-bind verbose,depth --depth 2 cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-#export evs_ver=v1.0.13
+#export evs_ver=v1.0.14
 
 export bacio_ver=2.4.1
 export bufr_ver=12.0.0


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

NCO implemented another version of EVS for more changes following the WCOSS2 upgrade.

Email from Wei

> We have implemented v1.0.14 to ops with the following changes to evs_global_ens_atmos_gefs_profile3_past[90|31]days_plot to stabilize the runtime.
> 
> Updated ecf/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile3_past[90][31]days_plots.ecf
> 
> Changed place=vscatter:shared,select=5:ncpus=64:mpiprocs=64:mem=175GB to place=vscatter:exclhost,select=6:ncpus=128:mpiprocs=55:mem=175GB
> Changed export OMP_NUM_THREADS=1 to export OMP_NUM_THREADS=2
> Updated scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
> 
> Changed mpiexec -np 320 -ppn 64 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh to mpiexec -np 330 -ppn 55 --cpu-bind verbose,depth —-depth2 cfp ${DATA}/run_all_poe.sh
> 

This is bringing those changes into the repo in a release/evs.v1.0.14 branch

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> No
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed for when the jobs are supposed to run?
> No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

No testing is needed. NCO tested and has this running in operations, and the same changes were tested and put into develop in #606.
