### PR TITLE
Corresponding changes due to RRFS NRT filename changes update grib2 filename

### DIFF
--- a/scripts/prep/cam/exevs_cam_rrfs_chem_grid2obs_prep.sh
+++ b/scripts/prep/cam/exevs_cam_rrfs_chem_grid2obs_prep.sh
@@ -72,7 +72,7 @@ for OBTTYPE in ${obstype}; do
                         fi
                     fi
                 else
-                    echo "WARNING: can not find ${prep_config_file}"
+                    echo "DEBUG: can not find ${prep_config_file}"
                 fi
             else
                 if [ ${SENDMAIL} = "YES" ]; then
@@ -159,7 +159,7 @@ for OBTTYPE in ${obstype}; do
                             if [ -e ${cpfile} ]; then cp -v ${cpfile} ${COMOUTprep}; fi
                         fi
                     else
-                        echo "WARNING: can not find ${prep_config_file}"
+                        echo "DEBUG: can not find ${prep_config_file}"
                     fi
                 else
                     if [ ${SENDMAIL} = "YES" ]; then
@@ -172,14 +172,14 @@ for OBTTYPE in ${obstype}; do
                 fi
             else
                 if [ ${SENDMAIL} = "YES" ]; then
-                    echo "WARNING: No AIRNOW ASCII data was available for valid date ${INITDATE}${vldhr}" >> ${email_msg}
+                    echo "DEBUG: No AIRNOW ASCII data was available for valid date ${INITDATE}${vldhr}" >> ${email_msg}
                     echo "Missing file is ${checkfile}" >> ${email_msg}
                     echo "==============" >> ${email_msg}
                     flag_send_message=YES
                 fi
         
-                echo "WARNING: No AIRNOW ASCII data was available for valid date ${INITDATE}${vldhr}"
-                echo "WARNING: Missing file is ${checkfile}"
+                echo "DEBUG: No AIRNOW ASCII data was available for valid date ${INITDATE}${vldhr}"
+                echo "DEBUG: Missing file is ${checkfile}"
             fi
             ((ic++))
         done
@@ -244,7 +244,7 @@ for mdl_cyc in "${cyc_opt[@]}"; do
         fi
         while [ ${hour_now} -le ${max_hour} ]; do
             fhr3=`printf %3.3d ${hour_now}`
-            mdl_full_grib2=${MODELNAME}.t${mdl_cyc}z.prslev.f${fhr3}.grib2
+            mdl_full_grib2=${MODELNAME}.t${mdl_cyc}z.prslev.3km.f${fhr3}.na.grib2
             reduced_rec_grib2=${MODELNAME}.t${mdl_cyc}z.prslev.f${fhr3}.reduced.grib2
             check_full_file=${com_rrfs}/${mdl_full_grib2}
             check_reduced_file=${com_rrfs}/${reduced_rec_grib2}
@@ -266,23 +266,23 @@ for mdl_cyc in "${cyc_opt[@]}"; do
                 fi
             else
                 if [ ${SENDMAIL} = "YES" ]; then
-                    echo "WARNING: Can not find RRFS aerosol forecast grib2 output" >> ${email_msg}
+                    echo "DEBUG: Can not find RRFS aerosol forecast grib2 output" >> ${email_msg}
                     echo "Missing file is ${check_full_file}" >> ${email_msg}
                     echo "==============" >> ${email_msg}
                     flag_send_message=YES
                 fi
-                echo "WARNING: Can not find RRFS aerosol forecast grib2 output"
+                echo "DEBUG: Can not find RRFS aerosol forecast grib2 output"
                 echo "Missing file is ${check_full_file}"
             fi
             ((hour_now+=${inc}))
         done
     else
         if [ ${SENDMAIL} = "YES" ]; then
-            echo "WARNING: Can not find RRFS output directory ${com_rrfs}" >> ${email_msg}
+            echo "DEBUG: Can not find RRFS output directory ${com_rrfs}" >> ${email_msg}
             echo "==============" >> ${email_msg}
             flag_send_message=YES
         fi
-        echo "WARNING: Can not find RRFS output directory ${com_rrfs}"
+        echo "DEBUG: Can not find RRFS output directory ${com_rrfs}"
     fi
 done
 #


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
YES, 04/07-04/24 2025

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  NO

- [X ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [ X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ X] Jobs over 15 minutes in runtime have restart capability.
- [ X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X ] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Prep test only.

The RRFS NRT started today, 04/01, so the PR test can only be tested on 04/04 (for INIDATE=04/01/2024, PDYm3)

Otherwise, the PR test can be performed on 04/02, with added lines in ~/dev/drivers/scripts/prep/cam/jevs_cam_rrfs_chem_grid2obs_prep.sh

export INITDATE=20250401
export COMINrrfs=/lfs/h2/emc/ptmp/emc.lam/com/rrfs/v1.0

Note the RRFS NRT is running on Cactus and mirrow to Dogwood, not all f084 grib2 files can be found on the Dogwood.  Therefore, this can only be an engineering test for prep using available model fcst files on Dogwood.

Until all grib2 files from f000-f084 can be mirrow from Cactus to Dogwood, emc.vpppg parallel will not start on RRFS-CHEM NRT verification.
