### PR TITLE
feature/subseasonal_prep_walltimes_memory_updates

### DIFF
--- a/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_cfs_prep.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_cfs_prep.sh
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:20:00
-#PBS -l place=shared,select=1:ncpus=1:mem=15GB
+#PBS -l walltime=00:15:00
+#PBS -l place=shared,select=1:ncpus=1:mem=18GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_gefs_prep.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_subseasonal_gefs_prep.sh
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=02:00:00
-#PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=260GB
+#PBS -l walltime=01:50:00
+#PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=300GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/prep/subseasonal/jevs_subseasonal_cfs_prep.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_subseasonal_cfs_prep.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=10GB
+#PBS -l place=shared,select=1:ncpus=1:mem=18GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/prep/subseasonal/jevs_subseasonal_gefs_prep.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_subseasonal_gefs_prep.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:55:00
-#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=150GB
+#PBS -l walltime=01:50:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=300GB
 #PBS -l debug=true
 
 export model=evs

--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -136,7 +136,7 @@ def log_missing_file_model(log_missing_file, missing_file, model, init_dt,
             lmf.write("#!/bin/bash\n")
             lmf.write(f'export subject="F{fhr} {model.upper()} Forecast '
                       +'Data Missing for EVS subseasonal"\n')
-            lmf.write(f'echo "Warning: No {model.upper()} forecast was '
+            lmf.write(f'echo "WARNING: No {model.upper()} forecast was '
                       +f'available for {init_dt:%Y%m%d%H}f{fhr}" '
                       +'> mailmsg\n')
             lmf.write(f'echo "Missing file is {missing_file}" >> mailmsg\n')
@@ -160,14 +160,14 @@ def log_missing_file_obs(log_missing_file, missing_file, obs, valid_dt):
                 lmf.write(f'export subject="{obs.upper()} prepbufr Data '
                           +'Missing for '
                           +'EVS subseasonal"\n')
-                lmf.write(f'echo "Warning: No {obs.upper()} prepbufr data '
+                lmf.write(f'echo "WARNING: No {obs.upper()} prepbufr data '
                           +f'was available for '
                           +f'valid date {valid_dt:%Y%m%d%H}" > mailmsg\n')
             else:
                 lmf.write(f'export subject="{obs.upper()} Analysis Data '
                           +'Missing for '
                           +'EVS subseasonal"\n')
-                lmf.write(f'echo "Warning: No {obs.upper()} Analysis data '
+                lmf.write(f'echo "WARNING: No {obs.upper()} Analysis data '
                           +f'was available for '
                           +f'valid date {valid_dt:%Y%m%d%H}" > mailmsg\n')
             lmf.write(f'echo "Missing file is {missing_file}" >> mailmsg\n')


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
Changed GEFS prep mem=300GB (driver and ecf) due to the following:
`jevs_subseasonal_gefs_prep.o195034486:05/05/2025 15:24:17  M    Cgroup memory limit exceeded`
Since this job used ~272GB, Alicia and I agreed to bump up the memory to 300GB.
Changed GEFS prep walltime to 1:50 per NCO standards (driver and ecf).
Change CFS prep walltime to 15 per NCO standards (driver).
Changed CFS prep mem=18GB (driver and ecf) because it was noticed that parallel jobs have been close to exceeding the previous limit of 15GB.
Changed "Warning" to "WARNING" in log_missing_file functions to match messages about missing data in util.py.
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
* No
* Do you have any planned upcoming annual leave/PTO?
* Yes, June 2-9
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  **No, but please be sure to run the prep jobs in the morning hours (before 1pm) as submitting in the afternoon might not be an accurate test of the changed walltimes.**
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
**git clone https://github.com/ShannonShields-NOAA/EVS.git and cd EVS
Then git checkout feature/subseasonal_prep_walltimes
Symlink FIXevs directory
To test the walltimes and memory changes, please run the following under dev/drivers/scripts/prep/subseasonal/:
qsub jevs_subseasonal_cfs_prep.sh (this should take about 8mins)
qsub jevs_subseasonal_gefs_prep.sh (this should take around 1hr 20mins)
Make sure to set HOMEevs to your test directory, you can keep "export KEEPDATA=NO", set "export SENDMAIL=NO", and set COMOUT accordingly.
If you wish to test the WARNING messages, let me know and I will send instructions after the main testing is completed.**