### PR TITLE
HREF: Adjust ncpus setting in  ecnt plotting jobs

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.sh
@@ -3,7 +3,7 @@
 #PBS -q dev
 #PBS -S /bin/bash
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:25:00
 #PBS -l place=vscatter,select=1:ncpus=66:mem=40GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=2:ncpus=33:mem=40GB
+#PBS -l place=vscatter,select=1:ncpus=66:mem=40GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last90days_plots.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last90days_plots.sh
@@ -3,8 +3,8 @@
 #PBS -q dev
 #PBS -S /bin/bash
 #PBS -A VERF-DEV
-#PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=33:mem=100GB
+#PBS -l walltime=00:40:00
+#PBS -l place=vscatter,select=1:ncpus=66:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=2:ncpus=33:mem=40GB
+#PBS -l place=vscatter,select=1:ncpus=66:mem=40GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last31days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:25:00
 #PBS -l place=vscatter,select=1:ncpus=66:mem=40GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last90days_plots.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_href_grid2obs_ecnt_last90days_plots.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=2:ncpus=33:mem=100GB
+#PBS -l walltime=00:40:00
+#PBS -l place=vscatter,select=1:ncpus=66:mem=100GB
 #PBS -l debug=true
 
 export model=evs 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

   Change the ncpus setting in the ecnt plotting driver scripts to fix "ncpus  .. exceeded 33 limit" warnings in the log files

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

   In the 31-days and 90days ecnt driver scripts 
    #PBS -l place=vscatter,select=2:ncpus=33:mem= ... 
   By this setting,  there are a series of warnings  "ncpus  ... exceeded 33 limit" in the log files.  
   In this PR, the the setting is changed to following 
     #PBS -l place=vscatter,select=1:ncpus=66:mem=... 
   By reducing "select" and increasing "ncpus" without changing memory limit, the warnings can be removed without increasing  the CPU resources.  But the execution time will increase a little bit.  
 
   ## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
  No

* Do you have any planned upcoming annual leave/PTO?
   I'll take one day PTO leave on Friday, May 9, 2025

* Are there any changes needed in the times when the jobs are supposed to run/kick-off? 
   No
  
- [ y] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ y] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ y] References the feature branch for `HOMEevs` are removed from the code.
- [y ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [y ] Jobs over 15 minutes in runtime have restart capability.
- [y ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ y] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [y ] Code is using METplus wrappers structure and not calling MET executables directly.
- [y ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
  Only 31-days and 90-days ecnt plotting jobs need to test
  The walltime for the 31-days and 90-days jobs are about 11min and 31min (increased by 10min than previous version), respectively, so only 90-days job need restart testing.
    
