### PR TITLE
feature/EVSv2-NFCENS_plots_mpmd

### DIFF
--- a/parm/metplus_config/plots/nfcens/wave_grid2obs/py_plotting_wave.config
+++ b/parm/metplus_config/plots/nfcens/wave_grid2obs/py_plotting_wave.config
@@ -91,7 +91,9 @@ export URL_HEADER=""
 export USH_DIR=${USHevs}
 export FIX_DIR=${FIXevs}
 export PRUNE_DIR=${job_work_dir}
+mkdir -p $PRUNE_DIR
 export SAVE_DIR=${job_work_dir}
+mkdir -p $SAVE_DIR
 export OUTPUT_BASE_DIR=${DATA}/stats/
 
 # Logfile settings. Log level options are "DEBUG", "INFO", "WARNING", "ERROR", and "CRITICAL"

--- a/parm/metplus_config/plots/nfcens/wave_grid2obs/py_plotting_wave.config
+++ b/parm/metplus_config/plots/nfcens/wave_grid2obs/py_plotting_wave.config
@@ -90,16 +90,16 @@ export URL_HEADER=""
 
 export USH_DIR=${USHevs}
 export FIX_DIR=${FIXevs}
-export PRUNE_DIR=${DATA}
-export SAVE_DIR=${DATA}
+export PRUNE_DIR=${job_work_dir}
+export SAVE_DIR=${job_work_dir}
 export OUTPUT_BASE_DIR=${DATA}/stats/
 
 # Logfile settings. Log level options are "DEBUG", "INFO", "WARNING", "ERROR", and "CRITICAL"
 metric1=${METRIC//, /_}
 if [ ${PTYPE} = 'time_series' ]; then
-  export LOG_METPLUS="${DATA}/plots_${WVAR}_${VHR}_${FHR}_${metric1}_${PTYPE}_${PERIOD}.out"
+  export LOG_METPLUS="${job_work_dir}/logs/plots_${WVAR}_${VHR}_${FHR}_${metric1}_${PTYPE}_${PERIOD}.out"
 elif [ ${PTYPE} = 'lead_average' ]; then
-  export LOG_METPLUS="${DATA}/plots_${WVAR}_${VHR}_${metric1}_${PTYPE}_${PERIOD}.out"
+  export LOG_METPLUS="${job_work_dir}/logs/plots_${WVAR}_${VHR}_${metric1}_${PTYPE}_${PERIOD}.out"
 fi
 
 export LOG_LEVEL="DEBUG"

--- a/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
+++ b/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
@@ -144,7 +144,7 @@ fi
 #########################
 # copy all the jobs files
 #########################
-${USHevs}/${COMPONENT}/glwu_wave_plots_copy_plots.sh
+${USHevs}/${COMPONENT}/nfcens_wave_plots_copy_plots.sh
 export err=$?; err_chk
 
 #######################
@@ -211,20 +211,9 @@ fi
 #########################################
 
 cd ${DATA}
-mkdir -p ${DATA}/logs
 log_dir=$DATA/job_work_dir/*/logs
 
-extns='out log'
-for extn in ${extns} ; do
-	count=$(find ${DATA} -type f -name "*.${extn}"|wc -l)
-	if [ $count != 0 ] ; then
-		cp ${DATA}/*.${extn} ${log_dir}
-
-	fi
-done	
-
-
-log_file_count=$(find ${DATA} -type f -name "*.out" -o -name ".log" |wc -l)
+log_file_count=$(find $log_dir -type f -name "*.out" -o -name ".log" |wc -l)
 if [[ $log_file_count -ne 0 ]]; then
 	for log_file in $log_dir/*; do
 		echo "Start: $log_file"

--- a/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
+++ b/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
@@ -5,7 +5,10 @@
 # Samira Ardani / samira.ardani@noaa.gov
 # Purpose of Script: Run the grid2obs plots for any global wave model           
 #                    (deterministic and ensemble: GEFS-Wave, GFS-Wave, NFCENS)  
-#                    NFCENSv2: Add FNMOC and GEFS model to compare against NFCENS                                                                                  
+#                    NFCENSv2: Add FNMOC and GEFS model to compare against NFCENS (07/2024)
+#                    NFCENSv2: Image names was updated. (08/2024)
+#                    NFCENSv2: mpmd was addressed (03/2025)
+#
 # Usage:                                                                        
 #  Parameters: None                                                             
 #  Input files:                                                                 
@@ -53,6 +56,8 @@ echo '-----------------------------'
 [[ "$LOUD" = YES ]] && set -x
 
 mkdir -p ${DATA}/stats
+mkdir -p ${DATA}/job_work_dir
+mkdir -p ${DATA}/images
 
 plot_start_date=${PDYm90}
 plot_end_date=${VDATE}
@@ -135,15 +140,20 @@ else
   sh plot_all_${MODELNAME}_${RUN}_g2o_plots.sh
 fi
 
+
+#########################
+# copy all the jobs files
+#########################
+${USHevs}/${COMPONENT}/glwu_wave_plots_copy_plots.sh
+export err=$?; err_chk
+
 #######################
 # Gather all the files 
 #######################
 periods='LAST31DAYS LAST90DAYS'
 if [ $gather = yes ] ; then
-  echo "copying all images into one directory"
-  cp ${DATA}/wave/*png ${DATA}/sfcshp/.  ## lead_average plots
-  nc=$(ls ${DATA}/sfcshp/*.fhrmean_valid*.png | wc -l | awk '{print $1}')
-  echo "copied $nc lead_average plots"
+  nc=$(ls ${DATA}/images/*.png | wc -l | awk '{print $1}')
+  echo "Found ${nc} ${DATA}/images/*.png "
   for period in ${periods} ; do
     period_lower=$(echo ${period,,})
     if [ ${period} = 'LAST31DAYS' ] ; then
@@ -151,9 +161,6 @@ if [ $gather = yes ] ; then
     elif [ ${period} = 'LAST90DAYS' ] ; then
       period_out='last90days'
     fi
-    # check to see if the plots are there
-    nc=$(ls ${DATA}/sfcshp/*${period_lower}*.png | wc -l | awk '{print $1}')
-    echo " Found ${nc} ${DATA}/plots/*${period_lower}*.png files for ${VDATE} "
     if [ "${nc}" != '0' ]
     then
       set -x
@@ -175,12 +182,16 @@ if [ $gather = yes ] ; then
     
     # tar and copy them to the final destination
     if [ "${nc}" > '0' ] ; then
-      cd ${DATA}/sfcshp
+      cd ${DATA}/images
       tar -cvf evs.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar evs.*${period_lower}*.png
+    fi
+    if [ $SENDCOM = YES ]; then
       if [ -s evs.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar ]; then
 	      cp -v evs.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar ${COMOUTplots}/.
       fi
     fi
+
+
   done
 else  
   echo "not copying the plots"
@@ -201,7 +212,7 @@ fi
 
 cd ${DATA}
 mkdir -p ${DATA}/logs
-log_dir=$DATA/logs
+log_dir=$DATA/job_work_dir/*/logs
 
 extns='out log'
 for extn in ${extns} ; do

--- a/ush/nfcens/evs_wave_leadaverages.sh
+++ b/ush/nfcens/evs_wave_leadaverages.sh
@@ -25,7 +25,6 @@ ptype='lead_average'
 export GRID2OBS_CONF="${PARMevs}/metplus_config/${STEP}/${COMPONENT}/${RUN}_${VERIF_CASE}"
 
 cd ${DATA}
-mkdir -p ${DATA}/sfcshp
 touch plot_all_${MODELNAME}_${RUN}_g2o_plots.sh
 
 # write the commands

--- a/ush/nfcens/evs_wave_leadaverages.sh
+++ b/ush/nfcens/evs_wave_leadaverages.sh
@@ -38,6 +38,7 @@ for period in ${periods} ; do
   for vhr in ${inithours} ; do
     for wvar in ${wave_vars} ; do
       for stats in ${stats_list}; do
+	job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${stats}_${ptype}_${period}      
         echo "export VERIF_CASE=${VERIF_CASE} " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export RUN=${RUN} " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export USHevs=${USHevs}/${COMPONENT} " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
@@ -49,6 +50,8 @@ for period in ${periods} ; do
         echo "export plot_start_date=${plot_start_date} " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export plot_end_date=${VDATE} " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export VHR=${vhr} " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
+	echo "export job_work_dir=${job_work_dir}" >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
+
         case ${stats} in
           'stats1')
             echo "export METRIC='me, rmse' " >> plot_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh

