### PR TITLE
bugfix/dev_fix_ghrsst

### DIFF
--- a/parm/metplus_config/stats/global_det/atmos_grid2grid/GridStat_fcstGLOBAL_DET_obsGHRSST_OSPO_DailyAvg.conf
+++ b/parm/metplus_config/stats/global_det/atmos_grid2grid/GridStat_fcstGLOBAL_DET_obsGHRSST_OSPO_DailyAvg.conf
@@ -8,6 +8,7 @@ FCST_IS_PROB = False
 OBS_GRID_STAT_INPUT_DIR = {INPUT_BASE}/data/{OBTYPE}
 OBS_GRID_STAT_INPUT_TEMPLATE = ghrsst_ospo.{valid?fmt=%Y%m%d%H?shift=-24H}to{valid?fmt=%Y%m%d%H}.nc
 OBS_GRID_STAT_INPUT_DATATYPE = NETCDF
+OBS_GRID_STAT_FILE_TYPE = NETCDF_NCCF
 OBS_IS_PROB = False
 #### Output
 GRID_STAT_OUTPUT_DIR = {ENV[job_num_work_dir]}

--- a/parm/metplus_config/stats/global_ens/atmos_grid2grid/EnsembleStat_fcstGEFS_obsGHRSST.conf
+++ b/parm/metplus_config/stats/global_ens/atmos_grid2grid/EnsembleStat_fcstGEFS_obsGHRSST.conf
@@ -93,7 +93,7 @@ ENSEMBLE_STAT_NC_PAIRS_FLAG_APPLY_MASK = FALSE
 
 
 
-ENSEMBLE_STAT_MET_CONFIG_OVERRIDES = tmp_dir = "{TMP_DIR}";  
+ENSEMBLE_STAT_MET_CONFIG_OVERRIDES = tmp_dir = "{TMP_DIR}"; obs = { file_type = NETCDF_NCCF; } 
 
 ###############################################################
 modelhead = {ENV[modelhead]}

--- a/parm/metplus_config/stats/global_ens/atmos_grid2grid/EnsembleStat_fcstGEFS_obsGHRSST.conf
+++ b/parm/metplus_config/stats/global_ens/atmos_grid2grid/EnsembleStat_fcstGEFS_obsGHRSST.conf
@@ -34,7 +34,6 @@ FCST_VAR1_LEVELS = "(*,*)"
 OBS_VAR1_NAME = analysed_sst
 OBS_VAR1_LEVELS = "(0,*,*)"
 
-
 lead = {ENV[lead]} 
 LEAD_SEQ = {lead} 
 #Other environment parameters  passed from scripts 

--- a/parm/metplus_config/stats/rtofs/grid2grid/GridStat_fcstRTOFS_obsGHRSST_climoWOA23.conf
+++ b/parm/metplus_config/stats/rtofs/grid2grid/GridStat_fcstRTOFS_obsGHRSST_climoWOA23.conf
@@ -190,6 +190,7 @@ FCST_GRID_STAT_INPUT_TEMPLATE = rtofs.{init?fmt=%Y%m%d}/{ENV[OBTYPE]}/rtofs_glo_
 
 # Template to look for observation input to GridStat relative to OBS_GRID_STAT_INPUT_DIR
 OBS_GRID_STAT_INPUT_TEMPLATE = {valid?fmt=%Y%m%d}_OSPO_L4_GHRSST.nc
+OBS_GRID_STAT_FILE_TYPE = NETCDF_NCCF
 
 # Optional subdirectories relative to GRID_STAT_OUTPUT_DIR to write output from GridStat
 GRID_STAT_OUTPUT_TEMPLATE = {ENV[RUN]}.{valid?fmt=%Y%m%d}/{ENV[OBTYPE]}/{ENV[VERIF_CASE]}/{ENV[VAR]}

