### PR TITLE
Bugfix/EVS-NWPS_1606

### DIFF
--- a/scripts/plots/nwps/exevs_nwps_wave_grid2obs_plots.sh
+++ b/scripts/plots/nwps/exevs_nwps_wave_grid2obs_plots.sh
@@ -115,7 +115,7 @@ for wfo in ${WFO}; do
 	cd ${DATA}
 	chmod 775 ${DATA}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
 	if [ ${run_mpi} = 'yes' ] ; then
-		mpiexec -np 36 --cpu-bind verbose,core cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+		mpiexec -np 36 --cpu-bind verbose,depth cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
 	else
 		echo "not running mpiexec"
 		sh plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh

--- a/ush/nwps/lead_average.py
+++ b/ush/nwps/lead_average.py
@@ -543,6 +543,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
     else:
         handles = []
         labels = []
+    n_mods = 0    
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -585,9 +586,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if nmods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
+                nmods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min

--- a/ush/nwps/lead_average.py
+++ b/ush/nwps/lead_average.py
@@ -586,10 +586,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if nmods == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
-                nmods+=1
+                n_mods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min

--- a/ush/nwps/time_series.py
+++ b/ush/nwps/time_series.py
@@ -615,11 +615,11 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
             else:
                 y_vals_metric_min = np.nanmin(y_vals_metric1)
                 y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if nmods == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
                 counts = pivot_counts[str(model_list[m])].values
-                nmods+=1
+                n_mods+=1
             else:
                 y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
                 y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])

--- a/ush/nwps/time_series.py
+++ b/ush/nwps/time_series.py
@@ -577,6 +577,7 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
         handles = []
         #labels = []
         labels = [model_list[0].upper()]
+    n_mods = 0
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -614,10 +615,11 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
             else:
                 y_vals_metric_min = np.nanmin(y_vals_metric1)
                 y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if nmods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
                 counts = pivot_counts[str(model_list[m])].values
+                nmods+=1
             else:
                 y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
                 y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR addresses the Bugzilla 1606 - counting of models in python scripts for EVS-NWPS #638.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
  No.
* Do you have any planned upcoming annual leave/PTO?
  No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No.
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- Clone my fork and checkout branch bugfix/EVS-NWPS_1606.
2- ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
3- Point $COMIN to emc.vpppg in "plots" driver script.
4- Run the "plots" driver script located at: EVS/dev/drivers/scripts/plots/nwps/*.