--- a/ush/nfcens/evs_wave_timeseries.sh
+++ b/ush/nfcens/evs_wave_timeseries.sh
@@ -38,6 +38,7 @@ for period in ${periods} ; do
     for wvar in ${wave_vars} ; do
       for stats in ${stats_list}; do
         for fhr in ${fhrs} ; do
+	  job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}
           echo "export VERIF_CASE=${VERIF_CASE} " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
           echo "export RUN=${RUN} " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
           echo "export USHevs=${USHevs}/${COMPONENT} " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
@@ -49,7 +50,9 @@ for period in ${periods} ; do
           echo "export plot_start_date=${plot_start_date} " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
           echo "export plot_end_date=${VDATE} " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
           echo "export VHR=${vhr} " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
-          case ${stats} in
+          echo "export job_work_dir=${job_work_dir}" >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
+	  
+	  case ${stats} in
             'stats1')
               echo "export METRIC='me, rmse' " >> plot_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
               ;;

--- a/ush/nfcens/evs_wave_timeseries.sh
+++ b/ush/nfcens/evs_wave_timeseries.sh
@@ -24,7 +24,6 @@ ptype='time_series'
 export GRID2OBS_CONF="${PARMevs}/metplus_config/${STEP}/${COMPONENT}/${RUN}_${VERIF_CASE}"
 
 cd ${DATA}
