### PR TITLE
GEFS-CHEM add obs src name to image title

### DIFF
--- a/jobs/JEVS_GLOBAL_ENS_PLOTS
+++ b/jobs/JEVS_GLOBAL_ENS_PLOTS
@@ -68,6 +68,7 @@ if [ "${RUN}" == "chem" ]; then
     export machine=${machine:-WCOSS2}
     export evs_run_mode=${evs_run_mode:-production}
     export DATA_TYPE=${DATA_TYPE:-aeronet}
+    export OBS_SRC=${OBS_SRC:-${DATA_TYPE}}
     export restart_mode=${restart_mode:-YES}
     export fig_name_label=${fig_name_label:-last${NDAYS}days}
 fi

--- a/ush/global_ens/global_ens_chem_plots.py
+++ b/ush/global_ens/global_ens_chem_plots.py
@@ -41,6 +41,7 @@ date_type = os.environ['date_type']
 NDAYS = os.environ['NDAYS']
 fig_name_label = os.environ['fig_name_label']
 dir_name_label = fig_name_label
+obs_src_name=os.environ['OBS_SRC']
 restart_mode = os.environ['restart_mode']
 plot_verbosity = os.environ['plot_verbosity']
 VERIF_TYPE = os.environ['VERIF_TYPE']
@@ -402,6 +403,7 @@ elif JOB_GROUP == 'make_plots':
             plot_info_dict['obs_var_level'] = ts_info[2][1][1]
             plot_info_dict['obs_var_thresh'] = ts_info[2][1][2]
             plot_info_dict['fig_name_label'] = fig_name_label
+            plot_info_dict['obs_src_name'] = obs_src_name
             init_hr = gda_util.get_init_hour(
                 int(date_info_dict['valid_hr_start']),
                 int(date_info_dict['forecast_hour'])
@@ -455,6 +457,7 @@ elif JOB_GROUP == 'make_plots':
             plot_info_dict['obs_var_level'] = la_info[1][1][1]
             plot_info_dict['obs_var_thresh'] = la_info[1][1][2]
             plot_info_dict['fig_name_label'] = fig_name_label
+            plot_info_dict['obs_src_name'] = obs_src_name
             job_work_image_name = plot_specs.get_savefig_name(
                 job_work_dir, plot_info_dict, date_info_dict
             )
@@ -506,6 +509,7 @@ elif JOB_GROUP == 'make_plots':
             plot_info_dict['obs_var_level'] = vha_info[0][1][1]
             plot_info_dict['obs_var_thresh'] = vha_info[0][1][2]
             plot_info_dict['fig_name_label'] = fig_name_label
+            plot_info_dict['obs_src_name'] = obs_src_name
             job_work_image_name = plot_specs.get_savefig_name(
                 job_work_dir, plot_info_dict, date_info_dict
             )
@@ -561,6 +565,7 @@ elif JOB_GROUP == 'make_plots':
             plot_info_dict['obs_var_name'] = obs_var_name
             plot_info_dict['obs_var_threshs'] = obs_var_thresh_list
             plot_info_dict['fig_name_label'] = fig_name_label
+            plot_info_dict['obs_src_name'] = obs_src_name
             init_hr = gda_util.get_init_hour(
                 int(date_info_dict['valid_hr_start']),
                 int(date_info_dict['forecast_hour'])
@@ -623,6 +628,7 @@ elif JOB_GROUP == 'make_plots':
             plot_info_dict['obs_var_name'] = obs_var_name
             plot_info_dict['obs_var_threshs'] = obs_var_thresh_list
             plot_info_dict['fig_name_label'] = fig_name_label
+            plot_info_dict['obs_src_name'] = obs_src_name
             init_hr = gda_util.get_init_hour(
                 int(date_info_dict['valid_hr_start']),
                 int(date_info_dict['forecast_hour'])

--- a/ush/global_ens/global_ens_chem_plots_specs.py
+++ b/ush/global_ens/global_ens_chem_plots_specs.py
@@ -441,6 +441,37 @@ class PlotSpecs:
             var_plot_name = var_name_level
         return var_plot_name
 
+    def get_obs_plot_name(self, ob_name):
+        """! Get the full obs source name that will be
+             displayed on the plot
+
+             Args:
+                 ob_name - abbreviated obs source name (string)
+
+             Returns:
+                 obs_plot_name - full obs source name that
+                                 will be displayed on the plot
+                                 (string)
+        """
+        obs_plot_name_dict = {
+            'airnow': 'AIRNOW',
+            'airnow_pm25': 'AIRNOW',
+            'airnow_pm10': 'AIRNOW',
+            'aeronet': 'AERONET',
+            'aeronet_aod': 'AERONET',
+            'abi': 'GOES ABI',
+            'abi_aod': 'GOES ABI',
+            'viirs': 'VIIRS',
+            'viirs_aod': 'VIIRS'
+        }
+        if ob_name in list(obs_plot_name_dict.keys()):
+            obs_plot_name = obs_plot_name_dict[ob_name]
+        else:
+            self.logger.debug(f"{ob_name} not recognized, "
+                              +f"using {ob_name} on plot")
+            obs_plot_name = ob_name
+        return obs_plot_name
+
     def get_vx_mask_plot_name(self, vx_mask):
         """! Get the full verification masking information that will
              be displayed on the plot
@@ -693,6 +724,9 @@ class PlotSpecs:
             plot_title = (plot_title+' '
                           +'Neighborhood Points: '
                           +plot_info_dict['interp_points'])
+        plot_title = (plot_title+' - '
+                      +'Validation: '
+                      +self.get_obs_plot_name(plot_info_dict['obs_src_name']))
         plot_title = (plot_title+'\n'
                       +self.get_dates_plot_name(date_info_dict['date_type'],
                                                 date_info_dict['start_date'],


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

To add the validation observations source name to GEFS-CHEM image title

to resolve the EVSv2.0 Fix and Additions : Add text in the image title to say which validation dataset  is being used in that plot


## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
NO

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
NO
  
- [ X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X ] References the feature branch for `HOMEevs` are removed from the code.
- [ X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ X] Jobs over 15 minutes in runtime have restart capability.
- [ X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ X] Code is using METplus wrappers structure and not calling MET executables directly.
- [ X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Download local branch feature/gefsplotobssrc to working directory

Update HOMEevs, COMIN, and COMOUT for PR test

Run /dev/drivers/scripts/plots/global_ens (use default)
jevs_global_ens_chem_gefs_grid2obs_aeronet_plots_last31days.sh
jevs_global_ens_chem_gefs_grid2obs_aeronet_plots_last90days.sh
jevs_global_ens_chem_gefs_grid2obs_airnow_plots_last31days.sh
jevs_global_ens_chem_gefs_grid2obs_airnow_plots_last90days.sh

