### PR TITLE
sendmail is only for missing/corrupt dcom files Feature/reset email function

### DIFF
--- a/scripts/prep/aqm/exevs_aqm_prep.sh
+++ b/scripts/prep/aqm/exevs_aqm_prep.sh
@@ -19,6 +19,7 @@
 ##   02/02/2024   Ho-Chun Huang  Replace cpreq with cp to copy file from DATA to COMOUT
 ##   02/21/2024   Ho-Chun Huang  modify for AQMv7 verification
 ##   06/25/2024   Ho-Chun Huang  Remove concatenating log file sections
+##   05/01/2025   Ho-Chun Huang  Remove email function for missing model forecast output
 ##
 ##
 #######################################################################
@@ -168,16 +169,7 @@ for hour in 06 12; do
                     if [ -s ${comout_file} ]; then cp -v ${comout_file} ${COMOUTproc}; fi
                 fi
             else
-                if [ ${SENDMAIL} = "YES" ]; then
-                    export subject="t${hour}z OZMAX8${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"
-                    echo "WARNING: No AQM OZMAX8${bctag} forecast was available for ${INITDATE} t${hour}z" > mailmsg
-                    echo "Missing file is ${ozmax8_file}" >> mailmsg
-                    echo "Job ID: $jobid" >> mailmsg
-                    cat mailmsg | mail -s "$subject" $MAILTO
-                fi
-        
-                echo "WARNING: No AQM OZMAX8${bctag} forecast was available for ${INITDATE} t${hour}z"
-                echo "WARNING: Missing file is ${ozmax8_file}"
+                echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${ozmax8_file}"
             fi
         fi
         
@@ -194,16 +186,7 @@ for hour in 06 12; do
                     if [ -s ${comout_file} ]; then cp -v ${comout_file} ${COMOUTproc}; fi
                 fi
             else
-                if [ ${SENDMAIL} = "YES" ]; then
-                    export subject="t${hour}z OZMAX8${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"
-                    echo "WARNING: No AQM OZMAX8${bctag} forecast was available for ${INITDATE} t${hour}z" > mailmsg
-                    echo "Missing file is ${ozmax8_file}" >> mailmsg
-                    echo "Job ID: $jobid" >> mailmsg
-                    cat mailmsg | mail -s "$subject" $MAILTO
-                fi
-        
-                echo "WARNING: No AQM OZMAX8${bctag} forecast was available for ${INITDATE} t${hour}z"
-                echo "WARNING: Missing file is ${ozmax8_file}"
+                echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${ozmax8_file}"
             fi
         fi
     done

--- a/scripts/prep/aqm/exevs_aqm_prep.sh
+++ b/scripts/prep/aqm/exevs_aqm_prep.sh
@@ -169,7 +169,7 @@ for hour in 06 12; do
                     if [ -s ${comout_file} ]; then cp -v ${comout_file} ${COMOUTproc}; fi
                 fi
             else
-                echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${ozmax8_file}"
+                echo "FCST_OUTPUT_MISSING: AQM forecast file ${ozmax8_file} is missing. The missing AQM forecast file will be skipped"
             fi
         fi
         
@@ -186,7 +186,7 @@ for hour in 06 12; do
                     if [ -s ${comout_file} ]; then cp -v ${comout_file} ${COMOUTproc}; fi
                 fi
             else
-                echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${ozmax8_file}"
+                echo "FCST_OUTPUT_MISSING: AQM forecast file ${ozmax8_file} is missing. The missing AQM forecast file will be skipped"
             fi
         fi
     done

--- a/scripts/prep/global_ens/exevs_global_ens_gefs_chem_grid2obs_prep.sh
+++ b/scripts/prep/global_ens/exevs_global_ens_gefs_chem_grid2obs_prep.sh
@@ -10,6 +10,7 @@
 ###
 ###   01/16/2024   Ho-Chun Huang  EVSv1.0 EE2 compliance
 ###   01/30/2024   Ho-Chun Huang  for a single email of missing files of both OBS and FCST
+###   05/01/2025   Ho-Chun Huang  Remove email function for missing model forecast output
 ###
 ########################################################################
 #
@@ -177,19 +178,12 @@ for mdl_cyc in "${cyc_opt[@]}"; do
                     cp -v ${reduced_rec_grib2} ${prep_gefs}
                 fi
             else
