### PR TITLE
Bugfix/global-det wave (Bug #1586)

### DIFF
--- a/ush/global_det/plot_util.py
+++ b/ush/global_det/plot_util.py
@@ -1279,8 +1279,9 @@ def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level,
             stat_values_rmse = np.sqrt(
                ffbar_est_samp + oobar_est_samp - 2*fobar_est_samp
             )
+            # Replace 0 with NaN to avoid division by zero
+            obar_est_mean[np.abs(obar_est_mean)<1e-9]= np.nan
             stat_values = 100 * stat_values_rmse / obar_est_mean
-            stat_values = stat_values[stat_values<=500]  #get rid of infinite values
    else:
       logger.error(stat+" is not a valid option")
       exit(1)
@@ -1581,8 +1582,9 @@ def calculate_stat(logger, model_data, stat):
          stat_values = (fy_oy + fn_on - C)/(total - C)
    elif stat == 'si':
        if line_type == 'SL1L2':
+           # Replace 0 with NaN to avoid dividing by zero
+           obar[np.abs(obar)<1e-9]=np.nan
            stat_values = 100*(np.sqrt(ffbar + oobar - 2*fobar))/obar
-           stat_values = stat_values[stat_values<=500]  #get rid of infinite values
    else:
       logger.error(stat+" is not a valid option")
       exit(1)


### PR DESCRIPTION
Remove threshold for wave scatter index calculation.

<b>Note to developers: You must use this PR template!</b>

## Description of Changes
> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Set zero denominator to NaN to avoid diving zero and get infinity value in wave scatter index. (Bug #1586)
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
1- Clone my fork and checkout branch wave_SI
2- ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
3- Point $COMIN to emc.vpppg.
4- Run the "plots" driver scripts located at: EVS/dev/drivers/scripts/plots/global_det/jevs_global_det_wave_grid2obs_plots*.sh