### PR TITLE
Addressing the Bugzilla 1606

### DIFF
--- a/ush/rtofs/lead_average.py
+++ b/ush/rtofs/lead_average.py
@@ -539,6 +539,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
     else:
         handles = []
         labels = []
+    n_mods = 0    
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -581,9 +582,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
+                n_mods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min

--- a/ush/rtofs/time_series.py
+++ b/ush/rtofs/time_series.py
@@ -573,6 +573,7 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
     else:
         handles = []
         labels = []
+    n_mods = 0    
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -610,10 +611,11 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
             else:
                 y_vals_metric_min = np.nanmin(y_vals_metric1)
                 y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
                 counts = pivot_counts[str(model_list[m])].values
+                n_mods+=1
             else:
                 y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
                 y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR addresses Bugzilla #1606 to ensure .py plotting scripts do not fail because of missing arrays. For more information please visit issue #634 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
  No.
* Do you have any planned upcoming annual leave/PTO?
  No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No.

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
  This will be the topic of another PR.
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- To test this PR, you need to run the driver scripts for only plots step.
2- Clone my fork in your local and checkout branch bugfix/EVSv2-RTOFS_1606
3- ln -s fix directory.
4- In COMIN, replace the ${USER} with emc.vpppg.
5- Run all the driver scripts for plots steps located at: EVS/dev/drivers/scripts/plots/rtofs/*