-                if [ ${SENDMAIL} = "YES" ]; then
-                    echo "DEBUG: Can not find GEFS-aerosol forecast output" >> mailmsg
-                    echo "Missing file is ${check_full_file}" >> mailmsg
-                    echo "==============" >> mailmsg
-                    flag_send_message=YES
-                fi
-                echo "DEBUG: Can not find GEFS-aerosol forecast output" >> mailmsg
-                echo "Missing file is ${check_full_file}" >> mailmsg
+                echo "FCST_OUTPUT_MISSING: Can not find GEFS-aerosol forecast output ${check_full_file}"
             fi
             ((hour_now+=${inc}))
         done
     else
-        echo "DEBUG: Can not find GEFS-aerosol output directory ${com_gefs}" >> mailmsg
+        echo "FCST_OUTPUT_MISSING: Can not find GEFS-aerosol output directory ${com_gefs}"
     fi
 done
 #

--- a/scripts/prep/global_ens/exevs_global_ens_gefs_chem_grid2obs_prep.sh
+++ b/scripts/prep/global_ens/exevs_global_ens_gefs_chem_grid2obs_prep.sh
@@ -178,12 +178,12 @@ for mdl_cyc in "${cyc_opt[@]}"; do
                     cp -v ${reduced_rec_grib2} ${prep_gefs}
                 fi
             else
-                echo "FCST_OUTPUT_MISSING: Can not find GEFS-aerosol forecast output ${check_full_file}"
+                echo "FCST_OUTPUT_MISSING: GEFS-aerosol forecast file ${check_full_file} is missing. The missing GEFS-aerosol forecast file will be skipped"
             fi
             ((hour_now+=${inc}))
         done
     else
-        echo "FCST_OUTPUT_MISSING: Can not find GEFS-aerosol output directory ${com_gefs}"
+        echo "FCST_OUTPUT_MISSING: GEFS-aerosol output directory ${com_gefs} is missing. The missing GEFS-aerosol forecast files will be skipped"
     fi
 done
 #

--- a/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
+++ b/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
@@ -76,7 +76,7 @@ obs_hourly_found=0
 if [ -s ${check_file} ]; then
   obs_hourly_found=1
 else
-  echo "PREP_OUTPUT_MISSING: Can not find pre-processed AIRNOW hourly input ${check_file}"
+  echo "PREP_OUTPUT_MISSING: Pre-processed AIRNOW hourly input ${check_file} is missing. The verification at ${vhr}Z will be skipped"
 fi
 echo "DEBUG: index of hourly obs found = ${obs_hourly_found}"
 
@@ -133,7 +133,7 @@ for outtyp in awpozcon pm25; do
             echo ${fhr} >> ${recorded_temp_list}
             let "num_fcst_in_metplus=num_fcst_in_metplus+1"
           else
-            echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${fcst_file}"
+            echo "FCST_OUTPUT_MISSING: AQM forecast file ${fcst_file} is missing. The missing AQM forecast file will be skipped"
           fi 
         fi 
         ((ihr++))
@@ -191,7 +191,7 @@ obs_daily_found=0
 if [ -s ${check_file} ]; then
   obs_daily_found=1
 else
-  echo "PREP_OUTPUT_MISSING: Can not find pre-processed AIRNOW daily input ${check_file}"
+  echo "PREP_OUTPUT_MISSING: Pre-processed AIRNOW daily input ${check_file} is missing. The verification on ${VDATE} will be skipped"
 fi
 echo "DEBUG: Index of daily obs found = ${obs_daily_found}"
 
@@ -236,7 +236,7 @@ if [ ${vhr} = 11 ]; then
           echo ${fhr} >> ${recorded_temp_list}
           let "num_fcst_in_metplus=num_fcst_in_metplus+1"
         else
-          echo "PREP_OUTPUT_MISSING: Can not find pre-processed AQM forecast output ${ozmax8_preprocessed_file}"
+          echo "PREP_OUTPUT_MISSING: Pre-processed AQM forecast output ${ozmax8_preprocessed_file} is missing. The missing AQM forecast file will be skipped"
         fi
         let "ihr=ihr+24"
       done
@@ -323,7 +323,7 @@ if [ ${vhr} = 04 ]; then
           echo ${fhr} >> ${recorded_temp_list}
           let "num_fcst_in_metplus=num_fcst_in_metplus+1"
         else
-          echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${fcst_file}"
+          echo "FCST_OUTPUT_MISSING: AQM forecast file ${fcst_file} is missing. The missing AQM forecast file will be skipped"
         fi
         let "ihr=ihr+24"
       done

