### PR TITLE
Feature/turn off imd

### DIFF
--- a/dev/drivers/scripts/prep/global_det/jevs_global_det_atmos_prep.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_global_det_atmos_prep.sh
@@ -42,7 +42,7 @@ export TMPDIR=$DATAROOT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT/$RUN
 
-export MODELNAME="cfs cmc cmc_regional dwd fnmoc gfs imd jma metfra ukmet ecmwf"
+export MODELNAME="cfs cmc cmc_regional dwd fnmoc gfs jma metfra ukmet ecmwf"
 export OBSNAME="osi_saf ghrsst_ospo ccpa_accum24hr prepbufr_gdas prepbufr_nam"
 
 # CALL executable job script here

--- a/ecf/scripts/prep/global_det/jevs_global_det_atmos_prep.ecf
+++ b/ecf/scripts/prep/global_det/jevs_global_det_atmos_prep.ecf
@@ -49,7 +49,7 @@ else
 fi
 export NET=evs
 export RUN=atmos
-export MODELNAME="cfs cmc cmc_regional dwd ecmwf fnmoc imd jma metfra ukmet"
+export MODELNAME="cfs cmc cmc_regional dwd ecmwf fnmoc jma metfra ukmet"
 export OBSNAME="osi_saf ghrsst_ospo"
 
 ############################################################


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Remove IMD verification from global_det (dataset is constantly missing). Also removed IMD verification from corresponding ecf scripts.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? NO
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?NO
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Clone the fork git@github.com:QiShi-NOAA/EVS.git
Checkout the feature/turn_off_imd branch.
Link the fix directory.
cd to dev/drivers/scripts/prep/global_det
Set the driver jevs_global_det_atmos_prep.sh to have HOMEevs set to your testing directory.
run  jevs_global_det_atmos_prep.sh around 3pm.
