### PR TITLE
AQM images title with observation source Feature/plot obs src

### DIFF
--- a/jobs/JEVS_AQM_PLOTS
+++ b/jobs/JEVS_AQM_PLOTS
@@ -80,6 +80,7 @@ mkdir -m 775 -p $COMOUT $COMOUTheadline
 export DATA_TYPE=${DATA_TYPE:-hourly}
 export restart_mode=${restart_mode:-YES}
 export fig_name_label=${fig_name_label:-last${NDAYS}days}
+export OBS_SRC=${OBS_SRC:-airnow}
 #######################################################################
 # Execute the script.
 #######################################################################

--- a/ush/aqm/aqm_plots.py
+++ b/ush/aqm/aqm_plots.py
@@ -41,6 +41,7 @@ date_type = os.environ['date_type']
 NDAYS = os.environ['NDAYS']
 fig_name_label = os.environ['fig_name_label']
 dir_name_label = fig_name_label
+obs_src_name=os.environ['OBS_SRC']
 restart_mode = os.environ['restart_mode']
 plot_verbosity = os.environ['plot_verbosity']
 VERIF_TYPE = os.environ['VERIF_TYPE']
@@ -434,6 +435,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for ts_info in \
                 list(itertools.product(valid_hrs, fhrs, var_info)):
             date_info_dict['valid_hr_start'] = str(ts_info[0])
@@ -493,6 +495,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for ts_info in list(var_info):
             logger.info(f"aqm_plots.py {ts_info}")
             date_info_dict['valid_hr_start'] = valid_hr_start
@@ -563,6 +566,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for la_info in list(itertools.product(valid_hrs, var_info)):
             date_info_dict['valid_hr_start'] = str(la_info[0])
             date_info_dict['valid_hr_end'] = str(la_info[0])
@@ -617,6 +621,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for la_info in list(var_info):
             date_info_dict['valid_hr_start'] = valid_hr_start
             date_info_dict['valid_hr_end'] = valid_hr_end
@@ -683,6 +688,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for vha_info in list(var_info):
             date_info_dict['valid_hr_start'] = valid_hr_start
             date_info_dict['valid_hr_end'] = valid_hr_end
@@ -742,6 +748,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for vhafm_info in list(var_info):
             date_info_dict['valid_hr_start'] = valid_hr_start
             date_info_dict['valid_hr_end'] = valid_hr_end
@@ -837,6 +844,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for ta_info in list(itertools.product(valid_hrs, fhrs)):
             date_info_dict['valid_hr_start'] = str(ta_info[0])
             date_info_dict['valid_hr_end'] = str(ta_info[0])
@@ -943,6 +951,7 @@ elif JOB_GROUP == 'make_plots':
         date_info_dict['fday_end'] = fday_end
         date_info_dict['fday_inc'] = fday_inc
         plot_info_dict['fig_name_label'] = fig_name_label
+        plot_info_dict['obs_src_name'] = obs_src_name
         for pd_info in list(itertools.product(valid_hrs, fhrs)):
             date_info_dict['valid_hr_start'] = str(pd_info[0])
             date_info_dict['valid_hr_end'] = str(pd_info[0])

--- a/ush/aqm/aqm_plots_specs.py
+++ b/ush/aqm/aqm_plots_specs.py
@@ -435,9 +435,14 @@ class PlotSpecs:
         """
         obs_plot_name_dict = {
             'airnow': 'AIRNOW',
+            'airnow_pm25': 'AIRNOW',
+            'airnow_pm10': 'AIRNOW',
             'aeronet': 'AERONET',
+            'aeronet_aod': 'AERONET',
             'abi': 'GOES ABI',
-            'viirs': 'VIIRS'
+            'abi_aod': 'GOES ABI',
+            'viirs': 'VIIRS',
+            'viirs_aod': 'VIIRS'
         }
         if ob_name in list(obs_plot_name_dict.keys()):
             obs_plot_name = obs_plot_name_dict[ob_name]

--- a/ush/aqm/aqm_plots_specs.py
+++ b/ush/aqm/aqm_plots_specs.py
@@ -421,6 +421,32 @@ class PlotSpecs:
             var_plot_name = var_name_level
         return var_plot_name
 
+    def get_obs_plot_name(self, ob_name):
+        """! Get the full obs source name that will be
+             displayed on the plot
+
+             Args:
+                 ob_name - abbreviated obs source name (string)
+
+             Returns:
+                 obs_plot_name - full obs source name that
+                                 will be displayed on the plot
+                                 (string)
+        """
+        obs_plot_name_dict = {
+            'airnow': 'AIRNOW',
+            'aeronet': 'AERONET',
+            'abi': 'GOES ABI',
+            'viirs': 'VIIRS'
+        }
+        if ob_name in list(obs_plot_name_dict.keys()):
+            obs_plot_name = obs_plot_name_dict[ob_name]
+        else:
+            self.logger.debug(f"{ob_name} not recognized, "
+                              +f"using {ob_name} on plot")
+            obs_plot_name = ob_name
+        return obs_plot_name
+
     def get_vx_mask_plot_name(self, vx_mask):
         """! Get the full verification masking information that will
              be displayed on the plot
@@ -746,6 +772,9 @@ class PlotSpecs:
             else:
                 plot_title = plot_title+', '+var_thresh_symbol+' '+units
             thresh_value = float(plot_info_dict['fcst_var_thresh'][2:])
+        plot_title = (plot_title+' - '
+                      +'Validation: '
+                      +self.get_obs_plot_name(plot_info_dict['obs_src_name']))
         if self.plot_type in [ 'time_series_fhr_mean', 'lead_average_vhr_mean', 'valid_hour_average_fhr_mean' ]:
             self.logger.debug(f"pass {self.plot_type} to get_dates_plot_name_aqm")
             plot_title = (plot_title+'\n'
@@ -843,6 +872,9 @@ class PlotSpecs:
             else:
                 plot_title = plot_title+', '+var_thresh_symbol+' '+units
             thresh_value = float(plot_info_dict['fcst_var_thresh'][2:])
+        plot_title = (plot_title+' - '
+                      +'Validation: '
+                      +self.get_obs_plot_name(plot_info_dict['obs_src_name']))
         plot_title = (plot_title+'\n'
                       +self.get_dates_plot_name(date_info_dict['date_type'],
                                                     date_info_dict['start_date'],


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

To add the validation observations source name to AQM image title

to resolve the EVSv2.0 Fix and Additions in "aqm": Add text in the image title to say which validation dataset  is being used in that plot

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 NO
 
- [ X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ X] References the feature branch for `HOMEevs` are removed from the code.
- [X ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ X] Jobs over 15 minutes in runtime have restart capability.
- [X ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X ] Code is using METplus wrappers structure and not calling MET executables directly.
- [X ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Download the local branch feature/PlotObsSrc to working directory

Update HOMEevs and other setting for PR test in ~/dev/drivers/scripts/plots/aqm
jevs_aqm_grid2obs_daily_plots_last31days.sh  jevs_aqm_grid2obs_hourly_plots_last31days.sh
jevs_aqm_grid2obs_daily_plots_last90days.sh  jevs_aqm_grid2obs_hourly_plots_last90days.sh

Run AQM plots of today, i.e.,VDATE=PDYm4.