--- a/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
+++ b/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
@@ -20,7 +20,7 @@
 ##   02/21/2024   Ho-Chun Huang  modify for AQMv7 verification
 ##   06/25/2024   Ho-Chun Huang  Remove concatenating log file sections
 ##   04/30/2025   Ho-Chun Huang  Remove email function for missing 
-##                               Prep-Obs input and Fcst Mdl output
+##                               pre-processed and original forecast output
 ##
 ##   Note :  The lead hours specification is important to avoid the error generated 
 ##           by the MetPlus for not finding the input FCST or OBS files. The error
@@ -76,7 +76,7 @@ obs_hourly_found=0
 if [ -s ${check_file} ]; then
   obs_hourly_found=1
 else
-  echo "DEBUG: Can not find pre-processed obs hourly input ${check_file}"
+  echo "PREP_OUTPUT_MISSING: Can not find pre-processed AIRNOW hourly input ${check_file}"
 fi
 echo "DEBUG: index of hourly obs found = ${obs_hourly_found}"
 
@@ -133,8 +133,7 @@ for outtyp in awpozcon pm25; do
             echo ${fhr} >> ${recorded_temp_list}
             let "num_fcst_in_metplus=num_fcst_in_metplus+1"
           else
-            echo "FCST_OUTPUT_MISSING: No AQM ${outtyp}${bctag} forecast was available for ${aday} t${acyc}z"
-            echo "FCST_OUTPUT_MISSING: Missing file is ${fcst_file}"
+            echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${fcst_file}"
           fi 
         fi 
         ((ihr++))
@@ -188,7 +187,7 @@ obs_daily_found=0
 if [ -s ${check_file} ]; then
   obs_daily_found=1
 else
-  echo "DEBUG: Can not find pre-processed obs daily input ${check_file}"
+  echo "PREP_OUTPUT_MISSING: Can not find pre-processed AIRNOW daily input ${check_file}"
 fi
 echo "DEBUG: Index of daily obs found = ${obs_daily_found}"
 
@@ -233,8 +232,7 @@ if [ ${vhr} = 11 ]; then
           echo ${fhr} >> ${recorded_temp_list}
           let "num_fcst_in_metplus=num_fcst_in_metplus+1"
         else
-          echo "FCST_OUTPUT_MISSING: No AQM max_8hr_o3${bctag} forecast was available for ${chk_date} t${hour}z"
-          echo "FCST_OUTPUT_MISSING: Missing file is ${ozmax8_preprocessed_file}"
+          echo "PREP_OUTPUT_MISSING: Can not find pre-processed AQM forecast output ${ozmax8_preprocessed_file}"
         fi
         let "ihr=ihr+24"
       done
@@ -317,8 +315,7 @@ if [ ${vhr} = 04 ]; then
           echo ${fhr} >> ${recorded_temp_list}
           let "num_fcst_in_metplus=num_fcst_in_metplus+1"
         else
-          echo "FCST_OUTPUT_MISSING: No AQM ave_24hr_pm25${bctag} forecast was available for ${chk_date} t${hour}z"
-          echo "FCST_OUTPUT_MISSING: Missing file is $fcst_file}"
+          echo "FCST_OUTPUT_MISSING: Can not find AQM forecast output ${fcst_file}"
         fi
         let "ihr=ihr+24"
       done

--- a/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
+++ b/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
@@ -150,8 +150,12 @@ for outtyp in awpozcon pm25; do
         run_metplus.py ${conf_file_dir}/${point_stat_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
       else
-        echo "DEBUG: NO ${cap_outtyp} FORECAST OR OBS TO VERIFY"
-        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_hourly_found}"
+        if [ ${obs_hourly_found} -eq 0 ]; then
+            echo "DEBUG: There is no pre-processed hourly ${cap_outtyp} OBS, the metplus stats process will be skipped"
+        fi
+        if [ ${num_fcst_in_metplus} -eq 0 ]; then
+            echo "DEBUG: There is no ${outtyp}${bcout} ${model1} ${hour}Z cycle forecast output validated at ${vhr}Z, the metplus stats process will be skipped"
+        fi
       fi
     done   ## hour loop
     mkdir -p ${COMOUTsmall}