-mkdir -p ${DATA}/sfcshp
 touch plot_all_${MODELNAME}_${RUN}_g2o_plots.sh
 
 # write the commands

--- a/ush/nfcens/lead_average.py
+++ b/ush/nfcens/lead_average.py
@@ -1048,7 +1048,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
     if save_header:
         save_name = f'{save_header}_'+save_name
     save_subdir = os.path.join(
-        save_dir, f'{str(run).lower()}' 
+        save_dir, 'images' 
     )
     if not os.path.isdir(save_subdir):
         os.makedirs(save_subdir)

--- a/ush/nfcens/nfcens_wave_plots_copy_plots.sh
+++ b/ush/nfcens/nfcens_wave_plots_copy_plots.sh
@@ -15,7 +15,7 @@ set -x
 
 small_periods='last31days last90days'
 
-inithours='01 07 13 19'
+inithours='00 12'
 wave_vars='HTSGW'
 fhrs='000 024 048 072 096 120 144'
 stats_list='stats1 stats2 stats3 stats4 stats5'
@@ -59,7 +59,7 @@ for small_period in ${small_periods} ; do
 				esac
 
 				# Lead average plots
-				imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.fhrmean_valid${vhr}z_f144.${region}.png
+				imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.fhrmean_valid${vhr}z_f144.latlon_0p25_${region}.png
             			tmp_image=$DATA/images/$imagename
 				job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${stats}_lead_average_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
 				job_image=$job_work_dir/images/$imagename
@@ -72,7 +72,7 @@ for small_period in ${small_periods} ; do
 				fi
 				# Time series plots
 				for fhr in ${fhrs} ; do
-					imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.timeseries_valid${vhr}z_f${fhr}.${region}.png
+					imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.timeseries_valid${vhr}z_f${fhr}.latlon_0p25_${region}.png
             				tmp_image=$DATA/images/$imagename
 					job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${fhr}_${stats}_time_series_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
 					job_image=$job_work_dir/images/$imagename

--- a/ush/nfcens/nfcens_wave_plots_copy_plots.sh
+++ b/ush/nfcens/nfcens_wave_plots_copy_plots.sh
@@ -17,7 +17,7 @@ small_periods='last31days last90days'
 
 inithours='00 12'
 wave_vars='HTSGW'
-fhrs='000 024 048 072 096 120 144'
+fhrs='000 024 048 072 096 120 144 168 192 216 240'
 stats_list='stats1 stats2 stats3 stats4 stats5'
 region='glb'
 export region=${region}
@@ -59,7 +59,7 @@ for small_period in ${small_periods} ; do
 				esac
 
 				# Lead average plots
-				imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.fhrmean_valid${vhr}z_f144.latlon_0p25_${region}.png
+				imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.fhrmean_valid${vhr}z_f240.latlon_0p25_${region}.png
             			tmp_image=$DATA/images/$imagename
 				job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${stats}_lead_average_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
 				job_image=$job_work_dir/images/$imagename

