### PR TITLE
global_ens: restart clean up for grid2grid and grid2obs stats jobs

### DIFF
--- a/ush/global_ens/evs_global_ens_atmos_grid2grid.sh
+++ b/ush/global_ens/evs_global_ens_atmos_grid2grid.sh
@@ -116,7 +116,9 @@ if [ $verify = upper ] ; then
 
   #*****************************************************************
   # Check if all stats sub-tasks are completed in the previous runs
-  if [ ! -s $COMOUTsmall/stats_completed ] ; then
+  if [ ! -s $COMOUTsmall/completed/stats_completed ] ; then
+  mkdir -p $COMOUTsmall/completed
+  mkdir -p $WORK/completed
 
   # Check if restart directory exists
   if [ -d $COMOUTsmall/restart/grid2grid ] ; then
@@ -209,7 +211,7 @@ if [ $verify = upper ] ; then
         for lead_hr in ${lead_arr[@]}; do
           # Check for restart: check if the single sub-task is completed in the previous run
 	  # If this task has been completed in the previous run, then skip it
-	  if [ ! -e $COMOUTsmall/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed ] ; then
+	  if [ ! -e $COMOUTsmall/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed ] ; then
 	    echo "export lead=${lead_hr}" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 
             if [ $metplus_job = GenEnsProd ] || [ $metplus_job = EnsembleStat ]; then
@@ -225,14 +227,14 @@ if [ $verify = upper ] ; then
             fi
 
 	    # Indicate sub-task is completed for restart 
