### PR TITLE
feature/cm jjob

### DIFF
--- a/jobs/JEVS_CAM_PLOTS
+++ b/jobs/JEVS_CAM_PLOTS
@@ -28,6 +28,15 @@ cd $DATA
 # Determine Job Output Name on System
 ####################################
 
+####################################
+# Define NET/RUN variables
+####################################
+export NET=${NET:-evs}
+export STEP=${STEP:-plots}
+export COMPONENT=${COMPONENT:-cam}
+export RUN=${RUN:-atmos}
+export VERIF_CASE=${VERIF_CASE:-grid2obs}
+export MODELNAME=${MODELNAME:-cam}
 
 ####################################
 # Set EVS directories

--- a/jobs/JEVS_CAM_PREP
+++ b/jobs/JEVS_CAM_PREP
@@ -39,6 +39,15 @@ cd $DATA
 # Determine Job Output Name on System
 ####################################
 
+####################################
+# Define NET/RUN variables
+####################################
+export NET=${NET:-evs}
+export STEP=${STEP:-prep}
+export COMPONENT=${COMPONENT:-cam}
+export RUN=${RUN:-atmos}
+export VERIF_CASE=${VERIF_CASE:-precip}
+export MODELNAME=${MODELNAME:-hiresarw}
 
 ####################################
 # Set EVS directories

--- a/jobs/JEVS_CAM_STATS
+++ b/jobs/JEVS_CAM_STATS
@@ -39,6 +39,15 @@ cd $DATA
 # Determine Job Output Name on System
 ####################################
 
+####################################
+# Define NET/RUN variables
+####################################
+export NET=${NET:-evs}
+export STEP=${STEP:-stats}
+export COMPONENT=${COMPONENT:-cam}
+export RUN=${RUN:-atmos}
+export VERIF_CASE=${VERIF_CASE:-grid2obs}
+export MODELNAME=${MODELNAME:-hiresarw}
 
 ####################################
 # Set EVS directories