@@ -248,8 +252,12 @@ if [ ${vhr} = 11 ]; then
         run_metplus.py ${conf_file_dir}/${point_stat_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
       else
-        echo "DEBUG: NO OZMAX8 OBS OR MODEL DATA"
-        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_daily_found}"
+        if [ ${obs_daily_found} -eq 0 ]; then
+            echo "DEBUG: There is no pre-processed ${outtyp} OBS, the metplus stats process will be skipped"
+        fi
+        if [ ${num_fcst_in_metplus} -eq 0 ]; then
+            echo "DEBUG: There is no ${outtyp}${bcout} ${model1} ${hour}Z cycle forecast output validated at ${vhr}Z, the metplus stats process will be skipped"
+        fi
       fi
     done   ## cyc hour loop
     if [ ${SENDCOM} = "YES" ]; then
@@ -332,8 +340,12 @@ if [ ${vhr} = 04 ]; then
         run_metplus.py ${conf_file_dir}/${point_stat_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
       else
-        echo "DEBUG: NO PMAVE OBS OR MODEL DATA"
-        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_daily_found}"
+        if [ ${obs_daily_found} -eq 0 ]; then
+            echo "DEBUG: There is no pre-processed ${outtyp} OBS, the metplus stats process will be skipped"
+        fi
+        if [ ${num_fcst_in_metplus} -eq 0 ]; then
+            echo "DEBUG: There is no ${outtyp}${bcout} ${model1} ${hour}Z cycle forecast output validated at ${vhr}Z, the metplus stats process will be skipped"
+        fi
       fi
     done   ## cyc hour loop
     if [ ${SENDCOM} = "YES" ]; then

--- a/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
+++ b/scripts/stats/aqm/exevs_aqm_grid2obs_stats.sh
@@ -19,6 +19,8 @@
 ##   02/02/2024   Ho-Chun Huang  Replace cpreq with cp to copy file from DATA to COMOUT
 ##   02/21/2024   Ho-Chun Huang  modify for AQMv7 verification
 ##   06/25/2024   Ho-Chun Huang  Remove concatenating log file sections
+##   04/30/2025   Ho-Chun Huang  Remove email function for missing 
+##                               Prep-Obs input and Fcst Mdl output
 ##
 ##   Note :  The lead hours specification is important to avoid the error generated 
 ##           by the MetPlus for not finding the input FCST or OBS files. The error
@@ -74,16 +76,9 @@ obs_hourly_found=0
 if [ -s ${check_file} ]; then
   obs_hourly_found=1
 else
-  echo "WARNING: Can not find pre-processed obs hourly input ${check_file}"
-  if [ $SENDMAIL = "YES" ]; then 
-    export subject="AQM Hourly Observed Missing for EVS ${COMPONENT}"
-    echo "WARNING: No AQM ${HOURLY_INPUT_TYPE} was available for ${vld_date} ${vld_time}" > mailmsg
-    echo "Missing file is ${check_file}" >> mailmsg
-    echo "Job ID: $jobid" >> mailmsg
-    cat mailmsg | mail -s "$subject" $MAILTO
-  fi
+  echo "DEBUG: Can not find pre-processed obs hourly input ${check_file}"
 fi
-echo "index of hourly obs found = ${obs_hourly_found}"
+echo "DEBUG: index of hourly obs found = ${obs_hourly_found}"
 
 for outtyp in awpozcon pm25; do
   export outtyp
@@ -138,16 +133,8 @@ for outtyp in awpozcon pm25; do
             echo ${fhr} >> ${recorded_temp_list}
             let "num_fcst_in_metplus=num_fcst_in_metplus+1"
           else
-            if [ $SENDMAIL = "YES" ]; then
-              export subject="t${acyc}z ${outtyp}${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"
-              echo "WARNING: No AQM ${outtyp}${bctag} forecast was available for ${aday} t${acyc}z" > mailmsg
-              echo "Missing file is ${fcst_file}" >> mailmsg
-              echo "Job ID: $jobid" >> mailmsg
-              cat mailmsg | mail -s "$subject" $MAILTO
-            fi
-
-            echo "WARNING: No AQM ${outtyp}${bctag} forecast was available for ${aday} t${acyc}z"
-            echo "WARNING: Missing file is ${fcst_file}"
+            echo "FCST_OUTPUT_MISSING: No AQM ${outtyp}${bctag} forecast was available for ${aday} t${acyc}z"
+            echo "FCST_OUTPUT_MISSING: Missing file is ${fcst_file}"
           fi 
         fi 
         ((ihr++))