-	    echo ">$WORK/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
-            echo "echo "${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g task is completed" >> $WORK/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
+	    echo ">$WORK/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
+            echo "echo "${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g task is completed" >> $WORK/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 
             # Save files for restart
 	    echo "if [ $SENDCOM = YES ] ; then" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	    echo "  if [ -d $WORK/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat/${modnam} ] ; then" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
             echo "    mkdir -p $COMOUTsmall/restart/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
-            echo "    cp -f $WORK/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed $COMOUTsmall" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
+            echo "    cp -f $WORK/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_hr}_${metplus_job}_g2g.completed $COMOUTsmall/completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	    echo "    cp -rfu $WORK/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat/${modnam} $COMOUTsmall/restart/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	    echo "  fi" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	    echo "fi" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
@@ -255,20 +257,20 @@ if [ $verify = upper ] ; then
           for lead_SFC in ${lead_SFC_arr[@]}; do
             # Check for restart: check if the single sub-task is completed in the previous run
 	    # If this task has been completed in the previous run, then skip it
-	    if [ ! -e $COMOUTsmall/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed ] ; then
+	    if [ ! -e $COMOUTsmall/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed ] ; then
 	      echo "export lead=${lead_SFC}" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	      echo "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2GRID_CONF}/${metplus_job}_fcst${conf_MODL}_obsModelAnalysis_climoERA5_mean_SFC.conf " >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
               echo "export err=\$?; err_chk" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 
               # Indicate sub-task is completed for restart
-	      echo ">$WORK/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
-              echo "echo "${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g task is completed" >> $WORK/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
+	      echo ">$WORK/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
+              echo "echo "${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g task is completed" >> $WORK/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 
               # Save files for restart
 	      echo "if [ $SENDCOM = YES ] ; then" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	      echo "  if [ -d $WORK/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat/${modnam} ] ; then" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	      echo "    mkdir -p $COMOUTsmall/restart/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
-              echo "    cp -f $WORK/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed $COMOUTsmall" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
+              echo "    cp -f $WORK/completed/run_${modnam}_valid_at_t${vhour}z_${fhr}_${lead_SFC}_${metplus_job}_g2g.completed $COMOUTsmall/completed" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	      echo "    cp -rfu $WORK/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat/${modnam} $COMOUTsmall/restart/grid2grid/run_${modnam}_valid_at_t${vhour}z_${fhr}/stat" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	      echo "  fi" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
 	      echo "fi" >> run_${modnam}_valid_at_t${vhour}z_${fhr}_${metplus_job}_g2g.sh
@@ -323,10 +325,10 @@ if [ $verify = upper ] ; then
   done # end of metplus_jobs loop
 
   # Indicate all tasks are completed
-  >$WORK/stats_completed
-  echo "All stats are completed" >> $WORK/stats_completed
+  >$WORK/completed/stats_completed
+  echo "All stats are completed" >> $WORK/completed/stats_completed
   if [ $SENDCOM = YES ] ; then
-    cp -f $WORK/stats_completed $COMOUTsmall
+    cp -f $WORK/completed/stats_completed $COMOUTsmall/completed
   fi
 
   fi # end of check restart for all tasks
@@ -379,7 +381,9 @@ if [ $verify = precip ] ; then
 
   #*****************************************************************
   # Check if all stats sub-tasks are completed in the previous runs
-  if [ ! -s $COMOUTsmall_precip/stats_completed ] ; then
+  if [ ! -s $COMOUTsmall_precip/completed/stats_completed ] ; then
+  mkdir -p $COMOUTsmall_precip/completed
+  mkdir -p $WORK/completed
 
   # Check if restart directory exists
   if [ -d $COMOUTsmall_precip/restart/grid2grid ] ; then
@@ -488,7 +492,7 @@ if [ $verify = precip ] ; then
         for lead_hr in ${lead_arr[@]}; do
         # Check for restart: check if the single sub-task is completed in the previous run
 	# If this task has been completed in the previous run, then skip it
-	if [ ! -e $COMOUTsmall_precip/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed ] ; then
+	if [ ! -e $COMOUTsmall_precip/completed/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed ] ; then
         echo "export lead=${lead_hr}" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
 
 	if [ $metplus_job = GenEnsProd ] || [ $metplus_job = EnsembleStat ]; then
@@ -512,14 +516,14 @@ if [ $verify = precip ] ; then
         fi
 
         # Indicate sub-task is completed for restart
-	echo ">$WORK/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
-        echo "echo "${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job} task is completed" >> $WORK/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
+	echo ">$WORK/completed/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
+        echo "echo "${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job} task is completed" >> $WORK/completed/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
 
 	# Save files for restart
 	echo "if [ $SENDCOM = YES ] ; then" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
         echo "  if [ -d $WORK/grid2grid/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z/stat/${modnam} ] ; then" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
         echo "    mkdir -p $COMOUTsmall_precip/restart/grid2grid/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z/stat" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
-        echo "    cp -f $WORK/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed $COMOUTsmall_precip" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
+        echo "    cp -f $WORK/completed/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_fhr${lead_hr}_${metplus_job}.completed $COMOUTsmall_precip/completed" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
 	echo "    cp -rfu $WORK/grid2grid/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z/stat/${modnam} $COMOUTsmall_precip/restart/grid2grid/run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z/stat" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
         echo "  fi" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
 	echo "fi" >> run_${modnam}_ccpa${apcp}_valid_at_t${vhour}z_${metplus_job}.sh
@@ -587,10 +591,10 @@ if [ $verify = precip ] ; then
   done # end of metplus_jobs loop
 
   # Indicate all tasks are completed
-  >$WORK/stats_completed
-  echo "All stats are completed" >> $WORK/stats_completed
+  >$WORK/completed/stats_completed
+  echo "All stats are completed" >> $WORK/completed/stats_completed
   if [ $SENDCOM = YES ] ; then
-    cp -f $WORK/stats_completed $COMOUTsmall_precip
+    cp -f $WORK/completed/stats_completed $COMOUTsmall_precip/completed
   fi
 
   fi # end of check restart for all tasks

--- a/ush/global_ens/evs_global_ens_atmos_grid2obs.sh
+++ b/ush/global_ens/evs_global_ens_atmos_grid2obs.sh
@@ -99,7 +99,9 @@ fi
 
 #*****************************************************************
 # Check if all stats sub-tasks are completed in the previous runs
-if [ ! -s $COMOUTsmall/stats_completed ] ; then
+if [ ! -s $COMOUTsmall/completed/stats_completed ] ; then
+mkdir -p $COMOUTsmall/completed
+mkdir -p $WORK/completed
 
 # Check if restart directory exists
 if [ -d $COMOUTsmall/restart/grid2obs ] ; then
@@ -244,7 +246,7 @@ for field in $fields ; do
 
           # Check for restart: check if the single sub-task is completed in the previous run
 	  # If this task has been completed in the previous run, then skip it
-	  if [ ! -e $COMOUTsmall/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed ] ; then
+	  if [ ! -e $COMOUTsmall/completed/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed ] ; then
 
 	  echo  "export output_base=$WORK/grid2obs/run_${modnam}_${vhour}_${fhr}_${field}_g2o" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
           if [ $modnam = naefs ] ; then
@@ -353,12 +355,12 @@ for field in $fields ; do
           fi
 
           # Indicate sub-task is completed for restart 
-	  echo ">$WORK/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
-	  echo "echo "${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o task is completed" >> $WORK/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
+	  echo ">$WORK/completed/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
+	  echo "echo "${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o task is completed" >> $WORK/completed/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
 
           # Save files for restart
 	  echo "if [ $SENDCOM = YES ] ; then" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
-          echo "  cp -f $WORK/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed $COMOUTsmall" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh 
+          echo "  cp -f $WORK/completed/run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.completed $COMOUTsmall/completed" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh 
 	  echo "  if [ -d $WORK/grid2obs/run_${modnam}_${vhour}_${fhr}_${field}_g2o/stat/${modnam} ] ; then" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
 	  echo "    mkdir -p $COMOUTsmall/restart/grid2obs/run_${modnam}_${vhour}_${fhr}_${field}_g2o/stat" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
 	  echo "    cp -rfu $WORK/grid2obs/run_${modnam}_${vhour}_${fhr}_${field}_g2o/stat/${modnam} $COMOUTsmall/restart/grid2obs/run_${modnam}_${vhour}_${fhr}_${field}_g2o/stat" >> run_${modnam}_${vhour}_${fhr}_${field}_${metplus_job}_g2o.sh
@@ -396,11 +398,11 @@ for field in $fields ; do
 done # end of fields loop
 
 # Indicate all tasks are completed
->$WORK/stats_completed
-echo "All stats are completed" >> $WORK/stats_completed
+>$WORK/completed/stats_completed
+echo "All stats are completed" >> $WORK/completed/stats_completed
 
 if [ $SENDCOM = YES ] ; then
-  cp -f $WORK/stats_completed $COMOUTsmall
+  cp -f $WORK/completed/stats_completed $COMOUTsmall/completed
 fi
 
 fi # end of check restart for all tasks


### PR DESCRIPTION
## Description of Changes
This PR moves completed files from COMOUTsmall to a new subdirectory for global_ens grid2grid and grid2obs stats jobs, so COMOUTsmall is more organized and cleaner. This PR addresses Issue https://github.com/NOAA-EMC/EVS/issues/532.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? Yes, on 5/2.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d
COMOUT - set to your test output directory
KEEPDATA - set to YES

(2) Run jobs
Run the following jobs in dev/drivers/scripts/stats/global_ens for any VDATE:
qsub jevs_global_ens_cmce_atmos_grid2grid_stats.sh
qsub jevs_global_ens_ecme_atmos_grid2grid_stats.sh
qsub jevs_global_ens_gefs_atmos_grid2grid_stats.sh
qsub jevs_global_ens_naefs_atmos_grid2grid_stats.sh
qsub jevs_global_ens_cmce_atmos_grid2obs_stats.sh
qsub jevs_global_ens_ecme_atmos_grid2obs_stats.sh
qsub jevs_global_ens_gefs_atmos_grid2obs_stats.sh
qsub jevs_global_ens_naefs_atmos_grid2obs_stats.sh

Log files should be checked for free of errors.

(3) Test restart capability
After a successful full run, save the final stat file for comparison. Run the job again and randomly stop the job using qdel. Then, resubmit the job using qsub. The resubmitted job should run shorter than the full run, and the final stat file from the resubmitted job should be the same from the full run.