### PR TITLE
bugfix for intel_ver in aqm /dev/driver scripts 

### DIFF
--- a/dev/modulefiles/aqm/aqm_prep.sh
+++ b/dev/modulefiles/aqm/aqm_prep.sh
@@ -6,7 +6,7 @@ module use /apps/ops/para/libs/modulefiles/compiler/intel/${intel_ver}
 export HPC_OPT=/apps/ops/para/libs
 module use /apps/dev/modulefiles
 module load PrgEnv-intel/${PrgEnvintel_ver}
-module load intel/${intel}
+module load intel/${intel_ver}
 module load ve/evs/${ve_evs_ver}
 module load cray-mpich/${craympich_ver}
 module load cray-pals/${craypals_ver}

--- a/dev/modulefiles/aqm/aqm_stats.sh
+++ b/dev/modulefiles/aqm/aqm_stats.sh
@@ -6,7 +6,7 @@ module use /apps/ops/para/libs/modulefiles/compiler/intel/${intel_ver}
 export HPC_OPT=/apps/ops/para/libs
 module use /apps/dev/modulefiles
 module load PrgEnv-intel/${PrgEnvintel_ver}
-module load intel/${intel}
+module load intel/${intel_ver}
 module load ve/evs/${ve_evs_ver}
 module load cray-mpich/${craympich_ver}
 module load cray-pals/${craypals_ver}

--- a/ecf/scripts/prep/aqm/jevs_aqm_prep.ecf
+++ b/ecf/scripts/prep/aqm/jevs_aqm_prep.ecf
@@ -19,7 +19,7 @@ export COMPONENT=aqm
 export STEP=prep
 
 module load PrgEnv-intel/${PrgEnvintel_ver}
-module load intel/${intel}
+module load intel/${intel_ver}
 module load ve/evs/${ve_evs_ver}
 module load cray-mpich/${craympich_ver}
 module load cray-pals/${craypals_ver}

--- a/ecf/scripts/stats/aqm/jevs_aqm_stats_vhr_master.ecf
+++ b/ecf/scripts/stats/aqm/jevs_aqm_stats_vhr_master.ecf
@@ -19,7 +19,7 @@ export COMPONENT=aqm
 export STEP=stats
 
 module load PrgEnv-intel/${PrgEnvintel_ver}
-module load intel/${intel}
+module load intel/${intel_ver}
 module load ve/evs/${ve_evs_ver}
 module load cray-mpich/${craympich_ver}
 module load cray-pals/${craypals_ver}


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
Replace "module load intel/${intel}" with "module load intel/${intel_ver}" for 
aqm_prep.sh  aqm_stats.sh
in ~/dev/modulefiles/aqm because environmental variable "intel" is not defined.

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
April 2025

* Are there any changes needed for when the jobs are supposed to run?
  NO

- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the approriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Run regular NRT ~/dev/drivers/scripts/prep/aqm/jevs_aqm_prep.sh and
/dev/drivers/scripts/stats/aqm/jevs_aqm_grid2obs_stats.sh for any vhr (one hour for checking is enough)

Check the log file loading the correct intel module version.