@@ -157,15 +144,15 @@ for outtyp in awpozcon pm25; do
       fi
       if [ -e ${recorded_temp_list} ]; then rm -f ${recorded_temp_list}; fi
       export num_fcst_in_metplus
-      echo "number of fcst lead in_metplus point_stat for ${outtyp}${bctag} == ${num_fcst_in_metplus}"
+      echo "DEBUG: number of fcst lead in_metplus point_stat for ${outtyp}${bctag} == ${num_fcst_in_metplus}"
     
       if [ ${num_fcst_in_metplus} -gt 0 -a ${obs_hourly_found} -eq 1 ]; then
         export fcsthours=${fcsthours_list}
         run_metplus.py ${conf_file_dir}/${point_stat_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
       else
-        echo "WARNING: NO ${cap_outtyp} FORECAST OR OBS TO VERIFY"
-        echo "WARNING: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_hourly_found}"
+        echo "DEBUG: NO ${cap_outtyp} FORECAST OR OBS TO VERIFY"
+        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_hourly_found}"
       fi
     done   ## hour loop
     mkdir -p ${COMOUTsmall}
@@ -201,16 +188,9 @@ obs_daily_found=0
 if [ -s ${check_file} ]; then
   obs_daily_found=1
 else
-  echo "WARNING: Can not find pre-processed obs daily input ${check_file}"
-  if [ $SENDMAIL = "YES" ]; then
-    export subject="AQM Daily Observed Missing for EVS ${COMPONENT}"
-    echo "WARNING: No AQM Daily Observed file was available for ${VDATE}" > mailmsg
-    echo "Missing file is ${check_file}" >> mailmsg
-    echo "Job ID: $jobid" >> mailmsg
-    cat mailmsg | mail -s "$subject" $MAILTO
-  fi
+  echo "DEBUG: Can not find pre-processed obs daily input ${check_file}"
 fi
-echo "Index of daily obs found = ${obs_daily_found}"
+echo "DEBUG: Index of daily obs found = ${obs_daily_found}"
 
 
 if [ ${vhr} = 11 ]; then
@@ -253,15 +233,8 @@ if [ ${vhr} = 11 ]; then
           echo ${fhr} >> ${recorded_temp_list}
           let "num_fcst_in_metplus=num_fcst_in_metplus+1"
         else
-          if [ $SENDMAIL = "YES" ]; then
-            export subject="ozmax8${bctag} AQM Daily Forecast Data Missing for EVS ${COMPONENT}"
-            echo "WARNING: No AQM ozmax8${bctag} daily forecast was available for ${chk_date} t${hour}z" > mailmsg
-            echo "Missing file is ${ozmax8_preprocessed_file}" >> mailmsg
-            echo "Job ID: $jobid" >> mailmsg
-            cat mailmsg | mail -s "$subject" $MAILTO
-          fi
-          echo "WARNING: No AQM max_8hr_o3${bctag} forecast was available for ${chk_date} t${hour}z"
-          echo "WARNING: Missing file is ${ozmax8_preprocessed_file}"
+          echo "FCST_OUTPUT_MISSING: No AQM max_8hr_o3${bctag} forecast was available for ${chk_date} t${hour}z"
+          echo "FCST_OUTPUT_MISSING: Missing file is ${ozmax8_preprocessed_file}"
         fi
         let "ihr=ihr+24"
       done
@@ -277,8 +250,8 @@ if [ ${vhr} = 11 ]; then
         run_metplus.py ${conf_file_dir}/${point_stat_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
       else
-        echo "WARNING: NO OZMAX8 OBS OR MODEL DATA"
-        echo "WARNING: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_daily_found}"
+        echo "DEBUG: NO OZMAX8 OBS OR MODEL DATA"
+        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_daily_found}"
       fi
     done   ## cyc hour loop
     if [ ${SENDCOM} = "YES" ]; then
@@ -344,16 +317,8 @@ if [ ${vhr} = 04 ]; then
           echo ${fhr} >> ${recorded_temp_list}
           let "num_fcst_in_metplus=num_fcst_in_metplus+1"
         else