--- a/parm/metplus_config/stats/subseasonal/grid2grid/GridStat_fcstSUBSEASONAL_obsGHRSST_OSPO_DailyAvg.conf
+++ b/parm/metplus_config/stats/subseasonal/grid2grid/GridStat_fcstSUBSEASONAL_obsGHRSST_OSPO_DailyAvg.conf
@@ -9,6 +9,7 @@ OBS_GRID_STAT_INPUT_DIR = {INPUT_BASE}/data/{OBTYPE}
 OBS_GRID_STAT_INPUT_TEMPLATE = ghrsst_ospo.{valid?fmt=%Y%m%d%H?shift=-24H}to{valid?fmt=%Y%m%d%H}.nc
 OBS_GRID_STAT_INPUT_DATATYPE = NETCDF
 OBS_IS_PROB = False
+OBS_GRID_STAT_FILE_TYPE = NETCDF_NCCF
 SCRUB_STAGING_DIR = False
 #### Output
 OUTPUT_BASE = {ENV[job_num_work_dir]}

--- a/parm/metplus_config/stats/subseasonal/grid2grid/GridStat_fcstSUBSEASONAL_obsGHRSST_OSPO_MonthlyAvg.conf
+++ b/parm/metplus_config/stats/subseasonal/grid2grid/GridStat_fcstSUBSEASONAL_obsGHRSST_OSPO_MonthlyAvg.conf
@@ -9,6 +9,7 @@ OBS_GRID_STAT_INPUT_DIR = {INPUT_BASE}/data/{OBTYPE}
 OBS_GRID_STAT_INPUT_TEMPLATE = ghrsst_ospo.{valid?fmt=%Y%m%d%H?shift=-720H}to{valid?fmt=%Y%m%d%H}.nc
 OBS_GRID_STAT_INPUT_DATATYPE = NETCDF
 OBS_IS_PROB = False
+OBS_GRID_STAT_FILE_TYPE = NETCDF_NCCF
 SCRUB_STAGING_DIR = False
 #### Output
 OUTPUT_BASE = {ENV[job_num_work_dir]}

--- a/parm/metplus_config/stats/subseasonal/grid2grid/GridStat_fcstSUBSEASONAL_obsGHRSST_OSPO_WeeklyAvg.conf
+++ b/parm/metplus_config/stats/subseasonal/grid2grid/GridStat_fcstSUBSEASONAL_obsGHRSST_OSPO_WeeklyAvg.conf
@@ -9,6 +9,7 @@ OBS_GRID_STAT_INPUT_DIR = {INPUT_BASE}/data/{OBTYPE}
 OBS_GRID_STAT_INPUT_TEMPLATE = ghrsst_ospo.{valid?fmt=%Y%m%d%H?shift=-168H}to{valid?fmt=%Y%m%d%H}.nc
 OBS_GRID_STAT_INPUT_DATATYPE = NETCDF
 OBS_IS_PROB = False
+OBS_GRID_STAT_FILE_TYPE = NETCDF_NCCF
 SCRUB_STAGING_DIR = False
 #### Output
 OUTPUT_BASE = {ENV[job_num_work_dir]}


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This brings the changes from #661 into develop. Note that the change `OBS_ENSEMBLE_STAT_INPUT_GRID_DATATYPE = NETCDF` was done in #503.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> Yes to make sure the SST stats start generating in the parallel
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
> No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
1. Checkout my fork and use branch bugfix/dev_fix_ghrsst
2. Link the fix files from /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix
4. From global_det stats run jevs_global_det_atmos_gfs_grid2grid_stats.sh, jevs_global_det_atmos_imd_grid2grid_stats.sh, jevs_global_det_atmos_ukmet_grid2grid_stats.sh
5. From rtofs stats run jevs_rtofs_ghrsst_stats.sh
6. From subseasonal stats run jevs_subseasonal_cfs_grid2grid_stats.sh and jevs_subseasonal_gefs_grid2grid_stats.sh
7. From global_ens run jevs_global_ens_gefs_atmos_sst_stats.sh

**NOTE:** Set HOMEevs to the location of the clone and COMIN to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0.