### PR TITLE
feature/rm_cpreq

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,9 @@
 > Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
 
 ## Developer Questions and Checklist
-* Is this a high priorty PR? If so, why and is there a date it needs to be merged by?
+* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
 * Do you have any planned upcoming annual leave/PTO?
-* Are there any changes needed for when the jobs are supposed to run?
+* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
   
 - [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
 - [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
@@ -15,7 +15,7 @@
 - [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
 - [ ] Jobs over 15 minutes in runtime have restart capability.
 - [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
-- [ ] Jobs contain the approriate file checking and don't run METplus for any missing data.
+- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
 - [ ] Code is using METplus wrappers structure and not calling MET executables directly.
 - [ ] Log is free of any ERRORs or WARNINGs.
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_radar_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_radar_plots.sh
@@ -55,7 +55,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_severe_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_severe_plots.sh
@@ -55,7 +55,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter:select=1:ncpus=16:ompthreads=1:mem=35GB
+#PBS -l place=vscatter:exclhost:select=1:ncpus=16:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=05:00:00
+#PBS -l walltime=09:45:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=6:00:00
+#PBS -l walltime=11:30:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarw_severe_prep.sh
@@ -54,7 +54,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswarwmem2_severe_prep.sh
@@ -54,7 +54,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hireswfv3_severe_prep.sh
@@ -54,7 +54,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_href_severe_prep.sh
@@ -40,7 +40,7 @@ export vhr=${vhr:-${vhr}}
 ############################################################
 export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
-export KEEPDATA=NO
+export KEEPDATA=YES
 export VERIF_CASE=severe
 export MODELNAME=href
 export modsys=href
@@ -53,7 +53,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_hrrr_severe_prep.sh
@@ -54,7 +54,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_namnest_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_namnest_severe_prep.sh
@@ -54,7 +54,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_radar_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_radar_prep.sh
@@ -54,7 +54,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/prep/cam/jevs_cam_severe_prep.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_cam_severe_prep.sh
@@ -53,7 +53,7 @@ export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
-export KEEPDATA=${KEEPDATA:-NO}
+export KEEPDATA=${KEEPDATA:-YES}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter:select=1:ncpus=16:ompthreads=1:mem=35GB
+#PBS -l place=vscatter:exclhost:select=1:ncpus=16:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_precip_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=05:00:00
+#PBS -l walltime=09:45:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_snowfall_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=06:00:00
+#PBS -l walltime=11:30:00
 #PBS -l place=vscatter:exclhost,select=12:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/parm/metplus_config/prep/global_ens/wave_grid2obs/PB2NC_wave.conf
+++ b/parm/metplus_config/prep/global_ens/wave_grid2obs/PB2NC_wave.conf
@@ -65,7 +65,7 @@ PB2NC_CONFIG_FILE = {ENV[METPLUS_PATH]}/parm/met_config/PB2NCConfig_wrapped
 # filename template already exists
 PB2NC_SKIP_IF_OUTPUT_EXISTS = False
 
-PB2NC_SKIP_TIMES = 
+PB2NC_SKIP_VALID_TIMES =
 SKIP_TIMES = 
 PB2NC_MANDATORY = True
 INPUT_MUST_EXIST = True

--- a/scripts/plots/aqm/exevs_aqm_grid2obs_plots.sh
+++ b/scripts/plots/aqm/exevs_aqm_grid2obs_plots.sh
@@ -61,7 +61,7 @@ for aqmtyp in ozone pm25 ozmax8 pmave; do
             cpfile=evs.stats.${COMPONENT}_${biasc}.${RUN}.${VERIF_CASE}_${aqmtyp}.v${DAY}.stat
             sedfile=evs.stats.${aqmtyp}_${biasc}.${RUN}.${VERIF_CASE}.v${DAY}.stat
             if [ -s ${EVSINaqm}.${DAY}/${cpfile} ]; then
-                cpreq ${EVSINaqm}.${DAY}/${cpfile} ${STATDIR}
+                cp -v ${EVSINaqm}.${DAY}/${cpfile} ${STATDIR}
                 sed "s/${model1}/${aqmtyp}_${biasc}/g" ${STATDIR}/${cpfile} > ${STATDIR}/${sedfile}
             else
                 echo "WARNING ${COMPONENT} ${STEP} :: Can not find ${EVSINaqm}.${DAY}/${cpfile}"
@@ -139,7 +139,7 @@ for region in CONUS CONUS_East CONUS_West CONUS_South CONUS_Central Appalachia C
                     export err=$?; err_chk
                 else
                     echo "RESTART - ${var} ${figtype} ${region} plot exists; copying over to plot directory"
-                    cpreq ${cpfile} ${PLOTDIR}
+                    cp -v ${cpfile} ${PLOTDIR}
                 fi
   
                 cpfile=${PLOTDIR}/${figfile}
@@ -198,7 +198,7 @@ for region in CONUS CONUS_East CONUS_West CONUS_South CONUS_Central Appalachia C
                     export err=$?; err_chk
                 else
                     echo "RESTART - plot exists; copying over to plot directory"
-                    cpreq ${cpfile} ${PLOTDIR}
+                    cp -v ${cpfile} ${PLOTDIR}
                 fi
 
                 cpfile=${PLOTDIR}/${figfile}
@@ -302,7 +302,7 @@ for region in CONUS CONUS_East CONUS_West CONUS_South CONUS_Central; do
                 export err=$?; err_chk
             else
                 echo "RESTART - plot exists; copying over to plot directory"
-                cpreq ${cpfile} ${PLOTDIR_headline}
+                cp -v ${cpfile} ${PLOTDIR_headline}
             fi
   
             cpfile=${PLOTDIR_headline}/${figfile}

--- a/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
@@ -49,7 +49,7 @@ theDate=${plot_start_date}
 while (( ${theDate} <= ${plot_end_date} )); do
   EVSINstats=${COMIN}/stats/${COMPONENT}/${MODELNAME}.${theDate}
   if [[ -s ${EVSINstats}/evs.stats.${MODELNAME}.${RUN}.${VERIF_CASE}.v${theDate}.stat ]]; then
-      cpreq -v ${EVSINstats}/evs.stats.${MODELNAME}.${RUN}.${VERIF_CASE}.v${theDate}.stat ${DATA}/stats/.
+      cp -v ${EVSINstats}/evs.stats.${MODELNAME}.${RUN}.${VERIF_CASE}.v${theDate}.stat ${DATA}/stats/.
   else
       echo "WARNING: DOES NOT EXIST ${EVSINstats}/evs.stats.${MODELNAME}.${RUN}.${VERIF_CASE}.v${theDate}.stat"
   fi

--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -95,7 +95,7 @@ done
   find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
-    cpreq -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
+    cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
 fi
 
 if [ $SENDDBN = YES ]; then

--- a/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
@@ -93,7 +93,7 @@ done
    find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
 
 if [ $SENDCOM = YES ]; then
-    cpreq -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
+    cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
 fi
 
 if [ $SENDDBN = YES ]; then

--- a/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
@@ -94,7 +94,7 @@ done
   find ${DATA}/${VERIF_CASE}/out/* -type f \( -name "*.png" -o -name "*.gif" \) -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
 
 if [ $SENDCOM = YES ]; then
-    cpreq -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
+    cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
 fi
 
 if [ $SENDDBN = YES ]; then

--- a/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
@@ -95,7 +95,7 @@ done
   find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
 
 if [ $SENDCOM = YES ]; then
-    cpreq ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
+    cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.
 fi
 
 if [ $SENDDBN = YES ]; then

--- a/scripts/prep/cam/exevs_href_severe_prep.sh
+++ b/scripts/prep/cam/exevs_href_severe_prep.sh
@@ -177,7 +177,7 @@ i=1
       # Copy the member files to working directory if they exist
       if [ -s $fcst_file ]; then
          echo "File found for member $i. Copying to working directory."
-         cpreq -v $fcst_file ${MODEL_INPUT_DIR}
+         cp -v $fcst_file ${MODEL_INPUT_DIR}
          nfiles=$((nfiles+1))
       else
          echo "Forecast file $fcst_file not found for member $i." >> missing_file_list
@@ -210,7 +210,7 @@ i=1
       if [ $SENDCOM = YES ]; then
          mkdir -p $COMOUT/${modsys}.${IDATE}
          for FILE in $DATA/sspf/${modsys}.${IDATE}/*; do
-            cpreq -v $FILE $COMOUT/${modsys}.${IDATE}
+            cp -v $FILE $COMOUT/${modsys}.${IDATE}
          done
       fi
 

--- a/scripts/prep/global_ens/exevs_global_ens_wave_grid2obs_prep.sh
+++ b/scripts/prep/global_ens/exevs_global_ens_wave_grid2obs_prep.sh
@@ -62,7 +62,7 @@ for ihour in ${inithours} ; do
 	fi
     else
         if [ ! -s ${COMOUTgefs}/${newname} ]; then
-            cpreq -v ${COMINgefs}/${MODELNAME}.${INITDATE}/${ihour}/wave/gridded/${filename} $DATA/gefs_wave_grib2/${newname}
+            cp -v ${COMINgefs}/${MODELNAME}.${INITDATE}/${ihour}/wave/gridded/${filename} $DATA/gefs_wave_grib2/${newname}
             if [ $SENDCOM = YES ]; then
                 if [ -s $DATA/gefs_wave_grib2/${newname} ]; then 
                     cp -v $DATA/gefs_wave_grib2/${newname} ${COMOUTgefs}/${newname}
@@ -91,7 +91,7 @@ for ihour in 00 06 12 18 ; do
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
   else
-      cpreq -v ${COMINobsproc}.${INITDATE}/${ihour}/atmos/gdas.${inithour}.prepbufr ${DATA}/gdas.${INITDATE}${ihour}.prepbufr
+      cp -v ${COMINobsproc}.${INITDATE}/${ihour}/atmos/gdas.${inithour}.prepbufr ${DATA}/gdas.${INITDATE}${ihour}.prepbufr
       chmod 640 ${DATA}/gdas.${INITDATE}${ihour}.prepbufr
       chgrp rstprod ${DATA}/gdas.${INITDATE}${ihour}.prepbufr
   fi

--- a/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
+++ b/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
@@ -180,7 +180,7 @@ for outtyp in awpozcon pm25; do
       mkdir -p ${COMOUTfinal}
       stat_file_count=$(find ${COMOUTsmall} -name "*${outtyp}${bcout}*" | wc -l)
       if [ ${stat_file_count} -ne 0 ]; then
-        cpreq ${COMOUTsmall}/*${outtyp}${bcout}* ${finalstat}
+        cp -v ${COMOUTsmall}/*${outtyp}${bcout}* ${finalstat}
         cd ${finalstat}
         run_metplus.py ${conf_file_dir}/${stat_analysis_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
@@ -290,7 +290,7 @@ if [ ${vhr} = 11 ]; then
     fi
     stat_file_count=$(find ${COMOUTsmall} -name "*${outtyp}${bcout}*" | wc -l)
     if [ ${stat_file_count} -ne 0 ]; then
-      cpreq ${COMOUTsmall}/*${outtyp}${bcout}* ${finalstat}
+      cp -v ${COMOUTsmall}/*${outtyp}${bcout}* ${finalstat}
       run_metplus.py ${conf_file_dir}/${stat_analysis_conf_file} ${PARMevs}/metplus_config/machine.conf
       export err=$?; err_chk
       if [ ${SENDCOM} = "YES" ]; then
@@ -383,7 +383,7 @@ if [ ${vhr} = 04 ]; then
     fi
     stat_file_count=$(find ${COMOUTsmall} -name "*${outtyp}${bcout}*" | wc -l)
     if [ ${stat_file_count} -ne 0 ]; then
-      cpreq ${COMOUTsmall}/*${outtyp}${bcout}* ${finalstat}
+      cp -v ${COMOUTsmall}/*${outtyp}${bcout}* ${finalstat}
       run_metplus.py ${conf_file_dir}/${stat_analysis_conf_file} ${PARMevs}/metplus_config/machine.conf
       export err=$?; err_chk
       if [ ${SENDCOM} = "YES" ]; then

--- a/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
+++ b/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
@@ -169,7 +169,7 @@ for ObsType in ${grid2obs_list}; do
     if [ "${vhr}" == "21" ]; then
       stat_file_count=$(find ${COMOUTsmall} -name "*${OutputId}*" | wc -l)
       if [ ${stat_file_count} -ne 0 ]; then
-        cpreq ${COMOUTsmall}/*${OutputId}* ${finalstat}
+        cp -v ${COMOUTsmall}/*${OutputId}* ${finalstat}
         cd ${finalstat}
         run_metplus.py ${stat_analysis_conf_file} ${config_common}
         export err=$?; err_chk

--- a/scripts/stats/global_ens/exevs_global_ens_wave_grid2obs_stats.sh
+++ b/scripts/stats/global_ens/exevs_global_ens_wave_grid2obs_stats.sh
@@ -91,11 +91,11 @@ for vhour in ${validhours} ; do
         DATAstatfilename=$DATA/all_stats/point_stat_fcst${MODNAM}_obsGDAS_climoERA5_${flead2}0000L_${VDATE}_${vhour2}0000V.stat
         COMOUTstatfilename=$COMOUTsmall/point_stat_fcst${MODNAM}_obsGDAS_climoERA5_${flead2}0000L_${VDATE}_${vhour2}0000V.stat
         if [[ -s $COMOUTstatfilename ]]; then
-            cpreq -v $COMOUTstatfilename $DATAstatfilename
+            cp -v $COMOUTstatfilename $DATAstatfilename
         else
             if [[ ! -s $DATAgdasncfilename ]]; then
                 if [[ -s $EVSgdasncfilename ]]; then
-                    cpreq -v $EVSgdasncfilename $DATAgdasncfilename
+                    cp -v $EVSgdasncfilename $DATAgdasncfilename
                 else
                     echo "WARNING: DOES NOT EXIST $EVSgdasncfilename"
                 fi
@@ -103,7 +103,7 @@ for vhour in ${validhours} ; do
             if [[ -s $DATAgdasncfilename ]]; then
                 if [[ ! -s $DATAmodelfilename ]]; then
                     if [[ -s $EVSmodelfilename ]]; then
-                        cpreq -v $EVSmodelfilename $DATAmodelfilename
+                        cp -v $EVSmodelfilename $DATAmodelfilename
                     else
                         echo "WARNING: DOES NOT EXIST $EVSmodelfilename"
                     fi

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -45,7 +45,7 @@ if [ $modnam = gfsanl ]; then
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      cpreq -v $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl $WORK/gfsanl.t${ihour}z.grid3.f000.grib2
+      cp -v $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl $WORK/gfsanl.t${ihour}z.grid3.f000.grib2
     fi
     if [ ! -s $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000 ]; then
       echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000 is not available"
@@ -467,7 +467,7 @@ if [ $modnam = ccpa ] ; then
             source_ccpa_file=${COMIN}/$STEP/${COMPONENT}/atmos.${vday_1}/gefs/ccpa.t18z.grid3.06h.f00.grib2
         fi
         if [ -s $source_ccpa_file ]; then
-            cpreq -v $source_ccpa_file ${WORK}/ccpa24/ccpa${nccpa_file}
+            cp -v $source_ccpa_file ${WORK}/ccpa24/ccpa${nccpa_file}
         else
             echo "WARNING: $source_ccpa_file is not available"
             if [ $SENDMAIL = YES ]; then
@@ -702,7 +702,7 @@ if [ $modnam = nohrsc24h ] ; then
   for ihour in 00 12 ; do
     snowfall=$DCOMINnohrsc/${vday}/wgrbbul/nohrsc_snowfall/sfav2_CONUS_24h_${vday}${ihour}_grid184.grb2
     if [ -s $snowfall ] ; then
-      cpreq -v $snowfall $WORK/nohrsc.t${ihour}z.grid184.grb2
+      cp -v $snowfall $WORK/nohrsc.t${ihour}z.grid184.grb2
       if [ $SENDCOM="YES" ] ; then
           if [ -s $WORK/nohrsc.t${ihour}z.grid184.grb2 ]; then
               cp -v $WORK/nohrsc.t${ihour}z.grid184.grb2 $COMOUTgefs/nohrsc.t${ihour}z.grid184.grb2

--- a/ush/global_ens/evs_get_gens_headline_data.sh
+++ b/ush/global_ens/evs_get_gens_headline_data.sh
@@ -74,7 +74,7 @@ done
 
 for hhh in 024 048 072 096  120 144 168 192 216 240 264 288 312 336 360 384 ; do
    if [ -s $EVSINgefs/gfs.t00z.grid3.f${hhh}.grib2 ]; then
-     cpreq -v $EVSINgefs/gfs.t00z.grid3.f${hhh}.grib2 $WORK/gfs.t00z.grid3.f${hhh}.grib2
+     cp -v $EVSINgefs/gfs.t00z.grid3.f${hhh}.grib2 $WORK/gfs.t00z.grid3.f${hhh}.grib2
      if [ $SENDCOM="YES" ] ; then
          if [ -s $WORK/gfs.t00z.grid3.f${hhh}.grib2 ]; then
              cp -v $WORK/gfs.t00z.grid3.f${hhh}.grib2 $COMOUTgefs/gfs.t00z.grid3.f${hhh}.grib2


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This removes the usage of `cpreq` in EVS (an item under coder manger fixes and additions). It also sets KEEPDATA to YES for cam prep jobs, uses PB2NC_SKIP_VALID_TIMES for global_ens wave prep, and adds exclhost for jevs_mesoscale_headline_plots.

It also fixes typos in the PR template.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
* Do you have any planned upcoming annual leave/PTO?
* Are there any changes needed for when the jobs are supposed to run?
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

###  **Set-up**
1. Clone my fork and checkout branch feature/rm_cpreq
2. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`
3. `cd sorc`; `./build`

For everything below, be sure to set `HOMEevs` to the location of the clone and `COMIN` to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2.

### ✔️ cam prep
4. `cd dev/drivers/scripts/prep/cam`
5. Run: `jevs_cam_href_severe_prep.sh`
> * Submit with `qsub -v vhr=00` and  `qsub -v vhr=12`

### ✔️ global_ens prep
6. `cd dev/drivers/scripts/prep/global_ens`
7. Run: `jevs_global_ens_wave_grid2obs_prep.sh`, `jevs_global_ens_atmos_prep.sh`, `jevs_global_ens_headline_prep.sh`

### ✔️ aqm stats
8. `cd dev/drivers/scripts/stats/aqm`
9. Run: `jevs_aqm_grid2obs_stats.sh`
> * Submit with `qsub -v vhr=00`

### ✔️ global_ens stats
10. `cd dev/drivers/scripts/stats/global_ens`
11. Run: `jevs_global_ens_wave_grid2obs_stats.sh`
12. Run: `jevs_global_ens_gefs_chem_grid2obs_aeronet_stats.sh`
> * Submit with `qsub -v vhr=00`

### ✔️ aqm plots
13. `cd dev/drivers/scripts/plots/aqm`
14. Run: `jevs_aqm_grid2obs_plots.sh`

### ✔️ global_ens plots
15. `cd dev/drivers/scripts/plots/global_ens`
16. Run: `jevs_global_ens_wave_grid2obs_plots.sh`

### ✔️ mesoscale plots
17. `cd dev/drivers/scripts/plots/mesoscale`
18. Run: `jevs_mesoscale_grid2obs_plots.sh`, `jevs_mesoscale_headline_plots.sh`, `jevs_mesoscale_precip_plots.sh`, `jevs_mesoscale_snowfall_plots.sh`
> * NOTE: jevs_mesoscale_snowfall_plots and jevs_mesoscale_precip_plots exceeding walltime have been exceeding their walltime in the emc.vpppg parallel; perhaps we can address the walltime increase in this PR if desired and needed.