### PR TITLE
2024 global_ens with UKMN

### DIFF
--- a/scripts/plots/hurricane/exevs_hurricane_global_ens_tropcyc_plots.sh
+++ b/scripts/plots/hurricane/exevs_hurricane_global_ens_tropcyc_plots.sh
@@ -68,24 +68,14 @@ stormName=$(sed "s/ //g" <<< $VARIABLE2)
 echo "Name_${stormName}_Name"
 echo "${stormBasin}, ${stormNumber}, ${stormYear}, ${stormName}"
 
-### NOTE TO USERS ###
-# UKM runs from 2024 are still being processed  #
-# The code will break if this model is included #
-# To run with UKM: 
-# comment out lines 85 and 86 #
-# uncomment lines 87 and 88   #
-
 #---Storm Plots 
 export LOGOroot=${FIXevs}/logos
 export PLOTDATA=${STORMroot}
 #export RUN="tropcyc"
 export img_quality="low"
-
 export fhr_list="0,12,24,36,48,60,72,84,96,108,120,132,144,156,168"
-export model_tmp_atcf_name_list="MD01,MD02,MD03"
-export model_plot_name_list="GEFS,EENS,CENS"
-#export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
-#export model_plot_name_list="GEFS,EENS,CENS,UKMN"
+export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
+export model_plot_name_list="GEFS,EENS,CENS,UKMN"
 export plot_CI_bars="NO"
 export under="_"
 export tc_name=${stbasin}${under}${stormYear}${under}${stormName}
@@ -143,24 +133,14 @@ elif [ ${stormBasin} = "wp" ]; then
   cp $metTCcomout/tc_stat/tc_stat_basin.out $metTCcomout/tc_stat/tc_stat.out
 fi
 
-### NOTE TO USERS ###
-# UKM runs from 2024 are still being processed  #
-# The code will break if this model is included #
-# To run with UKM: 
-# comment out lines 161 and 162 #
-# uncomment lines 163 and 164   #
-
 #--- Basin-Storms Plots 
 export LOGOroot=${FIXevs}/logos
 export PLOTDATA=${metTCcomout}
 #export RUN="tropcyc"
 export img_quality="low"
-
 export fhr_list="0,12,24,36,48,60,72,84,96,108,120,132,144,156,168"
-export model_tmp_atcf_name_list="MD01,MD02,MD03"
-export model_plot_name_list="GEFS,EENS,CENS"
-#export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
-#export model_plot_name_list="GEFS,EENS,CENS,UKMN"
+export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
+export model_plot_name_list="GEFS,EENS,CENS,UKMN"
 export plot_CI_bars="NO"
 export stormNameB=Basin
 export tc_name=${stbasin}${under}${stormYear}${under}${stormNameB}

--- a/scripts/stats/hurricane/exevs_hurricane_global_ens_tropcyc_stats.sh
+++ b/scripts/stats/hurricane/exevs_hurricane_global_ens_tropcyc_stats.sh
@@ -74,25 +74,17 @@ stormName=$(sed "s/ //g" <<< $VARIABLE2)
 echo "Name_${stormName}_Name"
 echo "${stormBasin}, ${stormNumber}, ${stormYear}, ${stormName}"
 
-### NOTE TO USERS ###
-# UKM runs from 2024 are still being processed  #
-# The code will break if this model is included #
-# To run with UKM: 
-# uncomment lines 89 and 93 #
-# use Model_List with MD04  #
-
 #---get the model forecast tracks "AEMN/EEMN/CEMN/UKMN" from archive file "tracks.atcfunix.${YY24}"
 grep "${stbasin}, ${stormNumber}" ${COMINtrack} > tracks.atcfunix.${YY24}_${stormBasin}${stormNumber}
 grep "03, AEMN" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} > a${stormBasin}${stormNumber}${stormYear}.dat
 grep "03, EEMN" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 grep "03, CEMN" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
-#grep "03, UKMN" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
+grep "03, UKMN" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, AEMN/03, MD01/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, EEMN/03, MD02/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, CEMN/03, MD03/' a${stormBasin}${stormNumber}${stormYear}.dat
-#sed -i 's/03, UKMN/03, MD04/' a${stormBasin}${stormNumber}${stormYear}.dat
-export Model_List="MD01,MD02,MD03"
-#export Model_List="MD01,MD02,MD03,MD04"
+sed -i 's/03, UKMN/03, MD04/' a${stormBasin}${stormNumber}${stormYear}.dat
+export Model_List="MD01,MD02,MD03,MD04"
 #export Model_Plot="GEFS,EENS,CENS,UKMN"
 
 #---get the $startdate, $enddate[YYMMDDHH] from the best track file  


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

All UKMET data has been processed, including the completion of all UKMN runs for 2024. This PR removes the comments to user(s) and uses model_list variables (model number/MD ## and model names) with **MD04** and **UKMN**. 

**Only two scripts were changed:** exevs_hurricane_global_ens_tropcyc_stats.sh and exevs_hurricane_global_ens_tropcyc_plots.sh ; only changes are lines deleted and uncommenting lines with MD04 and UKMN.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No
* Do you have any planned upcoming annual leave/PTO? Nothing scheduled.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. Copy branch in local EVS workspace
2. Set $USER to **olivia.ostwald** _**OR**_ copy data to your noscrub space:
cd /lfs/h2/emc/vpppg/noscrub/$USER
cp -r /lfs/h2/emc/vpppg/noscrub/olivia.ostwald/evs_tc_2024 .
3. Run for stats: **jevs_hurricane_global_ens_tropcyc_stats.sh**
4. Once stats are complete, run for plots: **jevs_hurricane_global_ens_tropcyc_plots.sh** 