-          if [ $SENDMAIL = "YES" ]; then
-            export subject="t${hour}z PMAVE${bctag} AQM Forecast Data Missing for EVS ${COMPONENT}"
-            echo "WARNING: No AQM ave_24hr_pm25${bctag} forecast was available for ${chk_date} t${hour}z" > mailmsg
-            echo "Missing file is $fcst_file}" >> mailmsg
-            echo "Job ID: $jobid" >> mailmsg
-            cat mailmsg | mail -s "$subject" $MAILTO
-          fi
-
-          echo "WARNING: No AQM ave_24hr_pm25${bctag} forecast was available for ${chk_date} t${hour}z"
-          echo "WARNING: Missing file is $fcst_file}"
+          echo "FCST_OUTPUT_MISSING: No AQM ave_24hr_pm25${bctag} forecast was available for ${chk_date} t${hour}z"
+          echo "FCST_OUTPUT_MISSING: Missing file is $fcst_file}"
         fi
         let "ihr=ihr+24"
       done
@@ -362,16 +327,16 @@ if [ ${vhr} = 04 ]; then
       fi
       if [ -e ${recorded_temp_list} ]; then rm -f ${recorded_temp_list}; fi
       export num_fcst_in_metplus
-      echo "number of fcst lead in_metplus point_stat for ${outtyp}${bctag} == ${num_fcst_in_metplus}"
-      echo "index of daily obs_found == ${obs_daily_found}"
+      echo "DEBUG: number of fcst lead in_metplus point_stat for ${outtyp}${bctag} == ${num_fcst_in_metplus}"
+      echo "DEBUG: index of daily obs_found == ${obs_daily_found}"
 
       if [ ${num_fcst_in_metplus} -gt 0 -a ${obs_daily_found} -gt 0 ]; then
         export fcsthours=${fcsthours_list}
         run_metplus.py ${conf_file_dir}/${point_stat_conf_file} ${PARMevs}/metplus_config/machine.conf
         export err=$?; err_chk
       else
-        echo "WARNING: NO PMAVE OBS OR MODEL DATA"
-        echo "WARNING: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_daily_found}"
+        echo "DEBUG: NO PMAVE OBS OR MODEL DATA"
+        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${obs_daily_found}"
       fi
     done   ## cyc hour loop
     if [ ${SENDCOM} = "YES" ]; then

--- a/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
+++ b/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
@@ -69,7 +69,7 @@ for ObsType in ${grid2obs_list}; do
         if [ -s ${check_file} ]; then
           num_obs_found=1
         else
-          echo "PREP_OUTPUT_MISSING: Can not find pre-processed ${OBSTYPE} Level 1.5 input ${check_file}"
+          echo "PREP_OUTPUT_MISSING: Pre-processed ${OBSTYPE} Level 1.5 input ${check_file} is missing. The verification on ${VDATE} will be skipped"
         fi
         echo "DEBUG: index of daily aeronet obs found = ${num_obs_found}"
     elif [ "${ObsType}" == "airnow" ]; then
@@ -84,7 +84,7 @@ for ObsType in ${grid2obs_list}; do
         if [ -s ${check_file} ]; then
           num_obs_found=1
         else
-          echo "PREP_OUTPUT_MISSING: Can not find pre-processed ${OBSTYPE} hourly input ${check_file}"
+          echo "PREP_OUTPUT_MISSING: Pre-processed ${OBSTYPE} hourly input ${check_file} is missing. The verification at ${vhr}Z will be skipped"
         fi
         echo "DEBUG: index of hourly AirNOW obs found = ${num_obs_found}"
     fi
@@ -111,7 +111,7 @@ for ObsType in ${grid2obs_list}; do
             echo ${fhr} >> ${recorded_temp_list}
             let "num_fcst_in_metplus=num_fcst_in_metplus+1"
           else
-            echo "PREP_OUTPUT_MISSING: Can not find pre-processed GEFS-aerosol output ${fcst_file}"
+            echo "PREP_OUTPUT_MISSING: Pre-processed GEFS-aerosol output ${fcst_file} is missing. The missing GEFS-aerosol forecast file will be skipped"
           fi 
         fi 
         ## ((ihr++))

--- a/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
+++ b/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
@@ -10,7 +10,7 @@
 ###
 ###   01/16/2024   Ho-Chun Huang  consolidate exevs_global_ens_chem_grid2obs scripts
 ###   04/30/2025   Ho-Chun Huang  Remove email function for missing 
-###                               Prep-Obs input and Fcst Mdl output
+###                               pre-processed forecast output
 ###
 ########################################################################
 set -x
@@ -69,7 +69,7 @@ for ObsType in ${grid2obs_list}; do
         if [ -s ${check_file} ]; then
           num_obs_found=1
         else
