### PR TITLE
2024tc-all-models

### DIFF
--- a/scripts/plots/hurricane/exevs_hurricane_global_det_tropcyc_plots.sh
+++ b/scripts/plots/hurricane/exevs_hurricane_global_det_tropcyc_plots.sh
@@ -68,24 +68,14 @@ stormName=$(sed "s/ //g" <<< $VARIABLE2)
 echo "Name_${stormName}_Name"
 echo "${stormBasin}, ${stormNumber}, ${stormYear}, ${stormName}"
 
-### NOTE TO USERS ###
-# UKM runs from 2024 are still being processed  #
-# The code will break if this model is included #
-# To run with UKM: 
-# comment out lines 85 and 86 #
-# uncomment lines 87 and 88   #
-
 #---Storm Plots 
 export LOGOroot=${FIXevs}/logos
 export PLOTDATA=${STORMroot}
 #export RUN="tropcyc"
 export img_quality="low"
-
 export fhr_list="0,12,24,36,48,60,72,84,96,108,120,132,144,156,168"
-export model_tmp_atcf_name_list="MD01,MD02,MD03"
-export model_plot_name_list="GFS,ECMWF,CMC"
-#export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
-#export model_plot_name_list="GFS,ECMWF,CMC,UKM"
+export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
+export model_plot_name_list="GFS,ECMWF,CMC,UKM"
 export plot_CI_bars="NO"
 export under="_"
 export tc_name=${stbasin}${under}${stormYear}${under}${stormName}
@@ -143,24 +133,14 @@ elif [ ${stormBasin} = "wp" ]; then
   cp $metTCcomout/tc_stat/tc_stat_basin.out $metTCcomout/tc_stat/tc_stat.out
 fi
 
-### NOTE TO USERS ###
-# UKM runs from 2024 are still being processed  #
-# The code will break if this model is included #
-# To run with UKM: 
-# comment out lines 161 and 162 #
-# uncomment lines 163 and 164   #
-
 #--- Basin-Storms Plots 
 export LOGOroot=${FIXevs}/logos
 export PLOTDATA=${metTCcomout}
 #export RUN="tropcyc"
 export img_quality="low"
-
 export fhr_list="0,12,24,36,48,60,72,84,96,108,120,132,144,156,168"
-export model_tmp_atcf_name_list="MD01,MD02,MD03"
-export model_plot_name_list="GFS,ECMWF,CMC"
-#export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
-#export model_plot_name_list="GFS,ECMWF,CMC,UKM"
+export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04"
+export model_plot_name_list="GFS,ECMWF,CMC,UKM"
 export plot_CI_bars="NO"
 export stormNameB=Basin
 export tc_name=${stbasin}${under}${stormYear}${under}${stormNameB}

--- a/scripts/plots/hurricane/exevs_hurricane_regional_tropcyc_plots.sh
+++ b/scripts/plots/hurricane/exevs_hurricane_regional_tropcyc_plots.sh
@@ -68,20 +68,14 @@ stormName=$(sed "s/ //g" <<< $VARIABLE2)
 echo "Name_${stormName}_Name"
 echo "${stormBasin}, ${stormNumber}, ${stormYear}, ${stormName}"
 
-### NOTE TO USERS ###
-# CTCX runs were not available for AL01, AL02, or AL03 for 2024  #
-# This causes the code to break, so CTCX lines are commented out #
-
 #---Storm Plots 
 export LOGOroot=${FIXevs}/logos
 export PLOTDATA=${STORMroot}
 #export RUN="tropcyc"
 export img_quality="low"
 export fhr_list="0,6,12,18,24,30,36,42,48,54,60,66,72,78,84,90,96,102,108,114,120,126"
-export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04,MD05"
-export model_plot_name_list="HFSA,HFSB,HWRF,HMON,GFS"
-#export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04,MD05,MD06"
-#export model_plot_name_list="HFSA,HFSB,HWRF,HMON,GFS,CTCX"
+export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04,MD05,MD06"
+export model_plot_name_list="HFSA,HFSB,HWRF,HMON,GFS,CTCX"
 export plot_CI_bars="NO"
 export under="_"
 export tc_name=${stbasin}${under}${stormYear}${under}${stormName}
@@ -140,20 +134,14 @@ elif [ ${stormBasin} = "wp" ]; then
   cp $metTCcomout/tc_stat/tc_stat_basin.out $metTCcomout/tc_stat/tc_stat.out
 fi
 
-### NOTE TO USERS ###
-# CTCX runs were not available for AL01, AL02, or AL03 for 2024  #
-# This causes the code to break, so CTCX lines are commented out #
-
 #--- Basin-Storms Plots 
 export LOGOroot=${FIXevs}/logos
 export PLOTDATA=${metTCcomout}
 #export RUN="tropcyc"
 export img_quality="low"
 export fhr_list="0,6,12,18,24,30,36,42,48,54,60,66,72,78,84,90,96,102,108,114,120,126"
-export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04,MD05"
-export model_plot_name_list="HFSA,HFSB,HWRF,HMON,GFS"
-#export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04,MD05,MD06"
-#export model_plot_name_list="HFSA,HFSB,HWRF,HMON,GFS,CTCX"
+export model_tmp_atcf_name_list="MD01,MD02,MD03,MD04,MD05,MD06"
+export model_plot_name_list="HFSA,HFSB,HWRF,HMON,GFS,CTCX"
 export plot_CI_bars="NO"
 export stormNameB=Basin
 export tc_name=${stbasin}${under}${stormYear}${under}${stormNameB}

