### PR TITLE
Updating mesoscale (det) plot titles with obs source

### DIFF
--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
@@ -54,6 +54,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
+export EVAL_PERIOD=last90days
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_MESOSCALE_PLOTS

--- a/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
+++ b/dev/drivers/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=16:ompthreads=1:mem=35GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
@@ -58,6 +58,7 @@ export VERIF_CASE=headline
 export MODELNAME=mesoscale
 export evs_run_mode=production
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}
+export EVAL_PERIOD=last90days
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
+++ b/ecf/scripts/plots/mesoscale/jevs_mesoscale_headline_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:15:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=16:ompthreads=1:mem=35GB
 #PBS -l debug=true
 

--- a/ush/mesoscale/lead_average.py
+++ b/ush/mesoscale/lead_average.py
@@ -1348,7 +1348,8 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         else:
             title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
     title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
-              + f'{date_start_string} to {date_end_string}')
+              + f'{date_start_string} to {date_end_string}, ' 
+              + f'Validation: {str(verif_type).upper()} ')
     title_center = '\n'.join([title1, title2, title3])
     if sample_equalization:
         title_pad=23
@@ -1744,7 +1745,7 @@ def main():
                         temp_fcst_level = [fcst_level, "Z0"]
                 df = df_preprocessing.get_preprocessed_data(
                     logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
-                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD,  
                     date_hours, FLEADS, requested_var, fcst_var_names, obs_var_names, 
                     models, model_queries,
                     domain, INTERP, MET_VERSION, clear_prune_dir, temp_fcst_level

--- a/ush/mesoscale/performance_diagram.py
+++ b/ush/mesoscale/performance_diagram.py
@@ -1142,7 +1142,8 @@ def plot_performance_diagram(df: pd.DataFrame, logger: logging.Logger,
     else:
         title2 = (f'{level_string}{var_long_name} ({units}), {domain_string}')
     title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
-              + f'{date_start_string} to {date_end_string}, {frange_string}')
+              + f'{date_start_string} to {date_end_string}, {frange_string}, ' 
+              + f'Validation: {str(verif_type).upper()} ')
     title_center = '\n'.join([title1, title2, title3])
     ax.set_title(title_center) 
     logger.info("... Plotting complete.")

--- a/ush/mesoscale/stat_by_level.py
+++ b/ush/mesoscale/stat_by_level.py
@@ -1051,7 +1051,8 @@ def plot_stat_by_level(df: pd.DataFrame, logger: logging.Logger,
     else:
         title2 = f'{var_long_name} (unitless), {domain_string}'
     title3 = (f'{str(date_type).capitalize()} {date_hours_string}'
-              + f' {date_start_string} to {date_end_string}, {frange_string}')
+              + f' {date_start_string} to {date_end_string}, {frange_string}, '
+              + f'Validation: {str(VERIF_TYPE).upper()} ')
     title_center = '\n'.join([title1, title2, title3])
     ax.set_title(title_center) 
     logger.info("... Plotting complete.")

--- a/ush/mesoscale/threshold_average.py
+++ b/ush/mesoscale/threshold_average.py
@@ -973,7 +973,8 @@ def plot_threshold_average(df: pd.DataFrame, logger: logging.Logger,
     else:
         title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
     title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
-              + f'{date_start_string} to {date_end_string}, {frange_string}')
+              + f'{date_start_string} to {date_end_string}, {frange_string}, '
+              + f'Validation: {str(verif_type).upper()} ')
     title_center = '\n'.join([title1, title2, title3])
     if sample_equalization:
         title_pad=23

--- a/ush/mesoscale/time_series.py
+++ b/ush/mesoscale/time_series.py
@@ -1212,7 +1212,8 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
         else:
             title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
     title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
-              + f'{date_start_string} to {date_end_string}, {frange_string}')
+              + f'{date_start_string} to {date_end_string}, {frange_string}, '
+              + f'Validation: {str(verif_type).upper()} ')
     title_center = '\n'.join([title1, title2, title3])
     if sample_equalization:
         title_pad=23

--- a/ush/mesoscale/valid_hour_average.py
+++ b/ush/mesoscale/valid_hour_average.py
@@ -1335,7 +1335,8 @@ def plot_valid_hour_average(df: pd.DataFrame, logger: logging.Logger,
         else:
             title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
     title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
-              + f'{date_start_string} to {date_end_string}, {frange_string}')
+              + f'{date_start_string} to {date_end_string}, {frange_string}, ' 
+              + f'Validation: {str(verif_type).upper()} ')
     title_center = '\n'.join([title1, title2, title3])
     if sample_equalization:
         title_pad=23


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR adds the observation source to the mesoscale (det) plot titles.

This PR also adds EVAL_PERIOD to the headline plot job.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

No


* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ x] Code is using METplus wrappers structure and not calling MET executables directly.
- [ x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS, git checkout feature/mesoscale_plot_obs_title
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/plots/mesoscale
5. In the grid2obs, precip, and snowfall mesoscale det jobs, set HOMEevs to your testing directory, and set COMIN to emc.vpppg.
6. Run the following:

qsub -v vhr=01 jevs_mesoscale_grid2obs_plots_last31days.sh
qsub -v vhr=13 jevs_mesoscale_precip_plots_last31days.sh
qsub -v vhr=13 jevs_mesoscale_snowfall_plots_last31days.sh
qsub -v vhr=01 jevs_mesoscale_headline_plots.sh

We can run the last90days plot jobs as desired, but they should work on the same plot scripts.  