-          echo "DEBUG: Can not find pre-processed ${OBSTYPE} Level 1.5 input ${check_file}"
+          echo "PREP_OUTPUT_MISSING: Can not find pre-processed ${OBSTYPE} Level 1.5 input ${check_file}"
         fi
         echo "DEBUG: index of daily aeronet obs found = ${num_obs_found}"
     elif [ "${ObsType}" == "airnow" ]; then
@@ -84,7 +84,7 @@ for ObsType in ${grid2obs_list}; do
         if [ -s ${check_file} ]; then
           num_obs_found=1
         else
-          echo "DEBUG: Can not find pre-processed ${OBSTYPE} hourly input ${check_file}"
+          echo "PREP_OUTPUT_MISSING: Can not find pre-processed ${OBSTYPE} hourly input ${check_file}"
         fi
         echo "DEBUG: index of hourly AirNOW obs found = ${num_obs_found}"
     fi
@@ -111,8 +111,7 @@ for ObsType in ${grid2obs_list}; do
             echo ${fhr} >> ${recorded_temp_list}
             let "num_fcst_in_metplus=num_fcst_in_metplus+1"
           else
-            echo "FCST_OUTPUT_MISSING: No ${model1} ${obs_var} forecast was available for ${aday} t${acyc}z"
-            echo "FCST_OUTPUT_MISSING: Missing file is ${fcst_file}"
+            echo "PREP_OUTPUT_MISSING: Can not find pre-processed GEFS-aerosol output ${fcst_file}"
           fi 
         fi 
         ## ((ihr++))

--- a/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
+++ b/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
@@ -9,6 +9,8 @@
 ###   Change Logs:
 ###
 ###   01/16/2024   Ho-Chun Huang  consolidate exevs_global_ens_chem_grid2obs scripts
+###   04/30/2025   Ho-Chun Huang  Remove email function for missing 
+###                               Prep-Obs input and Fcst Mdl output
 ###
 ########################################################################
 set -x
@@ -35,9 +37,6 @@ export METPLUS_PATH
 grid2obs_list="${DATA_TYPE}"
 
 export init_cyc="00 06 12 18"
-
-flag_send_message=NO
-if [ -e mailmsg ]; then /bin/rm -f mailmsg; fi
 
 for ObsType in ${grid2obs_list}; do
     export ObsType
@@ -71,14 +70,8 @@ for ObsType in ${grid2obs_list}; do
           num_obs_found=1
         else
           echo "DEBUG: Can not find pre-processed ${OBSTYPE} Level 1.5 input ${check_file}"
-          if [ "${SENDMAIL}" == "YES" ]; then 
-            echo "DEBUG: No pre-processed ${OBSTYPE} Level 1.5 was available for ${VDATE} " >> mailmsg
-            echo "Missing file is ${check_file}" >> mailmsg
-            echo "==============" >> mailmsg
-            flag_send_message=YES
-          fi
         fi
-        echo "index of daily aeronet obs found = ${num_obs_found}"
+        echo "DEBUG: index of daily aeronet obs found = ${num_obs_found}"
     elif [ "${ObsType}" == "airnow" ]; then
         fcstmax=120
 
@@ -92,14 +85,8 @@ for ObsType in ${grid2obs_list}; do
           num_obs_found=1
         else
           echo "DEBUG: Can not find pre-processed ${OBSTYPE} hourly input ${check_file}"
-          if [ "${SENDMAIL}" == "YES" ]; then 
-            echo "DEBUG: No ${OBSTYPE} ${HOURLY_INPUT_TYPE} was available for ${vld_date} ${vld_time}" >> mailmsg
-            echo "Missing file is ${check_file}" >> mailmsg
-            echo "==============" >> mailmsg
-            flag_send_message=YES
-          fi
         fi
-        echo "index of hourly AirNOW obs found = ${num_obs_found}"
+        echo "DEBUG: index of hourly AirNOW obs found = ${num_obs_found}"
     fi
 
     for mdl_cyc in ${init_cyc}; do
@@ -124,15 +111,8 @@ for ObsType in ${grid2obs_list}; do
             echo ${fhr} >> ${recorded_temp_list}
             let "num_fcst_in_metplus=num_fcst_in_metplus+1"
           else
