### PR TITLE
Global-det SST sea ice fix

### DIFF
--- a/parm/metplus_config/stats/global_det/atmos_grid2grid/GridStat_fcstGLOBAL_DET_obsGHRSST_OSPO_DailyAvg.conf
+++ b/parm/metplus_config/stats/global_det/atmos_grid2grid/GridStat_fcstGLOBAL_DET_obsGHRSST_OSPO_DailyAvg.conf
@@ -30,9 +30,10 @@ LEAD_SEQ = {ENV[fhr_list]}
 #### Variables
 FCST_VAR1_NAME = FCST_TMP_Z0_DAILYAVG
 FCST_VAR1_LEVELS = "(*,*)"
-FCST_VAR1_OPTIONS = set_attr_name = "SST_DAILYAVG";
+FCST_VAR1_OPTIONS = set_attr_name = "SST_DAILYAVG"; cnt_thresh = [ >= 271.15 ]; cnt_logic = INTERSECTION;
 OBS_VAR1_NAME = analysed_sst
 OBS_VAR1_LEVELS = "(0,*,*)"
+OBS_VAR1_OPTIONS = cnt_thresh = [ >= 271.15 ]; cnt_logic = INTERSECTION;
 #### GridStat
 GRID_STAT_CONFIG_FILE = {PARM_BASE}/met_config/GridStatConfig_wrapped
 GRID_STAT_ONCE_PER_FIELD = False

--- a/ush/global_det/global_det_atmos_plots_grid2grid_create_job_scripts.py
+++ b/ush/global_det/global_det_atmos_plots_grid2grid_create_job_scripts.py
@@ -464,8 +464,8 @@ for snow_job in list(filter_stats_jobs_dict['snow'].keys()):
 #### sst
 for sst_job in list(filter_stats_jobs_dict['sst'].keys()):
     filter_stats_jobs_dict['sst'][sst_job]['grid'] = 'G004'
-    filter_stats_jobs_dict['sst'][sst_job]['fcst_var_dict']['threshs'] = ['NA']
-    filter_stats_jobs_dict['sst'][sst_job]['obs_var_dict']['threshs'] = ['NA']
+    filter_stats_jobs_dict['sst'][sst_job]['fcst_var_dict']['threshs'] = ['ge271.15&&']
+    filter_stats_jobs_dict['sst'][sst_job]['obs_var_dict']['threshs'] = ['ge271.15']
     filter_stats_jobs_dict['sst'][sst_job]['interps'] = ['NEAREST/1']
 if JOB_GROUP == 'filter_stats':
     JOB_GROUP_dict = filter_stats_jobs_dict

--- a/ush/global_det/global_det_atmos_plots_specs.py
+++ b/ush/global_det/global_det_atmos_plots_specs.py
@@ -683,29 +683,13 @@ class PlotSpecs:
                 and units == '10^6_km^2':
             units = 'x'+units.replace('_', ' ')
         plot_title = plot_title+' '+'('+units+')'
-        if var_thresh_for_title != 'NA':
+        if var_thresh_for_title != 'NA'\
+               and plot_info_dict['fcst_var_name'] not in ['SST_DAILYAVG']:
             plot_title = plot_title+', '+var_thresh_for_title+' '+units
-            thresh_value = float(plot_info_dict['fcst_var_thresh'][2:])
             if plot_info_dict['fcst_var_name'] == 'APCP':
+                thresh_value = float(plot_info_dict['fcst_var_thresh'][2:])
                 thresh_in = round(thresh_value*0.0393701, 3)
                 plot_title = plot_title+' ('+str(thresh_in)+' in)'
-            elif plot_info_dict['fcst_var_name'] in ['SNOD_A24', 'WEASD_A24']:
-                thresh_in = round(thresh_value*39.3701,3)
-                plot_title = plot_title+' ('+str(thresh_in)+' in)'
-            elif plot_info_dict['fcst_var_name'] == 'DPT':
-                thresh_F = round((((thresh_value-273.15)*9)/5)+32)
-                plot_title = plot_title+' ('+str(thresh_F)+' F)'
-            elif plot_info_dict['fcst_var_name'] == 'HGT' \
-                    and plot_info_dict['fcst_var_level'] == 'CEILING':
-                thresh_kft = round(thresh_value/304.8,1)
-                if int(thresh_kft) == thresh_kft:
-                    thresh_kft = int(thresh_kft)
-                plot_title = plot_title+' ('+str(thresh_kft)+' kft)'
-            elif plot_info_dict['fcst_var_name'] == 'VIS':
-                thresh_mile = round(thresh_value * 0.000621371,1)
-                if int(thresh_mile) == thresh_mile:
-                    thresh_mile = int(thresh_mile)
-                plot_title = plot_title+' ('+str(thresh_mile)+' mile)'
         if plot_info_dict['interp_method'] == 'NBRHD_SQUARE':
             plot_title = (plot_title+' '
                           +'Neighborhood Points: '
@@ -747,9 +731,10 @@ class PlotSpecs:
                 thresh_symbol, thresh_letter = gda_util.format_thresh(
                     plot_info_dict['fcst_var_thresh']
                 )
-                metric_savefig_name = (
-                    metric_savefig_name+'_'
-                    +thresh_letter.replace('.','p')
+                if plot_info_dict['fcst_var_name'] not in ['SST_DAILYAVG']:
+                   metric_savefig_name = (
+                       metric_savefig_name+'_'
+                       +thresh_letter.replace('.','p')
                 )
         parameter_savefig_name = plot_info_dict['fcst_var_name']
         if plot_info_dict['fcst_var_name'] == 'HGT_DECOMP':


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
 
> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR fixes the SST issue with ice temp definition discrepancies between the forecasts and obs for global_det. In GridStat_fcstGLOBAL_DET_obsGHRSST_OSPO_DailyAvg.conf, "cnt_thresh = [ >= 271.15 ]; cnt_logic = INTERSECTION;" was set under FCST_VAR1_OPTIONS and OBS_VAR1_OPTIONS. Fixed plotting issue of fixed SST stat files by making changes in global_det_atmos_plots_specs.py.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? 
* Yes, this PR is needed for official validation.
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Checkout this feature branch and set up FIXevs and COMOUT accordingly. 
Test the SST G2G stats jobs by running the following:
dev/drivers/scripts/stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats.sh
After confirming the successful stats jobs, test the SST plot jobs by running:
dev/drivers/scripts/plots/global_det/jevs_global_det_atmos_grid2grid_sst_plots_last31days.sh
jevs_global_det_atmos_grid2grid_sst_plots_last90days.sh