--- a/ush/nfcens/nfcens_wave_plots_copy_plots.sh
+++ b/ush/nfcens/nfcens_wave_plots_copy_plots.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#########################################################################################################################
+# Name of Script: evs_wave_timeseries.sh
+# Developed for EVSv2-NFCENS: Samira Ardani (samira.ardani@noaa.gov)                   
+# Cited to: Mallory Rows's work for global_det component.     
+# Purpose of Script: Copy individual plot from tmp directory in $DATA to job working directory to address mpmd (03/2025)   
+
+#######################################
+# Copy the plots to a common directory
+#######################################
+
+
+# set up plot variables
+set -x
+
+small_periods='last31days last90days'
+
+inithours='01 07 13 19'
+wave_vars='HTSGW'
+fhrs='000 024 048 072 096 120 144'
+stats_list='stats1 stats2 stats3 stats4 stats5'
+region='glb'
+export region=${region}
+export obstype="sfcshp"
+ptype='timeseries fhrmean'
+
+for small_period in ${small_periods} ; do
+	for vhr in ${inithours} ; do
+		for wvar in ${wave_vars} ; do
+			w_var=$(echo ${wvar} | tr '[A-Z]' '[a-z]')
+			for stats in ${stats_list}; do
+				case ${stats} in
+					'stats1')
+					image_stat="me_rmse"
+					;;
+					'stats2')
+					image_stat="corr"
+			       		;;
+					'stats3')
+					image_stat="fbar_obar"
+					;;
+					'stats4')
+					image_stat="esd"
+		                	;;
+					'stats5')
+					image_stat="si"
+		                	;;
+		                	'stats6')
+					image_stat="p95"
+					;;
+				esac
+				case ${wvar} in
+					'WIND')
+					image_level="z10"
+					;;
+					*)
+					image_level="l0"
+					;;
+				esac
+
+				# Lead average plots
+				imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.fhrmean_valid${vhr}z_f144.${region}.png
+            			tmp_image=$DATA/images/$imagename
+				job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${stats}_lead_average_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
+				job_image=$job_work_dir/images/$imagename
+				if [[ ! -s $tmp_image ]]; then
+					if [[ -s $job_image ]]; then
+						cp -v $job_image $tmp_image
+					else
+						echo "NOTE: $job_image does not exist"
+					fi
+				fi
+				# Time series plots
+				for fhr in ${fhrs} ; do
+					imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.timeseries_valid${vhr}z_f${fhr}.${region}.png
+            				tmp_image=$DATA/images/$imagename
+					job_work_dir=${DATA}/job_work_dir/plot_${wvar}_${vhr}_${fhr}_${stats}_time_series_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
+					job_image=$job_work_dir/images/$imagename
+					if [[ ! -s $tmp_image ]]; then
+						if [[ -s $job_image ]]; then
+							cp -v $job_image $tmp_image
+						else
+							echo "NOTE: $job_image does not exist"
+						fi
+					fi
+				done
+			done
+		done
+	done
+done
+

--- a/ush/nfcens/time_series.py
+++ b/ush/nfcens/time_series.py
@@ -1061,7 +1061,7 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
     if save_header:
         save_name = f'{save_header}_'+save_name
     save_subdir = os.path.join(
-        save_dir, f'{str(obtype).lower()}'
+        save_dir, 'images'
     )
     if not os.path.isdir(save_subdir):
         os.makedirs(save_subdir)


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR addresses the Bugzilla 1547 - MPMD processes share the same working directory for EVS-NFCENS for **plots** step. Please see the issue https://github.com/NOAA-EMC/EVS/issues/560.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
  No.
* Do you have any planned upcoming annual leave/PTO?
  No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

Yes, If we want to have a comparison with emc.vpppg, please run after 1930Z to make sure that the stats for that $VDATE has been populated. The comparison can be made after 2100Z because the plots job for that $VDATE are run at this time and it takes less that 5 min to finish. 

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
  We probably need to discuss changing run times for NFCENS jobs. After the timings are finalized, ecf scripts will be updated accordingly.
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.  
There are WARNINGs due to missing files (ex. some stats data for FNMOC, etc.) which is expected.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- To test this PR, you need to run the driver script for only plots step.
2- Clone my fork in your local and checkout branch feature/EVSv2-NFCENS_plots_mpmd.
3- ln -s fix directory.
4- In plots driver script, set KEEPDATA to YES (`export KEEPDATA=${KEEPDATA:-YES}`) because we want to check the $DATA structure for mpmd is addressed.
5- In COMIN, replace the ${USER} with emc.vpppg.
6- Run the driver scripts for plots step located at: $EVS/dev/drivers/scripts/plots/nfcens/*
7- Please follow the time of runs instructions (explained earlier) for this component. Run the plots step few minutes after 1930Z if possible (once the stats for that $VDATE in emc.vpppg is done), then I can check your test outputs and let you know next morning. 