-            if [ "${SENDMAIL}" == "YES" ]; then
-              echo "DEBUG: No ${model1} ${obs_var} forecast was available for ${aday} t${acyc}z" >> mailmsg
-              echo "Missing file is ${fcst_file}" >> mailmsg
-              echo "==============" >> mailmsg
-              flag_send_message=YES
-            fi
-
-            echo "DEBUG: No ${model1} ${obs_var} forecast was available for ${aday} t${acyc}z"
-            echo "DEBUG: Missing file is ${fcst_file}"
+            echo "FCST_OUTPUT_MISSING: No ${model1} ${obs_var} forecast was available for ${aday} t${acyc}z"
+            echo "FCST_OUTPUT_MISSING: Missing file is ${fcst_file}"
           fi 
         fi 
         ## ((ihr++))
@@ -184,9 +164,4 @@ for ObsType in ${grid2obs_list}; do
     fi
 
 done
-if [ "${flag_send_message}" == "YES" ]; then
-    export subject="${OBSTYPE} Obs or ${CMODEL} Fcst files Missing for EVS ${COMPONENT} ${RUN} ${VERIF_CASE}"
-    echo "Job ID: ${jobid}" >> mailmsg
-    cat mailmsg | mail -s "${subject}" ${MAILTO}
-fi 
 exit

--- a/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
+++ b/scripts/stats/global_ens/exevs_global_ens_chem_grid2obs_stats.sh
@@ -122,7 +122,7 @@ for ObsType in ${grid2obs_list}; do
       fi
       if [ -e ${recorded_temp_list} ]; then rm -f ${recorded_temp_list}; fi
       export num_fcst_in_metplus
-      echo "number of fcst lead in_metplus point_stat for ${model1} ${obs_var} == ${num_fcst_in_metplus}"
+      echo "number of fcst lead in_metplus point_stat for ${CMODEL}-aerosol ${obs_var} == ${num_fcst_in_metplus}"
     
       if [ ${num_fcst_in_metplus} -gt 0 -a ${num_obs_found} -eq 1 ]; then
         export fcsthours=${fcsthours_list}
@@ -132,8 +132,12 @@ for ObsType in ${grid2obs_list}; do
         run_metplus.py ${point_stat_conf_file} ${config_common}
         export err=$?; err_chk
       else
-        echo "DEBUG: NO ${model1} ${obs_var} FORECAST OR OBS TO VERIFY"
-        echo "DEBUG: NUM FCST=${num_fcst_in_metplus}, INDEX OBS=${num_obs_found}"
+        if [ ${num_obs_found} -eq 0 ]; then
+            echo "DEBUG: There is no pre-processed ${OBSTYPE} OBS, the metplus stats process will be skipped"
+        fi
+        if [ ${num_fcst_in_metplus} -eq 0 ]; then
+            echo "DEBUG: There is no pre-processed ${obs_var} ${CMODEL}-aerosol ${mdl_cyc} cycle forecast output validated at ${vhr}Z, the metplus stats process will be skipped"
+        fi
       fi
     done   ## hour loop
     if [ "${SENDCOM}" == "YES" ]; then


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR is to resolve the Fixes and Additions in EVS v2.0: the SENDMAIL is only being used for missing/corrupt files in dcom.

All other missing files (model output or preprocessing output) has been turned into a log message with specific KEY WORD for monitoring.


## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
NO
  
- [X ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X ] References the feature branch for `HOMEevs` are removed from the code.
- [ X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X ] Jobs over 15 minutes in runtime have restart capability.
- [X ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ X] Code is using METplus wrappers structure and not calling MET executables directly.
- [*] Log is free of any ERRORs or WARNINGs.
WARNING is allowed for corrupt/missing dcom files

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Please run today's prep and stats for AQM and GEFS-CHEM.  No error/warning message should be found.

AQM stats, /dev/drivers/scripts/stats/aqm/jevs_aqm_grid2obs_stats.sh:
vhr=00-22 with one hour interval can be submitted together.  After 00-22 stats is done, submit vhr=23.

GEFS-CHEM stats, 
(1) /dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_chem_grid2obs_airnow_stats.sh
(2)/dev/drivers/scripts/stats/global_ens/jevs_global_ens_gefs_chem_grid2obs_aeronet_stats.sh
vhr=00-18 with 3-hour interval can be submitted together.  After 00-18 stats is done, submit vhr=21.

 
Repeat the AQM and GEFS-CHEM stats run with the date that has no prep output, e.g., 20250420, to check the message of missing forecast model output or pre-processed model/obs output.