### PR TITLE
feature/cm_setup_ecf_link_global_ens_chem

### DIFF
--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -135,4 +135,12 @@ link_master_to_cyc "jevs_analyses_rtma_precip_stats_vhr" "$cyc"
 cyc=$(seq 0 23)
 link_master_to_cyc "jevs_analyses_ccpa_precip_stats_vhr" "$cyc"
 
+# GLOBAL-ENS CHEM files
+cd $ECF_DIR/scripts/stats/global_ens
+echo "Linking GLOBAL_ENS - CHEM stats ..."
+cyc=$(seq 0 3 23)
+link_master_to_cyc "jevs_global_ens_gefs_chem_grid2obs_aeronet_stats_vhr" "$cyc"
+cyc=$(seq 0 3 23)
+link_master_to_cyc "jevs_global_ens_gefs_chem_grid2obs_airnow_stats_vhr" "$cyc"
+
 echo "Done."


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
This addresses the item under the Fixes and Additions document for general (code manager) to "Update ecf/setup_ecf_links.sh for global_ens chem ecf scripts"

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> No
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 > No

- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

1. Clone my fork and checkout branch `feature/cm_setup_ecf_link_global_ens_chem`
2. `cd ecf`
3. `./setup_ecf_links.sh`

Successful testing will have linked files in ecf/scripts/stats/global_ens for jevs_global_ens_gefs_chem_grid2obs_airnow_stats_vhr_[00,03,06,09,12,15,18,21].ecf and jevs_global_ens_gefs_chem_grid2obs_aeronet_stats_vhr_[00,03,06,09,12,15,18,21].ecf
