### PR TITLE
bugfix/long_term_stats

### DIFF
--- a/ush/global_det/global_det_atmos_stats_long_term.py
+++ b/ush/global_det/global_det_atmos_stats_long_term.py
@@ -225,7 +225,11 @@ def create_avg_time_range_stat_df(logger, time_range, model_info_dict,
             if np.isnan(model_forecst_day_avg) \
                     or np.ma.is_masked(model_forecst_day_avg) \
                     or model_time_range_stat_nvalues < nvalues_time_range_min:
-                model_forecst_day_avg = 'NA'
+                if var_name == 'APCP' and \
+                        model_time_range_stat_nvalues < nvalues_time_range_min:
+                    model_forecst_day_avg = model_forecst_day_avg
+                else:
+                    model_forecst_day_avg = 'NA'
             else:
                 model_forecst_day_avg = str(round(model_forecst_day_avg,3))
             time_range_stat_df.loc[model][forecast_day_header] = (
@@ -639,9 +643,14 @@ for avg_time_range in avg_time_range_list:
                 valid_hour = loop2_info[0]
                 var_thresh = loop2_info[1]
                 if 'in' in var_thresh:
-                    var_thresh_mm = str(
-                        float(var_thresh.replace('in', ''))*25.4
-                    )+'mm'
+                    if var_thresh == '3in':
+                        var_thresh_mm = str(
+                            round(float(var_thresh.replace('in', ''))*25.4,1)
+                        )+'mm'
+                    else:
+                        var_thresh_mm = str(
+                            float(var_thresh.replace('in', ''))*25.4
+                        )+'mm'
                 else:
                     var_thresh_mm = var_thresh
                 logger.info(f"Working on valid hour {valid_hour} "

--- a/ush/global_det/global_det_atmos_stats_long_term.py
+++ b/ush/global_det/global_det_atmos_stats_long_term.py
@@ -222,6 +222,33 @@ def create_avg_time_range_stat_df(logger, time_range, model_info_dict,
             model_forecst_day_avg = gda_util.calculate_average(
                 logger, avg_method, line_type, stat, calc_avg_df
             )
+            if line_type == 'NBRCNT' and stat == 'FSS':
+                stat_file = os.path.join(
+                    output_dir, f"fcstgfs_apcpa24{var_thresh}_obs24hrccpa_"
+                    +f"apcpa24{var_thresh}_linetypenbrcnt_grid{grid.lower()}_"
+                    +f"vxmask{vx_mask.lower()}_"
+                    +f"interpnbrhd_square{interp_points}_"
+                    +f"valid{valid_dates[0]:%Y%m%d%H}0000to"
+                    +f"{valid_dates[-1]:%Y%m%d%H}0000_"
+                    +f"fhr{str(forecast_hour).zfill(3)}.stat"
+                )
+                agg_stat_file = stat_file.replace('.stat', '_agg.stat')
+                if os.path.exists(stat_file):
+                    stat_analysis_cmd_list = [
+                        'stat_analysis', '-lookin', stat_file,
+                        '-job', 'aggregate', '-line_type', 'NBRCNT',
+                        '-out', agg_stat_file
+                    ]
+                    gda_util.run_shell_command(stat_analysis_cmd_list)
+                    if os.path.exists(agg_stat_file):
+                        agg_stat_df = pd.read_csv(
+                            agg_stat_file, delimiter=" ",
+                            skipinitialspace=True, skiprows=1
+                        )
+                        if len(agg_stat_df['FSS'].values) == 1:
+                            model_forecst_day_avg = (
+                                agg_stat_df['FSS'].values[0]
+                            )
             if np.isnan(model_forecst_day_avg) \
                     or np.ma.is_masked(model_forecst_day_avg) \
                     or model_time_range_stat_nvalues < nvalues_time_range_min:


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This corrects some items for the global_det long-term stats. It uses stat_analysis to aggregate FSS and doesn't require a minimum number of days to calculate for precip. This matches the methods that had been previously done by verf_precip. It also fixes an issue with the 3 inch conversion to mm.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
> No
* Do you have any planned upcoming annual leave/PTO?
> No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
> No
 
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

###  **Set-up**
1. Clone my fork and checkout branch bugfix/long_term_stats
2. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`

###  :black_square_button: global_det stats
4. `cd dev/drivers/scripts/stats/global_det`
5. Run `jevs_global_det_atmos_long_term_stats.sh` (takes a few hours to run)
> * Set COMIN to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/global/archive/evs_data