--- a/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_PLOTS
+++ b/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_PLOTS
@@ -31,17 +31,9 @@ export SENDECF=${SENDECF:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export SENDMAIL=${SENDMAIL:-NO}
-####################################
-# Set EVS directories               
-####################################
-export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
-export EXECevs=${EXECevs:-$HOMEevs/exec}
-export FIXevs=${FIXevs:-$HOMEevs/fix}
-export PARMevs=${PARMevs:-$HOMEevs/parm}
-export USHevs=${USHevs:-$HOMEevs/ush}
 
 ####################################
-# Define NET/RUN variables          
+# Define NET/RUN variables
 ####################################
 export NET=${NET:-evs}
 export MODEL=${MODEL:-evs}
@@ -52,6 +44,15 @@ export MODNAM=$(echo $MODELNAME | tr '[a-z]' '[A-Z]')
 export OBTYPE=${OBTYPE:-GDAS}
 export RUN=${RUN:-wave}
 export VERIF_CASE=${VERIF_CASE:-grid2obs}
+
+####################################
+# Set EVS directories
+####################################
+export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
+export EXECevs=${EXECevs:-$HOMEevs/exec}
+export FIXevs=${FIXevs:-$HOMEevs/fix}
+export PARMevs=${PARMevs:-$HOMEevs/parm}
+export USHevs=${USHevs:-$HOMEevs/ush}
 
 ####################################
 # Define COMIN/COMOUT variables     

--- a/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_PREP
+++ b/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_PREP
@@ -33,15 +33,6 @@ export SENDDBN=${SENDDBN:-YES}
 export SENDMAIL=${SENDMAIL:-NO}
 
 ####################################
-# Set EVS directories               
-####################################
-export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
-export EXECevs=${EXECevs:-$HOMEevs/exec}
-export FIXevs=${FIXevs:-$HOMEevs/fix}
-export PARMevs=${PARMevs:-$HOMEevs/parm}
-export USHevs=${USHevs:-$HOMEevs/ush}
-
-####################################
 # Define NET/RUN variables          
 ####################################
 export NET=${NET:-evs}
@@ -53,6 +44,15 @@ export MODNAM=echo $MODELNAME | tr '[a-z]' '[A-Z]'
 export OBTYPE=${OBTYPE:-GDAS}
 export RUN=${RUN:-wave}
 export VERIF_CASE=${VERIF_CASE:-grid2obs}
+
+####################################
+# Set EVS directories
+####################################
+export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
+export EXECevs=${EXECevs:-$HOMEevs/exec}
+export FIXevs=${FIXevs:-$HOMEevs/fix}
+export PARMevs=${PARMevs:-$HOMEevs/parm}
+export USHevs=${USHevs:-$HOMEevs/ush}
 
 ####################################
 # Define COMIN/COMOUT variables     

--- a/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_STATS
+++ b/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_STATS
@@ -31,17 +31,9 @@ export SENDECF=${SENDECF:-YES}
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export SENDMAIL=${SENDMAIL:-NO}
-####################################
-# Set EVS directories               
-####################################
-export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
-export EXECevs=${EXECevs:-$HOMEevs/exec}
-export FIXevs=${FIXevs:-$HOMEevs/fix}
-export PARMevs=${PARMevs:-$HOMEevs/parm}
-export USHevs=${USHevs:-$HOMEevs/ush}
 
 ####################################
-# Define NET/RUN variables          
+# Define NET/RUN variables
 ####################################
 export NET=${NET:-evs}
 export MODEL=${MODEL:-evs}
@@ -52,6 +44,15 @@ export MODNAM=$(echo $MODELNAME | tr '[a-z]' '[A-Z]')
 export OBTYPE=${OBTYPE:-GDAS}
 export RUN=${RUN:-wave}
 export VERIF_CASE=${VERIF_CASE:-grid2obs}
+
+####################################
+# Set EVS directories
+####################################
+export HOMEevs=${HOMEevs:-${PACKAGEROOT}/${NET}.${evs_ver}}
+export EXECevs=${EXECevs:-$HOMEevs/exec}
+export FIXevs=${FIXevs:-$HOMEevs/fix}
+export PARMevs=${PARMevs:-$HOMEevs/parm}
+export USHevs=${USHevs:-$HOMEevs/ush}
 
 ####################################
 # Define EVSIN/COMOUT variables     

--- a/jobs/JEVS_NARRE_PLOTS
+++ b/jobs/JEVS_NARRE_PLOTS
@@ -7,8 +7,6 @@
 ###############################################################################
 set -x
 
-
-
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export SENDECF=${SENDECF:-YES}
@@ -27,6 +25,16 @@ setpdy.sh
 mkdir -p $DATA/logs
 
 export VDATE=${VDATE:-$PDYm1}
+
+####################################
+# Define NET/RUN variables
+####################################
+export NET=${NET:-evs}
+export STEP=${STEP:-plots}
+export COMPONENT=${COMPONENT:-narre}
+export RUN=${RUN:-atmos}
+export VERIF_CASE=${VERIF_CASE:-grid2obs}
+export MODELNAME=${MODELNAME:-narre}
 
 export COMIN=${COMIN:-$(compath.py  $envir/com/$NET/$evs_ver)}/stats/$COMPONENT/$MODELNAME.$VDATE
 export COMOUT=${COMOUT:-$(compath.py -o $NET/$evs_ver)}/$STEP/$COMPONENT/$RUN.$VDATE
@@ -48,12 +56,9 @@ export ush_dir=$USHevs/narre/ush_narre_plot_py
 export outid="LL$job"
 export jobid="${outid}.o${pid}"
 
-
 ####################################
 # Specify codes and scripts locaton
 ####################################
-
-
 
 $HOMEevs/scripts/${STEP}/${COMPONENT}/exevs_${MODELNAME}_${STEP}.sh 
 export err=$?; err_chk
@@ -64,4 +69,3 @@ if [ "$KEEPDATA" != "YES" ] ; then
 fi
 
 #date
-

--- a/jobs/JEVS_NARRE_STATS
+++ b/jobs/JEVS_NARRE_STATS
@@ -20,7 +20,6 @@ setpdy.sh
 
 export VDATE=${VDATE:-$PDYm1}
 
-
 ##################################################
 # SAVEGES  - Copy Files From TMPDIR to $GESdir
 # SENDECF  - Flag Events on ECF
@@ -32,6 +31,16 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDMAIL=${SENDMAIL:-NO} 
+
+####################################
+# Define NET/RUN variables
+####################################
+export NET=${NET:-evs}
+export STEP=${STEP:-stats}
+export COMPONENT=${COMPONENT:-narre}
+export RUN=${RUN:-atmos}
+export VERIF_CASE=${VERIF_CASE:-grid2obs}
+export MODELNAME=${MODELNAME:-narre}
 
 export COMIN=${COMIN:-$(compath.py  $envir/com/$NET/$evs_ver)}
 export COMINnarre=${COMINnarre:-$(compath.py  $envir/com/narre/$narre_ver)}
@@ -60,7 +69,6 @@ export jobid="${outid}.o${pid}"
 ####################################
 # Specify codes and scripts locaton
 ####################################
-
 
 $HOMEevs/scripts/${STEP}/${COMPONENT}/exevs_${MODELNAME}_${STEP}.sh 
 export err=$?; err_chk


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This addresses the item in the general (code manager) section of the Fixes and Additions document: "Define $NET prior to $HOMEevs; apply this change across all J-jobs".

For JEVS_GLOBAL_ENS_WAVE_GRID2OBS_*, the NET simply needed to be moved prior to HOMEevs.
For JEVS_CAM_PLOTS, JEVS_CAM_PREP, JEVS_CAM_STATS,  JEVS_NARRE_PLOTS, JEVS_NARRE_STATS, they did not have NET defined in at all, so it was added along with other key variables. All dev driver and ecf scripts had these variables defined in them.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> No
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 > No

- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

###  **Set-up**
1. Clone my fork and checkout branch feature/cm_jjob
2. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`
3. `cd sorc`; `./build`

For everything below, be sure to set `HOMEevs` to the location of the clone and `COMIN` to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2.

###  ✔️ cam prep
4. `cd dev/drivers/scripts/prep/cam`
5. Run `jevs_cam_severe_prep.sh`
6. Run `jevs_cam_hrrr_severe_prep.sh`
> * Submit with `qsub -v vhr=00`,  `qsub -v vhr=06, `qsub -v vhr=12`, `qsub -v vhr=18` sometime after 18Z.

###  ✔️   cam stats
7. `cd dev/drivers/scripts/stats/cam`
8. Run `jevs_cam_href_grid2obs_stats.sh`
9. Run `jevs_cam_hrrr_severe_stats.sh`
> * Submit with  `qsub -v vhr=08`

### ✔️  cam plots
10. `cd dev/drivers/scripts/plots/cam`
11. Run `jevs_cam_nam_firewxnest_grid2obs_plots.sh`

### ✔️  global_ens prep - wave
12. `cd dev/drivers/scripts/prep/global_ens`
13. Run `jevs_global_ens_wave_grid2obs_prep.sh`

### ✔️  global_ens stats - wave
14. `cd dev/drivers/scripts/stats/global_ens`
15. Run `jevs_global_ens_wave_grid2obs_stats.sh`

### ✔️  global_ens plots - wave
16. `cd dev/drivers/scripts/plots/global_ens`
17. Run `jevs_global_ens_wave_grid2obs_plots.sh`

### ✔️  narre stats
18. `cd dev/drivers/scripts/stats/narre`
19. Run `jevs_narre_stats.sh`

### ✔️  narre plots
18. `cd dev/drivers/scripts/plots/narre`
19. Run `jevs_narre_last31days_plots.sh`