### PR TITLE
global_ens: SST ice fix

### DIFF
--- a/parm/metplus_config/stats/global_ens/atmos_grid2grid/EnsembleStat_fcstGEFS_obsGHRSST.conf
+++ b/parm/metplus_config/stats/global_ens/atmos_grid2grid/EnsembleStat_fcstGEFS_obsGHRSST.conf
@@ -4,7 +4,7 @@ LOG_METPLUS =
 
 OUTPUT_BASE = {ENV[output_base]}
 
-# time looping - options are INIT, VALID, RETRO, and REALTIME
+# Time looping - options are INIT, VALID, RETRO, and REALTIME
 LOOP_BY = VALID
 
 # Format of VALID_BEG and VALID_END
@@ -24,19 +24,19 @@ METPLUS_PATH = {ENV[METPLUS_PATH]}
 STAT_ANALYSIS_RUNTIME_FREQ = RUN_ONCE_PER_INIT_OR_VALID
 
 # List of applications to run
-#PROCESS_LIST = EnsembleStat, GridStat
 PROCESS_LIST = EnsembleStat
-
-#convert fcst icec from 0~1 to 0~ 100% to match OSI_SAF data
 
 FCST_VAR1_NAME = TMP_Z0_mean
 FCST_VAR1_LEVELS = "(*,*)"
+FCST_VAR1_OPTIONS = censor_thresh = [ <271.15 ]; censor_val = [ -9999 ]; vld_thresh = 0.5;
 OBS_VAR1_NAME = analysed_sst
 OBS_VAR1_LEVELS = "(0,*,*)"
+OBS_VAR1_OPTIONS = censor_thresh = [ <271.15 ]; censor_val = [ -9999 ];
+ENSEMBLE_STAT_DESC = GE271.15
 
 lead = {ENV[lead]} 
 LEAD_SEQ = {lead} 
-#Other environment parameters  passed from scripts 
+# Other environment parameters passed from scripts 
 MODEL = {ENV[MODEL]}
 model = {ENV[model]}
 
@@ -48,7 +48,6 @@ TMP_DIR = {OUTPUT_BASE}/tmp
 GRID_STAT_ONCE_PER_FIELD = False
 
 ENSEMBLE_STAT_REGRID_TO_GRID = G003
-ENSEMBLE_STAT_DESC = NA
 ENSEMBLE_STAT_REGRID_METHOD = BILIN
 ENSEMBLE_STAT_REGRID_WIDTH = 2
 ENSEMBLE_STAT_REGRID_VLD_THRESH = 0.5
@@ -70,7 +69,6 @@ ENSEMBLE_STAT_INTERP_SHAPE = SQUARE
 ENSEMBLE_STAT_INTERP_TYPE_METHOD = NEAREST
 ENSEMBLE_STAT_INTERP_TYPE_WIDTH = 1
 
-
 ENSEMBLE_STAT_OUTPUT_FLAG_ECNT = BOTH
 ENSEMBLE_STAT_OUTPUT_FLAG_RPS = NONE
 ENSEMBLE_STAT_OUTPUT_FLAG_RHIST = NONE
@@ -90,8 +88,6 @@ ENSEMBLE_STAT_NC_PAIRS_FLAG_GRADIENT = FALSE
 ENSEMBLE_STAT_NC_PAIRS_FLAG_DISTANCE_MAP = FALSE
 ENSEMBLE_STAT_NC_PAIRS_FLAG_APPLY_MASK = FALSE
 
-
-
 ENSEMBLE_STAT_MET_CONFIG_OVERRIDES = tmp_dir = "{TMP_DIR}"; obs = { file_type = NETCDF_NCCF; } 
 
 ###############################################################
@@ -103,15 +99,14 @@ modeltail = {ENV[modeltail]}
 obsvpath = {ENV[obsvpath]}
 obsvhead = {ENV[obsvhead]}
 
-
 members = {ENV[members]}
 
-# location of ensemble_stat and grid_stat MET config files
+# Location of ensemble_stat MET config file
 ENSEMBLE_STAT_CONFIG_FILE = {METPLUS_BASE}/parm/met_config/EnsembleStatConfig_wrapped
 ENSEMBLE_STAT_ONCE_PER_FIELD = False
 ENSEMBLE_STAT_SKIP_IF_OUTPUT_EXISTS = False
 
-#Defines the name of final metplus conf
+# Define the name of final metplus conf
 METPLUS_CONF = {OUTPUT_BASE}/final_{model}_sst24h_ens.conf
 
 FCST_ENSEMBLE_STAT_INPUT_DATATYPE = NETCDF
@@ -126,12 +121,8 @@ FCST_ENSEMBLE_STAT_INPUT_DIR = {modelpath}
 OBS_ENSEMBLE_STAT_GRID_INPUT_DIR = {obsvpath}
 ENSEMBLE_STAT_OUTPUT_DIR = {OUTPUT_BASE}/stat/{model}
 
-
 [filename_templates]
-
 FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = atmos.{init?fmt=%Y%m%d}/{modelhead}/{modelhead}.ens??.t{init?fmt=%H}z.{modelgrid}{lead?fmt=%3H}{modeltail}
 
 OBS_ENSEMBLE_STAT_GRID_INPUT_TEMPLATE = atmos.{valid?fmt=%Y%m%d}/{modelhead}/{obsvhead}.t{valid?fmt=%H}z.nc
-
-
 


### PR DESCRIPTION
## Description of Changes
This PR fixes the SST issue with ice temp definition discrepancies between the forecasts and observations by filtering out data < 271.15 (K) in Ensemble _Stat. Test run results are available at
https://www.emc.ncep.noaa.gov/users/verification/global/gefs/test/atmos/grid2grid/sst/

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d
COMOUT - set to your test output directory

(2) Run jobs
Run the following job in EVS/dev/drivers/scripts/stats/global_ens:

qsub jevs_global_ens_gefs_atmos_sst_stats.sh
