### PR TITLE
Mesoscale - fix create_child_workdirs for stats and plots

### DIFF
--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter:exclhost:select=1:ncpus=16:ompthreads=1:mem=35GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=16:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -60,7 +60,6 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
 
   export vhr=${vhr:-${vhr}}
   export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
-  # export MAILTO="firstname.lastname@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_MESOSCALE_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
@@ -39,7 +39,6 @@ export nproc=128
 export evs_run_mode="production"
 
 export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
-# export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
@@ -39,7 +39,6 @@ export nproc=128
 export evs_run_mode="production"
 
 export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
-# export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 
@@ -51,7 +50,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
-export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
+export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/mesoscale2
 
 # Job Settings and Run
 ${HOMEevs}/jobs/JEVS_MESOSCALE_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
@@ -50,7 +50,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
-export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/mesoscale2
+export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 # Job Settings and Run
 ${HOMEevs}/jobs/JEVS_MESOSCALE_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -60,7 +60,6 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
 
   export vhr=${vhr:-${vhr}}
   export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
-  # export MAILTO="firstname.lastname@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_MESOSCALE_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
@@ -39,7 +39,6 @@ export nproc=128
 export evs_run_mode="production"
 
 export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
-# export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
@@ -39,7 +39,6 @@ export nproc=128
 export evs_run_mode="production"
 
 export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
-# export MAILTO="firstname.lastname@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter:exclhost:select=1:ncpus=16:ompthreads=1:mem=35GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=16:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs

--- a/ush/mesoscale/mesoscale_create_child_workdirs.py
+++ b/ush/mesoscale/mesoscale_create_child_workdirs.py
@@ -63,6 +63,7 @@ else:
             if job_name[:3] == 'job'
         ]
         for job_name in job_scripts:
+          if STEP == "stats":
             RESTART_DIR = os.environ['RESTART_DIR']
             COMPLETED_JOBS_FILE = os.environ['COMPLETED_JOBS_FILE']
             completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_" + job_name + ".txt"
@@ -75,7 +76,16 @@ else:
                   'find', '.', '-type', 'd', '-not', '-path', 
                   '\"*workdirs*\"', '-not', '-path', '\"*job*\"', '-exec', 
                   'mkdir', '-p', os.path.join(workdir,'{}'), '\\;'
-            ])
+              ]) 
+          elif STEP == "plots":
+            workdir = os.path.join(workdirs, job_name)
+            if not os.path.exists(workdir):
+                os.makedirs(workdir)
+            cutil.run_shell_command([
+                'find', '.', '-type', 'd', '-not', '-path',
+                '\"*workdirs*\"', '-not', '-path', '\"*job*\"', '-exec',
+                'mkdir', '-p', os.path.join(workdir,'{}'), '\\;'
+            ]) 
         if STEP == "prep":
             print(
                 "Done making working directories for child prcoesses."


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In PR #708 , the fix to Mesoscale NAM/RAP restart, that fix for the stats jobs caused the plots job to fail because the ush code affected, mesoscale_create_child_workdirs.py, runs for both stats and plots.  This job updates the code so it works for both stats and plots.  

This also updates the jevs_mesoscale_headline_plots.sh job.  The resources line had an errant colon where there should be a comma.  This fix was originally added to PR #709 , the update to snowfall plots, but will be removed there and added here, so we can include headline in the plot tests.  

Currently PR #709 is paused until this PR is merged.  PR #709 will not work without these changes.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, somewhat.  Mesoscale plots will fail if PR 708 is merged into emc.vpppg, and so having this update will prevent failure of plots.

* Do you have any planned upcoming annual leave/PTO?

1/2 day off on Friday, 5/2, starting at noon

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

We will need to test both stats and plots, including stats restart.  The plots restart does not need to be tested as that will be refined in a future PR.  

1) Clone https://github.com/PerryShafran-NOAA/EVS.git
2) cd in EVS and git checkout bugfix/mesoscale_create_workdirs_fix
3) ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4) Test all NAM/RAP stats jobs:
   a) Set HOMEevs to your testing directory for all
   b) Set COMIN to emc.vpppg for all
   c) Run the following the grid2obs jobs.  Use qsub -v vhr=07 for your runs.
          i) Do a full uninterrupted run.  Save the final stats file so it is not overwritten by the restart test.  
          ii) Do a restart run.  Interrupt the NAM job at 13 minutes, the RAP job at 15 minutes.  
   d) Run the precip and snowfall jobs, using qsub -v vhr=XX, where XX is 00, 06, 12, 18.  You may run 00, 06, 12 at the same time, but please wait for all to finish before you start the vhr=18 jobs as that is the gather step.  This does not need restart because they are short runs.  
5) Test mesoscale plot jobs.  
   a) Set HOMEevs to your testing directory for all.  
   b) Set COMIN to emc.vpppg for all. 
   c) Run the following.  Note - plot jobs take many hours, esp. precip and snowfall.  
          i) qsub -v vhr=01 jevs_mesoscale_grid2obs_plots.sh
          ii) qsub -v vhr=01 jevs_mesoscale_headline_plots.sh
          iii) qsub -v vhr=13 jevs_mesoscale_precip_plots.sh
          iv) qsub -v vhr=13 jevs_mesoscale_snowfall_plots.sh