### PR TITLE
bugfix/ops_jevs_mesoscale_sref_cape_past90days_plots

### DIFF
--- a/ush/mesoscale/ush_sref_plot_py/lead_average.py
+++ b/ush/mesoscale/ush_sref_plot_py/lead_average.py
@@ -656,6 +656,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         connect_points = True
     else:
         connect_points = False
+    n_mods = 0
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -700,9 +701,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
+                n_mods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-#export evs_ver=v1.0.15
+#export evs_ver=v1.0.16
 
 export bacio_ver=2.4.1
 export bufr_ver=12.0.0


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This fixes the 20241228 production failure of jevs_mesoscale_sref_cape_past90days_plots.

Notes on the failure from Wei Wei.

> In the log:
> Traceback (most recent call last):
>   File "/lfs/h1/ops/prod/packages/evs.v1.0.15/ush/mesoscale/ush_sref_plot_py/lead_average.py", line 1622, in <module>
>     main()
>   File "/lfs/h1/ops/prod/packages/evs.v1.0.15/ush/mesoscale/ush_sref_plot_py/lead_average.py", line 1475, in main
>     plot_lead_average(
>   File "/lfs/h1/ops/prod/packages/evs.v1.0.15/ush/mesoscale/ush_sref_plot_py/lead_average.py", line 707, in plot_lead_average
>     if math.isinf(y_mod_min):
> UnboundLocalError: local variable 'y_mod_min' referenced before assignment
> 
> It seems in ush/mesoscale/ush_sref_plot_py/lead_average.py,  y_mod_min and  y_mod_max are not defined before the else statement on line 706.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> Yes, merged by 12/30
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed for when the jobs are supposed to run?
> No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### Set-up
1. Clone my fork and checkout branch bugfix/ops_jevs_mesoscale_sref_cape_past90days_plots
2. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
3. Uncomment `evs_ver` in versions/run.ver

### :heavy_check_mark:  mesoscale plots
4. `cd dev/drivers/scripts/plots/mesoscale`
5. Run jevs_mesoscale_sref_cape_past90days_plots.sh

> * Set HOMEevs to the location of the clone.
> * Set COMIN to /lfs/h1/ops/prod/com/$NET/$evs_ver_2d
> * Add `export VDATE=20241226`