### PR TITLE
bugfix/ops_cam_href_spcoutlook

### DIFF
--- a/ush/cam/evs_href_gather.sh
+++ b/ush/cam/evs_href_gather.sh
@@ -71,8 +71,8 @@ for MODL in $MODELS ; do
     elif [ $verify = precip ] ; then
       echo  "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${PRECIP_CONF}/StatAnlysis_fcstHREF_obsAnalysis_GatherByDay.conf " >> run_gather_${verify}_${MODL}.sh
    fi
-
-    echo "[[ $SENDCOM = YES  && -s ${WORK}/gather/${vday}/${MODL}_${verify}_${vday}.stat ]] && cp -v ${WORK}/gather/${vday}/${MODL}_${verify}_${vday}.stat  $COMOUTfinal/evs.stats.${modl}.${verify}.v${vday}.stat" >> run_gather_${verify}_${MODL}.sh
+    echo "if [[ $SENDCOM = YES  && -s ${WORK}/gather/${vday}/${MODL}_${verify}_${vday}.stat ]]; then cp -v ${WORK}/gather/${vday}/${MODL}_${verify}_${vday}.stat  $COMOUTfinal/evs.stats.${modl}.${verify}.v${vday}.stat" >> run_gather_${verify}_${MODL}.sh
+    echo "else  echo ${WORK}/gather/${vday}/${MODL}_${verify}_${vday}.stat empty; fi" >> run_gather_${verify}_${MODL}.sh
 
     chmod +x run_gather_${verify}_${MODL}.sh
  


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

jevs_cam_href_spcoutlook failed in operations over the weekend. A small verifying area didn't catch any match pairs resulting in StatAnalysis creating a 0 byte sized file. This caused the code to fail. This fixes it to operational code delivery.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> Yes, merge by 12/23 to send CDF.

* Do you have any planned upcoming annual leave/PTO?
> 12/24-12/27

* Are there any changes needed for when the jobs are supposed to run?
> No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### Set-up

1. Clone my fork and checkout branch bugfix/ops_cam_href_spcoutlook
2. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
3. Uncomment `evs_ver` in versions/run.ver

### ✅  cam stats
4. `cd dev/drivers/scripts/stats/cam`
5. Run jevs_cam_href_spcoutlook.sh

> * Set HOMEevs to the location of the clone.
> * Set COMIN to /lfs/h1/ops/prod/com/$NET/$evs_ver_2d
> * Add `export VDATE=20241221`
> * Add `export EVSINspcotlk=/lfs/h1/ops/prod/com/evs/v1.0/prep/cam`
