### PR TITLE
feature/sref_increase precip plot walltime 

### DIFF
--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=100:mem=100GB
+#PBS -l place=vscatter,select=1:ncpus=100:mem=200GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:30:00
 #PBS -l place=vscatter,select=1:ncpus=100:mem=100GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:15:00
 #PBS -l place=vscatter,select=1:ncpus=100:mem=200GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=100:mem=200GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=100:mem=100GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=100:mem=200GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_sref_precip_last90days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=100:mem=100GB
 #PBS -l debug=true
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

   Increased the walltime from 15min to 30mn for the 90-day precip plotting job
   
 Increase 
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?  No
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?  No 
  
- [y ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [y ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ y] References the feature branch for `HOMEevs` are removed from the code.
- [ y] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [y ] Jobs over 15 minutes in runtime have restart capability.
- [y ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [y ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [y ] Code is using METplus wrappers structure and not calling MET executables directly.
- [y ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests. 
   Only  jevs_mesoscale_sref_precip_last90days_plots.sh  needs to test