--- a/scripts/stats/hurricane/exevs_hurricane_global_det_tropcyc_stats.sh
+++ b/scripts/stats/hurricane/exevs_hurricane_global_det_tropcyc_stats.sh
@@ -74,26 +74,17 @@ stormName=$(sed "s/ //g" <<< $VARIABLE2)
 echo "Name_${stormName}_Name"
 echo "${stormBasin}, ${stormNumber}, ${stormYear}, ${stormName}"
 
-### NOTE TO USERS ###
-# UKM runs from 2024 are still being processed  #
-# The code will break if this model is included #
-# To run with UKM: 
-# uncomment lines 89 and 93 #
-# use Model_List with MD04  #
-
 #---get the model forecast tracks "AVNO/EMX/CMC/UKM" from archive file "tracks.atcfunix.${YY24}"
 grep "${stbasin}, ${stormNumber}" ${COMINtrack} > tracks.atcfunix.${YY24}_${stormBasin}${stormNumber}
 grep "03, AVNO" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} > a${stormBasin}${stormNumber}${stormYear}.dat
 grep "03,  EMX" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 grep "03,  CMC" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
-#grep "03,  UKM" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
+grep "03,  UKM" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, AVNO/03, MD01/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03,  EMX/03, MD02/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03,  CMC/03, MD03/' a${stormBasin}${stormNumber}${stormYear}.dat
-#sed -i 's/03,  UKM/03, MD04/' a${stormBasin}${stormNumber}${stormYear}.dat
-export Model_List="MD01,MD02,MD03"
-#export Model_List="MD01,MD02,MD03,MD04"
-#export Model_Plot="GFS,ECMWF,CMC,UKM"
+sed -i 's/03,  UKM/03, MD04/' a${stormBasin}${stormNumber}${stormYear}.dat
+export Model_List="MD01,MD02,MD03,MD04"
 
 #---get the $startdate, $enddate[YYMMDDHH] from the best track file  
 echo $(head -n 1 ${bdeckfile}) > head.txt

--- a/scripts/stats/hurricane/exevs_hurricane_regional_tropcyc_stats.sh
+++ b/scripts/stats/hurricane/exevs_hurricane_regional_tropcyc_stats.sh
@@ -74,13 +74,6 @@ stormName=$(sed "s/ //g" <<< $VARIABLE2)
 echo "Name_${stormName}_Name"
 echo "${stormBasin}, ${stormNumber}, ${stormYear}, ${stormName}"
 
-### NOTE TO USERS ###
-# CTCX runs were not available for AL01, AL02, or AL03 for 2024  #
-# This causes the code to break, so CTCX lines are commented out #
-# To run with CTCX:
-# uncomment grep and sed lines below
-# use Model_List with MD06
-
 #---get the model forecast tracks "AVNO/HWRF/HMON/CTCX" from archive file "tracks.atcfunix.${YY24}"
 grep "${stbasin}, ${stormNumber}" ${COMINtrack} > tracks.atcfunix.${YY24}_${stormBasin}${stormNumber}
 grep "03, HFSA" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} > a${stormBasin}${stormNumber}${stormYear}.dat
@@ -88,15 +81,14 @@ grep "03, HFSB" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormB
 grep "03, HWRF" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 grep "03, HMON" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 grep "03, AVNO" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
-#grep "03, CTCX" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
+grep "03, CTCX" tracks.atcfunix.${YY24}_${stormBasin}${stormNumber} >> a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, HFSA/03, MD01/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, HFSB/03, MD02/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, HWRF/03, MD03/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, HMON/03, MD04/' a${stormBasin}${stormNumber}${stormYear}.dat
 sed -i 's/03, AVNO/03, MD05/' a${stormBasin}${stormNumber}${stormYear}.dat
-#sed -i 's/03, CTCX/03, MD06/' a${stormBasin}${stormNumber}${stormYear}.dat
-export Model_List="MD01,MD02,MD03,MD04,MD05"
-#export Model_List="MD01,MD02,MD03,MD04,MD05,MD06"
+sed -i 's/03, CTCX/03, MD06/' a${stormBasin}${stormNumber}${stormYear}.dat
+export Model_List="MD01,MD02,MD03,MD04,MD05,MD06"
 
 #---get the $startdate, $enddate[YYMMDDHH] from the best track file  
 echo $(head -n 1 ${bdeckfile}) > head.txt
@@ -201,7 +193,6 @@ fi
 if [ -d ${comoutbas}/tc_stat ]; then
   rm -rf ${comoutbas}/tc_stat
 fi
-
 
 nfile=$(ls ${comoutbas}/*.tcst |wc -l)
 if [ $nfile -ne 0 ]; then


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR removes the comments and optional/commented-out lines regarding regional and global_det models in the tropcyc code packages. All CTCX and UKM files for 2024 were made available/shared with the developer, and have been added to EVS-hurricane input data directory. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. Copy branch in local EVS workspace
2. Set $USER to olivia.ostwald OR copy data to your noscrub space:
cd /lfs/h2/emc/vpppg/noscrub/$USER
cp -r /lfs/h2/emc/vpppg/noscrub/olivia.ostwald/evs_tc_2024 .
3.  Run for stats: 
**jevs_hurricane_global_det_tropcyc_stats.sh**
**jevs_hurricane_regional_tropcyc_stats.sh**
4. Once stats are complete, run for plots: 
**jevs_hurricane_global_det_tropcyc_plots.sh**
**jevs_hurricane_regional_tropcyc_plots.sh**

