### PR TITLE
Bugzilla 1606: Fixed the plots codes to prevent potential failure.

### DIFF
--- a/ush/nfcens/lead_average.py
+++ b/ush/nfcens/lead_average.py
@@ -539,6 +539,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
     else:
         handles = []
         labels = []
+    n_mods = 0     
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -581,9 +582,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
+                n_mods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min

--- a/ush/nfcens/time_series.py
+++ b/ush/nfcens/time_series.py
@@ -578,6 +578,7 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
         labels = [model_list[0].upper()]
     handles = []
     labels = []
+    n_mods = 0
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -615,10 +616,11 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
             else:
                 y_vals_metric_min = np.nanmin(y_vals_metric1)
                 y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
                 counts = pivot_counts[str(model_list[m])].values
+                n_mods+=1
             else:
                 y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
                 y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR addresses the Bugzilla 1606 - counting of models in python scripts for EVS-NFCENS [#631](https://github.com/NOAA-EMC/EVS/issues/631)

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.

* Do you have any planned upcoming annual leave/PTO?
No.

* Are there any changes needed for when the jobs are supposed to run?
If you test this before the time that the job runs daily, please use PDYm2. 

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
1- Clone my fork and checkout branch bugfix/EVS-NFCENS_1606.
2- ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
3- Point $COMIN to /lfs/h1/ops/prod/com/$NET/$evs_ver_2d.
4- Run the "plots" driver script located at: EVS/dev/drivers/scripts/plots/nfcens/*.