### PR TITLE
Remove #sys.exit from check_variables.py

### DIFF
--- a/ush/mesoscale/ush_sref_plot_cnv_py/check_variables.py
+++ b/ush/mesoscale/ush_sref_plot_cnv_py/check_variables.py
@@ -15,11 +15,9 @@ def check_VERIF_CASE(VERIF_CASE):
         sys.exit(f"The provided VERIF_CASE ('{VERIF_CASE}') is not a string."
                      + f"  VERIF_CASE must be a string. Check the plotting"
                      + f" configuration file.")
-        ##sys.exit(1)
     if not VERIF_CASE:
         sys.exit(f"The provided VERIF_CASE is empty. VERIF_CASE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        ##sys.exit(1)
     return VERIF_CASE
 
 # VERIF_TYPE
@@ -31,11 +29,9 @@ def check_VERIF_TYPE(VERIF_TYPE):
         sys.exit(f"The provided VERIF_TYPE ('{VERIF_TYPE}') is not a string."
                      + f"  VERIF_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        ##sys.exit(1)
     if not VERIF_TYPE:
         sys.exit(f"The provided VERIF_TYPE is empty. VERIF_TYPE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        ##sys.exit(1)
     return VERIF_TYPE
 
 # URL_HEADER
@@ -47,13 +43,11 @@ def check_URL_HEADER(URL_HEADER):
         sys.exit(f"The provided URL_HEADER ('{URL_HEADER}') is not a string."
                      + f"  URL_HEADER must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-\\]', URL_HEADER):
         sys.exit(f"The provided URL_HEADER string ('{URL_HEADER}') contains"
                      + f" invalid characters. URL_HEADER must be made of"
                      + f" alphanumeric characters, hyphen, and/or underscore."
                      + f" Check the plotting configuration file.")
-        #sys.exit(1)
     return URL_HEADER
 
 # USH_DIR
@@ -65,7 +59,6 @@ def check_USH_DIR(USH_DIR):
         sys.exit(f"The provided USH_DIR ('{USH_DIR}') is not a string."
                      + f"  USH_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(USH_DIR).exists():
         print(f"WARNING: The provided USH_DIR ('{USH_DIR}') does not exist on the"
                        + f" current system.")
@@ -85,7 +78,6 @@ def check_PRUNE_DIR(PRUNE_DIR):
         sys.exit(f"The provided PRUNE_DIR ('{PRUNE_DIR}') is not a string."
                      + f"  PRUNE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(PRUNE_DIR).exists():
         print(f"WARNING: The provided PRUNE_DIR ('{PRUNE_DIR}') does not exist on the"
                        + f" current system.")
@@ -105,7 +97,6 @@ def check_SAVE_DIR(SAVE_DIR):
         sys.exit(f"The provided SAVE_DIR ('{SAVE_DIR}') is not a string."
                      + f"  SAVE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(SAVE_DIR).exists():
         print(f"WARNING: The provided SAVE_DIR ('{SAVE_DIR}') does not exist on the"
                        + f" current system.")
@@ -125,7 +116,6 @@ def check_OUTPUT_BASE_DIR(OUTPUT_BASE_DIR):
         sys.exit(f"The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') is not a string."
                      + f"  OUTPUT_BASE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(OUTPUT_BASE_DIR).exists():
         print(f"WARNING: The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') does not exist on the"
                        + f" current system.")
@@ -145,7 +135,6 @@ def check_LOG_METPLUS(LOG_METPLUS):
         sys.exit(f"The provided LOG_METPLUS ('{LOG_METPLUS}') is not a string."
                      + f"  LOG_METPLUS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not LOG_METPLUS:
         print(f"WARNING: The provided LOG_METPLUS is empty. The logger will be"
                        + f" the root logger of the hierarchy.")
@@ -160,7 +149,6 @@ def check_LOG_LEVEL(LOG_LEVEL):
         sys.exit(f"The provided LOG_LEVEL ('{LOG_LEVEL}') is not a string."
                      + f" LOG_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if str(LOG_LEVEL).upper() not in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]:
         print(f"WARNING: The provided LOG_LEVEL ('{LOG_LEVEL}') may not be"
                        + f" supported by the logger.  Consider using one of"
@@ -173,7 +161,6 @@ def check_LOG_LEVEL(LOG_LEVEL):
     if not LOG_LEVEL:
         sys.exit(f"The provided LOG_LEVEL is empty. LOG_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return LOG_LEVEL
 
 # MET_VERSION
@@ -185,12 +172,10 @@ def check_MET_VERSION(MET_VERSION):
         sys.exit(f"The provided MET_VERSION ('{MET_VERSION}') is not a string."
                      + f" MET_VERSION must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not re.search(r'^[1-9]\d*(\.\d+)?$', MET_VERSION):
         sys.exit(f"The provided MET_VERSION ('{MET_VERSION}') is not a"
                      + f" parseable number. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return MET_VERSION
 
 # MODEL
@@ -202,13 +187,11 @@ def check_MODEL(MODEL):
         sys.exit(f"The provided MODEL ('{MODEL}') is not a string."
                      + f" MODEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not re.search(r'(^[ A-Za-z0-9,\-_]+)$', MODEL):
         sys.exit(f"The provided MODEL ('{MODEL}') is not valid. MODEL may"
                      + f" contain letters, numbers, hyphens, underscores,"
                      + f" commas, and spaces only. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     return MODEL
 
 # DATE_TYPE
@@ -220,12 +203,10 @@ def check_DATE_TYPE(DATE_TYPE):
         sys.exit(f"The provided DATE_TYPE ('{DATE_TYPE}') is not a string."
                      + f" DATE_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if str(DATE_TYPE).upper() not in ['INIT', 'VALID']:
         sys.exit(f"You provided the following DATE_TYPE: '{DATE_TYPE}'."
                      + f" DATE_TYPE must be either 'INIT' or 'VALID'. Check"
                      + f" the plotting configuration file.")
-        #sys.exit(1)
     return DATE_TYPE
 
 
@@ -238,13 +219,11 @@ def check_EVAL_PERIOD(EVAL_PERIOD):
         sys.exit(f"The provided EVAL_PERIOD ('{EVAL_PERIOD}') is not a string."
                      + f" EVAL_PERIOD must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-\\]', EVAL_PERIOD):
         sys.exit(f"The provided EVAL_PERIOD string ('{EVAL_PERIOD}') contains"
                      + f" invalid characters. EVAL_PERIOD must be made of"
                      + f" alphanumeric characters, hyphen, and/or underscore."
                      + f" Check the plotting configuration file.")
-        #sys.exit(1)
     if EVAL_PERIOD=="TEST":
         print(f"Since the EVAL_PERIOD is set to 'TEST', will use a"
                     + f" custom INIT/VALID period.")
@@ -264,7 +243,6 @@ def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') is not a string."
                      + f" VALID_BEG must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "VALID" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -274,19 +252,16 @@ def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', VALID_BEG cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not VALID_BEG.isdigit():
             sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') contains"
                          + f" non-numeric characters. VALID_BEG may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(VALID_BEG) == 8:
             sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') is too short"
                          + f" or too long.  VALID_BEG must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return VALID_BEG
 
 
@@ -300,7 +275,6 @@ def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided VALID_END ('{VALID_END}') is not a string."
                      + f" VALID_END must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "VALID" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -310,19 +284,16 @@ def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', VALID_END cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not VALID_END.isdigit():
             sys.exit(f"The provided VALID_END ('{VALID_END}') contains"
                          + f" non-numeric characters. VALID_END may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(VALID_END) == 8:
             sys.exit(f"The provided VALID_END ('{VALID_END}') is too short"
                          + f" or too long.  VALID_END must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return VALID_END
 
 
@@ -335,7 +306,6 @@ def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') is not a string."
                      + f" INIT_BEG must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "INIT" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -345,19 +315,16 @@ def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', INIT_BEG cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not INIT_BEG.isdigit():
             sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') contains"
                          + f" non-numeric characters. INIT_BEG may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(INIT_BEG) == 8:
             sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') is too short"
                          + f" or too long.  INIT_BEG must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return INIT_BEG
 
 
@@ -370,7 +337,6 @@ def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided INIT_END ('{INIT_END}') is not a string."
                      + f" INIT_END must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "INIT" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -380,19 +346,16 @@ def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', INIT_END cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not INIT_END.isdigit():
             sys.exit(f"The provided INIT_END ('{INIT_END}') contains"
                          + f" non-numeric characters. INIT_END may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(INIT_END) == 8:
             sys.exit(f"The provided INIT_END ('{INIT_END}') is too short"
                          + f" or too long.  INIT_END must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return INIT_END
 
 # FCST_INIT_HOUR
@@ -404,7 +367,6 @@ def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
         sys.exit(f"The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is not a string."
                      + f" FCST_INIT_HOUR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if (str(DATE_TYPE).upper() == "INIT" 
             or str(plot_type).lower() == "valid_hour_average"):
         if not FCST_INIT_HOUR:
@@ -412,13 +374,11 @@ def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
                          + f" '{str(DATE_TYPE).upper()}' and plot type is"
                          + f" '{str(plot_type).lower()}', FCST_INIT_HOUR cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not re.search(r'(^[ 0-9,]+)$', FCST_INIT_HOUR):
             sys.exit(f"The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is"
                          + f" not valid. FCST_INIT_HOUR may contain numbers,"
                          + f" commas, and spaces only. Check the plotting"
                          + f" configuration file.")
-        #sys.exit(1)
     return FCST_INIT_HOUR
 
 # FCST_VALID_HOUR
@@ -430,7 +390,6 @@ def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
         sys.exit(f"The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is not a string."
                      + f" FCST_VALID_HOUR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if (str(DATE_TYPE).upper() == "VALID" 
             or str(plot_type).lower() == "valid_hour_average"):
         if not FCST_VALID_HOUR:
@@ -438,13 +397,11 @@ def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
                          + f" '{str(DATE_TYPE).upper()}' and plot type is"
                          + f" '{str(plot_type).lower()}', FCST_VALID_HOUR cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not re.search(r'(^[ 0-9,]+)$', FCST_VALID_HOUR):
             sys.exit(f"The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is"
                          + f" not valid. FCST_VALID_HOUR may contain numbers,"
                          + f" commas, and spaces only. Check the plotting"
                          + f" configuration file.")
-        #sys.exit(1)
     return FCST_VALID_HOUR
 
 # FCST_LEVEL
@@ -456,11 +413,9 @@ def check_FCST_LEVEL(FCST_LEVEL):
         sys.exit(f"The provided FCST_LEVEL ('{FCST_LEVEL}') is not a string."
                      + f" FCST_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not FCST_LEVEL:
         sys.exit(f"The provided FCST_LEVEL is empty. FCST_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return FCST_LEVEL
 
 # OBS_LEVEL
@@ -472,11 +427,9 @@ def check_OBS_LEVEL(OBS_LEVEL):
         sys.exit(f"The provided OBS_LEVEL ('{OBS_LEVEL}') is not a string."
                      + f" OBS_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not OBS_LEVEL:
         sys.exit(f"The provided OBS_LEVEL is empty. OBS_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return OBS_LEVEL
 
 # var_name
@@ -488,18 +441,15 @@ def check_var_name(var_name):
         sys.exit(f"The provided var_name ('{var_name}') is not a string."
                      + f" var_name must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not var_name:
         sys.exit(f"The provided var_name is empty. var_name cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', var_name):
         sys.exit(f"The provided var_name string ('{var_name}') contains"
                      + f" invalid characters. var_name must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return var_name
 
 # VX_MASK_LIST
@@ -511,18 +461,15 @@ def check_VX_MASK_LIST(VX_MASK_LIST):
         sys.exit(f"The provided VX_MASK_LIST ('{VX_MASK_LIST}') is not a string."
                      + f" VX_MASK_LIST must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not VX_MASK_LIST:
         sys.exit(f"The provided VX_MASK_LIST is empty. VX_MASK_LIST cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', VX_MASK_LIST):
         sys.exit(f"The provided VX_MASK_LIST string ('{VX_MASK_LIST}') contains"
                      + f" invalid characters. VX_MASK_LIST must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return VX_MASK_LIST
 
 # FCST_LEAD
@@ -534,17 +481,14 @@ def check_FCST_LEAD(FCST_LEAD):
         sys.exit(f"The provided FCST_LEAD ('{FCST_LEAD}') is not a string."
                      + f" FCST_LEAD must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not FCST_LEAD:
         sys.exit(f"The provided FCST_LEAD is empty. FCST_LEAD cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ 0-9,]', FCST_LEAD):
         sys.exit(f"The provided FCST_LEAD string ('{FCST_LEAD}') contains"
                      + f" invalid characters. FCST_LEAD must be made of"
                      + f" numerics, commas and/or spaces only. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     return FCST_LEAD
 
 # LINE_TYPE
@@ -556,17 +500,14 @@ def check_LINE_TYPE(LINE_TYPE):
         sys.exit(f"The provided LINE_TYPE ('{LINE_TYPE}') is not a string."
                      + f" LINE_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not LINE_TYPE:
         sys.exit(f"The provided LINE_TYPE is empty. LINE_TYPE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9]', LINE_TYPE):
         sys.exit(f"The provided LINE_TYPE string ('{LINE_TYPE}') contains"
                      + f" invalid characters. LINE_TYPE must be made of"
                      + f" alphanumeric characters only. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     return LINE_TYPE
 
 # INTERP
@@ -578,17 +519,14 @@ def check_INTERP(INTERP):
         sys.exit(f"The provided INTERP ('{INTERP}') is not a string."
                      + f" INTERP must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not INTERP:
         sys.exit(f"The provided INTERP is empty. INTERP cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-]', INTERP):
         sys.exit(f"The provided INTERP string ('{INTERP}') contains"
                      + f" invalid characters. INTERP must be made of"
                      + f" alphanumeric characters, hyphens, and/or underscores"
                      + f" only. Check the plotting configuration file.")
-        #sys.exit(1)
     return INTERP
 
 # FCST_THRESH
@@ -600,35 +538,30 @@ def check_FCST_THRESH(FCST_THRESH, LINE_TYPE):
         sys.exit(f"The provided FCST_THRESH ('{FCST_THRESH}') is not a"
                      + f" string. FCST_THRESH must be a string. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
         if not FCST_THRESH:
             sys.exit(f"The provided FCST_THRESH is empty. Since the"
                          + f" provided line type is '{LINE_TYPE}', FCST_THRESH"
                          + f" cannot be empty. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'[^A-Za-z0-9<>=.,! /-]', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}') contains"
                          + f" invalid characters. FCST_THRESH must be made of"
                          + f" alphanumeric characters, comparison operators,"
                          + f" periods, hyphens, commas and/or spaces only. Check the"
                          + f" plotting configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![<=!>]).)*$', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}')"
                          + f" does not contain a valid comparison operator"
                          + f" (<,>,<=,>=,!=,==). FCST_THRESH must contain a"
                          + f" valid comparison operator.  Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![0-9]).)*$', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}')"
                          + f" contains no numerics (digits 0-9). FCST_THRESH"
                          + f" must contain an integer or decimal in order to"
                          + f" be valid.  Check the plotting configuration"
                          + f" file.")
-            #sys.exit(1)
     return FCST_THRESH
 
 # OBS_THRESH
@@ -640,35 +573,30 @@ def check_OBS_THRESH(OBS_THRESH, FCST_THRESH, LINE_TYPE):
         sys.exit(f"The provided OBS_THRESH ('{OBS_THRESH}') is not a"
                      + f" string. OBS_THRESH must be a string. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
         if not OBS_THRESH:
             sys.exit(f"The provided OBS_THRESH is empty. Since the"
                          + f" provided line type is '{LINE_TYPE}', OBS_THRESH"
                          + f" cannot be empty. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'[^A-Za-z0-9<>=.,! /-]', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}') contains"
                          + f" invalid characters. OBS_THRESH must be made of"
                          + f" alphanumeric characters, comparison operators,"
                          + f" periods, hyphens, commas and/or spaces only. Check the"
                          + f" plotting configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![<=!>]).)*$', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}')"
                          + f" does not contain a valid comparison operator"
                          + f" (<,>,<=,>=,!=,==). OBS_THRESH must contain a"
                          + f" valid comparison operator.  Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![0-9]).)*$', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}')"
                          + f" contains no numerics (digits 0-9). OBS_THRESH"
                          + f" must contain an integer or decimal in order to"
                          + f" be valid.  Check the plotting configuration"
                          + f" file.")
-            #sys.exit(1)
         if (OBS_THRESH.replace(' ','') != FCST_THRESH.replace(' ','')
                 or len(re.split(r'[\s,]+', OBS_THRESH)) 
                 != len(re.split(r'[\s,]+', FCST_THRESH))):
@@ -686,18 +614,15 @@ def check_STATS(STATS):
         sys.exit(f"The provided STATS ('{STATS}') is not a string."
                      + f" STATS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not STATS:
         sys.exit(f"The provided STATS is empty. STATS cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', STATS):
         sys.exit(f"The provided STATS string ('{STATS}') contains"
                      + f" invalid characters. STATS must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return STATS
 
 # CONFIDENCE_INTERVALS
@@ -709,7 +634,6 @@ def check_CONFIDENCE_INTERVALS(CONFIDENCE_INTERVALS):
         sys.exit(f"The provided CONFIDENCE_INTERVALS ('{CONFIDENCE_INTERVALS}') is not a string."
                      + f" CONFIDENCE_INTERVALS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not CONFIDENCE_INTERVALS:
         print(f"WARNING: The provided CONFIDENCE_INTERVALS is empty."
                        + f" Confidence intervals will not be plotted. Set to"
@@ -725,11 +649,9 @@ def check_INTERP_PTS(INTERP_PTS):
         sys.exit(f"The provided INTERP_PTS ('{INTERP_PTS}') is not a string."
                      + f" INTERP_PTS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ 0-9,]', INTERP_PTS):
         sys.exit(f"The provided INTERP_PTS string ('{INTERP_PTS}') contains"
                      + f" invalid characters. INTERP_PTS must be made of"
                      + f" numerics, commas and/or spaces only. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     return INTERP_PTS

--- a/ush/mesoscale/ush_sref_plot_precip_py/check_variables.py
+++ b/ush/mesoscale/ush_sref_plot_precip_py/check_variables.py
@@ -15,11 +15,9 @@ def check_VERIF_CASE(VERIF_CASE):
         sys.exit(f"The provided VERIF_CASE ('{VERIF_CASE}') is not a string."
                      + f"  VERIF_CASE must be a string. Check the plotting"
                      + f" configuration file.")
-        ##sys.exit(1)
     if not VERIF_CASE:
         sys.exit(f"The provided VERIF_CASE is empty. VERIF_CASE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        ##sys.exit(1)
     return VERIF_CASE
 
 # VERIF_TYPE
@@ -31,11 +29,9 @@ def check_VERIF_TYPE(VERIF_TYPE):
         sys.exit(f"The provided VERIF_TYPE ('{VERIF_TYPE}') is not a string."
                      + f"  VERIF_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        ##sys.exit(1)
     if not VERIF_TYPE:
         sys.exit(f"The provided VERIF_TYPE is empty. VERIF_TYPE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        ##sys.exit(1)
     return VERIF_TYPE
 
 # URL_HEADER
@@ -47,13 +43,11 @@ def check_URL_HEADER(URL_HEADER):
         sys.exit(f"The provided URL_HEADER ('{URL_HEADER}') is not a string."
                      + f"  URL_HEADER must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-\\]', URL_HEADER):
         sys.exit(f"The provided URL_HEADER string ('{URL_HEADER}') contains"
                      + f" invalid characters. URL_HEADER must be made of"
                      + f" alphanumeric characters, hyphen, and/or underscore."
                      + f" Check the plotting configuration file.")
-        #sys.exit(1)
     return URL_HEADER
 
 # USH_DIR
@@ -65,7 +59,6 @@ def check_USH_DIR(USH_DIR):
         sys.exit(f"The provided USH_DIR ('{USH_DIR}') is not a string."
                      + f"  USH_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(USH_DIR).exists():
         print(f"WARNING: The provided USH_DIR ('{USH_DIR}') does not exist on the"
                        + f" current system.")
@@ -85,7 +78,6 @@ def check_PRUNE_DIR(PRUNE_DIR):
         sys.exit(f"The provided PRUNE_DIR ('{PRUNE_DIR}') is not a string."
                      + f"  PRUNE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(PRUNE_DIR).exists():
         print(f"WARNING: The provided PRUNE_DIR ('{PRUNE_DIR}') does not exist on the"
                        + f" current system.")
@@ -105,7 +97,6 @@ def check_SAVE_DIR(SAVE_DIR):
         sys.exit(f"The provided SAVE_DIR ('{SAVE_DIR}') is not a string."
                      + f"  SAVE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(SAVE_DIR).exists():
         print(f"WARNING: The provided SAVE_DIR ('{SAVE_DIR}') does not exist on the"
                        + f" current system.")
@@ -125,7 +116,6 @@ def check_OUTPUT_BASE_DIR(OUTPUT_BASE_DIR):
         sys.exit(f"The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') is not a string."
                      + f"  OUTPUT_BASE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(OUTPUT_BASE_DIR).exists():
         print(f"WARNING: The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') does not exist on the"
                        + f" current system.")
@@ -145,7 +135,6 @@ def check_LOG_METPLUS(LOG_METPLUS):
         sys.exit(f"The provided LOG_METPLUS ('{LOG_METPLUS}') is not a string."
                      + f"  LOG_METPLUS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not LOG_METPLUS:
         print(f"WARNING: The provided LOG_METPLUS is empty. The logger will be"
                        + f" the root logger of the hierarchy.")
@@ -160,7 +149,6 @@ def check_LOG_LEVEL(LOG_LEVEL):
         sys.exit(f"The provided LOG_LEVEL ('{LOG_LEVEL}') is not a string."
                      + f" LOG_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if str(LOG_LEVEL).upper() not in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]:
         print(f"WARNING: The provided LOG_LEVEL ('{LOG_LEVEL}') may not be"
                        + f" supported by the logger.  Consider using one of"
@@ -173,7 +161,6 @@ def check_LOG_LEVEL(LOG_LEVEL):
     if not LOG_LEVEL:
         sys.exit(f"The provided LOG_LEVEL is empty. LOG_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return LOG_LEVEL
 
 # MET_VERSION
@@ -185,12 +172,10 @@ def check_MET_VERSION(MET_VERSION):
         sys.exit(f"The provided MET_VERSION ('{MET_VERSION}') is not a string."
                      + f" MET_VERSION must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not re.search(r'^[1-9]\d*(\.\d+)?$', MET_VERSION):
         sys.exit(f"The provided MET_VERSION ('{MET_VERSION}') is not a"
                      + f" parseable number. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return MET_VERSION
 
 # MODEL
@@ -202,13 +187,11 @@ def check_MODEL(MODEL):
         sys.exit(f"The provided MODEL ('{MODEL}') is not a string."
                      + f" MODEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not re.search(r'(^[ A-Za-z0-9,\-_]+)$', MODEL):
         sys.exit(f"The provided MODEL ('{MODEL}') is not valid. MODEL may"
                      + f" contain letters, numbers, hyphens, underscores,"
                      + f" commas, and spaces only. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     return MODEL
 
 # DATE_TYPE
@@ -220,12 +203,10 @@ def check_DATE_TYPE(DATE_TYPE):
         sys.exit(f"The provided DATE_TYPE ('{DATE_TYPE}') is not a string."
                      + f" DATE_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if str(DATE_TYPE).upper() not in ['INIT', 'VALID']:
         sys.exit(f"You provided the following DATE_TYPE: '{DATE_TYPE}'."
                      + f" DATE_TYPE must be either 'INIT' or 'VALID'. Check"
                      + f" the plotting configuration file.")
-        #sys.exit(1)
     return DATE_TYPE
 
 
@@ -238,13 +219,11 @@ def check_EVAL_PERIOD(EVAL_PERIOD):
         sys.exit(f"The provided EVAL_PERIOD ('{EVAL_PERIOD}') is not a string."
                      + f" EVAL_PERIOD must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-\\]', EVAL_PERIOD):
         sys.exit(f"The provided EVAL_PERIOD string ('{EVAL_PERIOD}') contains"
                      + f" invalid characters. EVAL_PERIOD must be made of"
                      + f" alphanumeric characters, hyphen, and/or underscore."
                      + f" Check the plotting configuration file.")
-        #sys.exit(1)
     if EVAL_PERIOD=="TEST":
         print(f"Since the EVAL_PERIOD is set to 'TEST', will use a"
                     + f" custom INIT/VALID period.")
@@ -264,7 +243,6 @@ def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') is not a string."
                      + f" VALID_BEG must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "VALID" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -274,19 +252,16 @@ def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', VALID_BEG cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not VALID_BEG.isdigit():
             sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') contains"
                          + f" non-numeric characters. VALID_BEG may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(VALID_BEG) == 8:
             sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') is too short"
                          + f" or too long.  VALID_BEG must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return VALID_BEG
 
 
@@ -300,7 +275,6 @@ def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided VALID_END ('{VALID_END}') is not a string."
                      + f" VALID_END must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "VALID" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -310,19 +284,16 @@ def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', VALID_END cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not VALID_END.isdigit():
             sys.exit(f"The provided VALID_END ('{VALID_END}') contains"
                          + f" non-numeric characters. VALID_END may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(VALID_END) == 8:
             sys.exit(f"The provided VALID_END ('{VALID_END}') is too short"
                          + f" or too long.  VALID_END must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return VALID_END
 
 
@@ -335,7 +306,6 @@ def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') is not a string."
                      + f" INIT_BEG must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "INIT" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -345,19 +315,16 @@ def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', INIT_BEG cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not INIT_BEG.isdigit():
             sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') contains"
                          + f" non-numeric characters. INIT_BEG may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(INIT_BEG) == 8:
             sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') is too short"
                          + f" or too long.  INIT_BEG must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return INIT_BEG
 
 
@@ -370,7 +337,6 @@ def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided INIT_END ('{INIT_END}') is not a string."
                      + f" INIT_END must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "INIT" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -380,19 +346,16 @@ def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', INIT_END cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not INIT_END.isdigit():
             sys.exit(f"The provided INIT_END ('{INIT_END}') contains"
                          + f" non-numeric characters. INIT_END may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(INIT_END) == 8:
             sys.exit(f"The provided INIT_END ('{INIT_END}') is too short"
                          + f" or too long.  INIT_END must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return INIT_END
 
 # FCST_INIT_HOUR
@@ -404,7 +367,6 @@ def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
         sys.exit(f"The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is not a string."
                      + f" FCST_INIT_HOUR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if (str(DATE_TYPE).upper() == "INIT" 
             or str(plot_type).lower() == "valid_hour_average"):
         if not FCST_INIT_HOUR:
@@ -412,13 +374,11 @@ def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
                          + f" '{str(DATE_TYPE).upper()}' and plot type is"
                          + f" '{str(plot_type).lower()}', FCST_INIT_HOUR cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not re.search(r'(^[ 0-9,]+)$', FCST_INIT_HOUR):
             sys.exit(f"The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is"
                          + f" not valid. FCST_INIT_HOUR may contain numbers,"
                          + f" commas, and spaces only. Check the plotting"
                          + f" configuration file.")
-        #sys.exit(1)
     return FCST_INIT_HOUR
 
 # FCST_VALID_HOUR
@@ -430,7 +390,6 @@ def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
         sys.exit(f"The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is not a string."
                      + f" FCST_VALID_HOUR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if (str(DATE_TYPE).upper() == "VALID" 
             or str(plot_type).lower() == "valid_hour_average"):
         if not FCST_VALID_HOUR:
@@ -438,13 +397,11 @@ def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
                          + f" '{str(DATE_TYPE).upper()}' and plot type is"
                          + f" '{str(plot_type).lower()}', FCST_VALID_HOUR cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not re.search(r'(^[ 0-9,]+)$', FCST_VALID_HOUR):
             sys.exit(f"The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is"
                          + f" not valid. FCST_VALID_HOUR may contain numbers,"
                          + f" commas, and spaces only. Check the plotting"
                          + f" configuration file.")
-        #sys.exit(1)
     return FCST_VALID_HOUR
 
 # FCST_LEVEL
@@ -456,11 +413,9 @@ def check_FCST_LEVEL(FCST_LEVEL):
         sys.exit(f"The provided FCST_LEVEL ('{FCST_LEVEL}') is not a string."
                      + f" FCST_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not FCST_LEVEL:
         sys.exit(f"The provided FCST_LEVEL is empty. FCST_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return FCST_LEVEL
 
 # OBS_LEVEL
@@ -472,11 +427,9 @@ def check_OBS_LEVEL(OBS_LEVEL):
         sys.exit(f"The provided OBS_LEVEL ('{OBS_LEVEL}') is not a string."
                      + f" OBS_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not OBS_LEVEL:
         sys.exit(f"The provided OBS_LEVEL is empty. OBS_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return OBS_LEVEL
 
 # var_name
@@ -488,18 +441,15 @@ def check_var_name(var_name):
         sys.exit(f"The provided var_name ('{var_name}') is not a string."
                      + f" var_name must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not var_name:
         sys.exit(f"The provided var_name is empty. var_name cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', var_name):
         sys.exit(f"The provided var_name string ('{var_name}') contains"
                      + f" invalid characters. var_name must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return var_name
 
 # VX_MASK_LIST
@@ -511,18 +461,15 @@ def check_VX_MASK_LIST(VX_MASK_LIST):
         sys.exit(f"The provided VX_MASK_LIST ('{VX_MASK_LIST}') is not a string."
                      + f" VX_MASK_LIST must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not VX_MASK_LIST:
         sys.exit(f"The provided VX_MASK_LIST is empty. VX_MASK_LIST cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', VX_MASK_LIST):
         sys.exit(f"The provided VX_MASK_LIST string ('{VX_MASK_LIST}') contains"
                      + f" invalid characters. VX_MASK_LIST must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return VX_MASK_LIST
 
 # FCST_LEAD
@@ -534,17 +481,14 @@ def check_FCST_LEAD(FCST_LEAD):
         sys.exit(f"The provided FCST_LEAD ('{FCST_LEAD}') is not a string."
                      + f" FCST_LEAD must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not FCST_LEAD:
         sys.exit(f"The provided FCST_LEAD is empty. FCST_LEAD cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ 0-9,]', FCST_LEAD):
         sys.exit(f"The provided FCST_LEAD string ('{FCST_LEAD}') contains"
                      + f" invalid characters. FCST_LEAD must be made of"
                      + f" numerics, commas and/or spaces only. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     return FCST_LEAD
 
 # LINE_TYPE
@@ -556,17 +500,14 @@ def check_LINE_TYPE(LINE_TYPE):
         sys.exit(f"The provided LINE_TYPE ('{LINE_TYPE}') is not a string."
                      + f" LINE_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not LINE_TYPE:
         sys.exit(f"The provided LINE_TYPE is empty. LINE_TYPE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9]', LINE_TYPE):
         sys.exit(f"The provided LINE_TYPE string ('{LINE_TYPE}') contains"
                      + f" invalid characters. LINE_TYPE must be made of"
                      + f" alphanumeric characters only. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     return LINE_TYPE
 
 # INTERP
@@ -578,17 +519,14 @@ def check_INTERP(INTERP):
         sys.exit(f"The provided INTERP ('{INTERP}') is not a string."
                      + f" INTERP must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not INTERP:
         sys.exit(f"The provided INTERP is empty. INTERP cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-]', INTERP):
         sys.exit(f"The provided INTERP string ('{INTERP}') contains"
                      + f" invalid characters. INTERP must be made of"
                      + f" alphanumeric characters, hyphens, and/or underscores"
                      + f" only. Check the plotting configuration file.")
-        #sys.exit(1)
     return INTERP
 
 # FCST_THRESH
@@ -600,35 +538,30 @@ def check_FCST_THRESH(FCST_THRESH, LINE_TYPE):
         sys.exit(f"The provided FCST_THRESH ('{FCST_THRESH}') is not a"
                      + f" string. FCST_THRESH must be a string. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
         if not FCST_THRESH:
             sys.exit(f"The provided FCST_THRESH is empty. Since the"
                          + f" provided line type is '{LINE_TYPE}', FCST_THRESH"
                          + f" cannot be empty. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'[^A-Za-z0-9<>=.,! /-]', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}') contains"
                          + f" invalid characters. FCST_THRESH must be made of"
                          + f" alphanumeric characters, comparison operators,"
                          + f" periods, hyphens, commas and/or spaces only. Check the"
                          + f" plotting configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![<=!>]).)*$', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}')"
                          + f" does not contain a valid comparison operator"
                          + f" (<,>,<=,>=,!=,==). FCST_THRESH must contain a"
                          + f" valid comparison operator.  Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![0-9]).)*$', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}')"
                          + f" contains no numerics (digits 0-9). FCST_THRESH"
                          + f" must contain an integer or decimal in order to"
                          + f" be valid.  Check the plotting configuration"
                          + f" file.")
-            #sys.exit(1)
     return FCST_THRESH
 
 # OBS_THRESH
@@ -640,35 +573,30 @@ def check_OBS_THRESH(OBS_THRESH, FCST_THRESH, LINE_TYPE):
         sys.exit(f"The provided OBS_THRESH ('{OBS_THRESH}') is not a"
                      + f" string. OBS_THRESH must be a string. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
         if not OBS_THRESH:
             sys.exit(f"The provided OBS_THRESH is empty. Since the"
                          + f" provided line type is '{LINE_TYPE}', OBS_THRESH"
                          + f" cannot be empty. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'[^A-Za-z0-9<>=.,! /-]', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}') contains"
                          + f" invalid characters. OBS_THRESH must be made of"
                          + f" alphanumeric characters, comparison operators,"
                          + f" periods, hyphens, commas and/or spaces only. Check the"
                          + f" plotting configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![<=!>]).)*$', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}')"
                          + f" does not contain a valid comparison operator"
                          + f" (<,>,<=,>=,!=,==). OBS_THRESH must contain a"
                          + f" valid comparison operator.  Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![0-9]).)*$', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}')"
                          + f" contains no numerics (digits 0-9). OBS_THRESH"
                          + f" must contain an integer or decimal in order to"
                          + f" be valid.  Check the plotting configuration"
                          + f" file.")
-            #sys.exit(1)
         if (OBS_THRESH.replace(' ','') != FCST_THRESH.replace(' ','')
                 or len(re.split(r'[\s,]+', OBS_THRESH)) 
                 != len(re.split(r'[\s,]+', FCST_THRESH))):
@@ -686,18 +614,15 @@ def check_STATS(STATS):
         sys.exit(f"The provided STATS ('{STATS}') is not a string."
                      + f" STATS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not STATS:
         sys.exit(f"The provided STATS is empty. STATS cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', STATS):
         sys.exit(f"The provided STATS string ('{STATS}') contains"
                      + f" invalid characters. STATS must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return STATS
 
 # CONFIDENCE_INTERVALS
@@ -709,7 +634,6 @@ def check_CONFIDENCE_INTERVALS(CONFIDENCE_INTERVALS):
         sys.exit(f"The provided CONFIDENCE_INTERVALS ('{CONFIDENCE_INTERVALS}') is not a string."
                      + f" CONFIDENCE_INTERVALS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not CONFIDENCE_INTERVALS:
         print(f"WARNING: The provided CONFIDENCE_INTERVALS is empty."
                        + f" Confidence intervals will not be plotted. Set to"
@@ -725,11 +649,9 @@ def check_INTERP_PTS(INTERP_PTS):
         sys.exit(f"The provided INTERP_PTS ('{INTERP_PTS}') is not a string."
                      + f" INTERP_PTS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ 0-9,]', INTERP_PTS):
         sys.exit(f"The provided INTERP_PTS string ('{INTERP_PTS}') contains"
                      + f" invalid characters. INTERP_PTS must be made of"
                      + f" numerics, commas and/or spaces only. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     return INTERP_PTS

--- a/ush/mesoscale/ush_sref_plot_py/check_variables.py
+++ b/ush/mesoscale/ush_sref_plot_py/check_variables.py
@@ -15,11 +15,9 @@ def check_VERIF_CASE(VERIF_CASE):
         sys.exit(f"The provided VERIF_CASE ('{VERIF_CASE}') is not a string."
                      + f"  VERIF_CASE must be a string. Check the plotting"
                      + f" configuration file.")
-        ##sys.exit(1)
     if not VERIF_CASE:
         sys.exit(f"The provided VERIF_CASE is empty. VERIF_CASE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        ##sys.exit(1)
     return VERIF_CASE
 
 # VERIF_TYPE
@@ -31,11 +29,9 @@ def check_VERIF_TYPE(VERIF_TYPE):
         sys.exit(f"The provided VERIF_TYPE ('{VERIF_TYPE}') is not a string."
                      + f"  VERIF_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        ##sys.exit(1)
     if not VERIF_TYPE:
         sys.exit(f"The provided VERIF_TYPE is empty. VERIF_TYPE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        ##sys.exit(1)
     return VERIF_TYPE
 
 # URL_HEADER
@@ -47,13 +43,11 @@ def check_URL_HEADER(URL_HEADER):
         sys.exit(f"The provided URL_HEADER ('{URL_HEADER}') is not a string."
                      + f"  URL_HEADER must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-\\]', URL_HEADER):
         sys.exit(f"The provided URL_HEADER string ('{URL_HEADER}') contains"
                      + f" invalid characters. URL_HEADER must be made of"
                      + f" alphanumeric characters, hyphen, and/or underscore."
                      + f" Check the plotting configuration file.")
-        #sys.exit(1)
     return URL_HEADER
 
 # USH_DIR
@@ -65,7 +59,6 @@ def check_USH_DIR(USH_DIR):
         sys.exit(f"The provided USH_DIR ('{USH_DIR}') is not a string."
                      + f"  USH_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(USH_DIR).exists():
         print(f"WARNING: The provided USH_DIR ('{USH_DIR}') does not exist on the"
                        + f" current system.")
@@ -85,7 +78,6 @@ def check_PRUNE_DIR(PRUNE_DIR):
         sys.exit(f"The provided PRUNE_DIR ('{PRUNE_DIR}') is not a string."
                      + f"  PRUNE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(PRUNE_DIR).exists():
         print(f"WARNING: The provided PRUNE_DIR ('{PRUNE_DIR}') does not exist on the"
                        + f" current system.")
@@ -105,7 +97,6 @@ def check_SAVE_DIR(SAVE_DIR):
         sys.exit(f"The provided SAVE_DIR ('{SAVE_DIR}') is not a string."
                      + f"  SAVE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(SAVE_DIR).exists():
         print(f"WARNING: The provided SAVE_DIR ('{SAVE_DIR}') does not exist on the"
                        + f" current system.")
@@ -125,7 +116,6 @@ def check_OUTPUT_BASE_DIR(OUTPUT_BASE_DIR):
         sys.exit(f"The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') is not a string."
                      + f"  OUTPUT_BASE_DIR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not Path(OUTPUT_BASE_DIR).exists():
         print(f"WARNING: The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') does not exist on the"
                        + f" current system.")
@@ -145,7 +135,6 @@ def check_LOG_METPLUS(LOG_METPLUS):
         sys.exit(f"The provided LOG_METPLUS ('{LOG_METPLUS}') is not a string."
                      + f"  LOG_METPLUS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not LOG_METPLUS:
         print(f"WARNING: The provided LOG_METPLUS is empty. The logger will be"
                        + f" the root logger of the hierarchy.")
@@ -160,7 +149,6 @@ def check_LOG_LEVEL(LOG_LEVEL):
         sys.exit(f"The provided LOG_LEVEL ('{LOG_LEVEL}') is not a string."
                      + f" LOG_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if str(LOG_LEVEL).upper() not in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]:
         print(f"WARNING: The provided LOG_LEVEL ('{LOG_LEVEL}') may not be"
                        + f" supported by the logger.  Consider using one of"
@@ -173,7 +161,6 @@ def check_LOG_LEVEL(LOG_LEVEL):
     if not LOG_LEVEL:
         sys.exit(f"The provided LOG_LEVEL is empty. LOG_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return LOG_LEVEL
 
 # MET_VERSION
@@ -185,12 +172,10 @@ def check_MET_VERSION(MET_VERSION):
         sys.exit(f"The provided MET_VERSION ('{MET_VERSION}') is not a string."
                      + f" MET_VERSION must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not re.search(r'^[1-9]\d*(\.\d+)?$', MET_VERSION):
         sys.exit(f"The provided MET_VERSION ('{MET_VERSION}') is not a"
                      + f" parseable number. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return MET_VERSION
 
 # MODEL
@@ -202,13 +187,11 @@ def check_MODEL(MODEL):
         sys.exit(f"The provided MODEL ('{MODEL}') is not a string."
                      + f" MODEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not re.search(r'(^[ A-Za-z0-9,\-_]+)$', MODEL):
         sys.exit(f"The provided MODEL ('{MODEL}') is not valid. MODEL may"
                      + f" contain letters, numbers, hyphens, underscores,"
                      + f" commas, and spaces only. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     return MODEL
 
 # DATE_TYPE
@@ -220,12 +203,10 @@ def check_DATE_TYPE(DATE_TYPE):
         sys.exit(f"The provided DATE_TYPE ('{DATE_TYPE}') is not a string."
                      + f" DATE_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if str(DATE_TYPE).upper() not in ['INIT', 'VALID']:
         sys.exit(f"You provided the following DATE_TYPE: '{DATE_TYPE}'."
                      + f" DATE_TYPE must be either 'INIT' or 'VALID'. Check"
                      + f" the plotting configuration file.")
-        #sys.exit(1)
     return DATE_TYPE
 
 
@@ -238,13 +219,11 @@ def check_EVAL_PERIOD(EVAL_PERIOD):
         sys.exit(f"The provided EVAL_PERIOD ('{EVAL_PERIOD}') is not a string."
                      + f" EVAL_PERIOD must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-\\]', EVAL_PERIOD):
         sys.exit(f"The provided EVAL_PERIOD string ('{EVAL_PERIOD}') contains"
                      + f" invalid characters. EVAL_PERIOD must be made of"
                      + f" alphanumeric characters, hyphen, and/or underscore."
                      + f" Check the plotting configuration file.")
-        #sys.exit(1)
     if EVAL_PERIOD=="TEST":
         print(f"Since the EVAL_PERIOD is set to 'TEST', will use a"
                     + f" custom INIT/VALID period.")
@@ -264,7 +243,6 @@ def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') is not a string."
                      + f" VALID_BEG must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "VALID" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -274,19 +252,16 @@ def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', VALID_BEG cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not VALID_BEG.isdigit():
             sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') contains"
                          + f" non-numeric characters. VALID_BEG may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(VALID_BEG) == 8:
             sys.exit(f"The provided VALID_BEG ('{VALID_BEG}') is too short"
                          + f" or too long.  VALID_BEG must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return VALID_BEG
 
 
@@ -300,7 +275,6 @@ def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided VALID_END ('{VALID_END}') is not a string."
                      + f" VALID_END must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "VALID" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -310,19 +284,16 @@ def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', VALID_END cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not VALID_END.isdigit():
             sys.exit(f"The provided VALID_END ('{VALID_END}') contains"
                          + f" non-numeric characters. VALID_END may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(VALID_END) == 8:
             sys.exit(f"The provided VALID_END ('{VALID_END}') is too short"
                          + f" or too long.  VALID_END must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return VALID_END
 
 
@@ -335,7 +306,6 @@ def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') is not a string."
                      + f" INIT_BEG must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "INIT" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -345,19 +315,16 @@ def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', INIT_BEG cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not INIT_BEG.isdigit():
             sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') contains"
                          + f" non-numeric characters. INIT_BEG may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(INIT_BEG) == 8:
             sys.exit(f"The provided INIT_BEG ('{INIT_BEG}') is too short"
                          + f" or too long.  INIT_BEG must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return INIT_BEG
 
 
@@ -370,7 +337,6 @@ def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
         sys.exit(f"The provided INIT_END ('{INIT_END}') is not a string."
                      + f" INIT_END must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if ((str(DATE_TYPE).upper() == "INIT" 
                 or str(plot_type).lower() == "valid_hour_average")
             and EVAL_PERIOD == "TEST"):
@@ -380,19 +346,16 @@ def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
                          + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
                          + f" '{str(EVAL_PERIOD).upper()}', INIT_END cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not INIT_END.isdigit():
             sys.exit(f"The provided INIT_END ('{INIT_END}') contains"
                          + f" non-numeric characters. INIT_END may only"
                          + f" contain numeric characters. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if not len(INIT_END) == 8:
             sys.exit(f"The provided INIT_END ('{INIT_END}') is too short"
                          + f" or too long.  INIT_END must be a date"
                          + f" in the form of YYYYMMDD. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
     return INIT_END
 
 # FCST_INIT_HOUR
@@ -404,7 +367,6 @@ def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
         sys.exit(f"The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is not a string."
                      + f" FCST_INIT_HOUR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if (str(DATE_TYPE).upper() == "INIT" 
             or str(plot_type).lower() == "valid_hour_average"):
         if not FCST_INIT_HOUR:
@@ -412,13 +374,11 @@ def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
                          + f" '{str(DATE_TYPE).upper()}' and plot type is"
                          + f" '{str(plot_type).lower()}', FCST_INIT_HOUR cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not re.search(r'(^[ 0-9,]+)$', FCST_INIT_HOUR):
             sys.exit(f"The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is"
                          + f" not valid. FCST_INIT_HOUR may contain numbers,"
                          + f" commas, and spaces only. Check the plotting"
                          + f" configuration file.")
-        #sys.exit(1)
     return FCST_INIT_HOUR
 
 # FCST_VALID_HOUR
@@ -430,7 +390,6 @@ def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
         sys.exit(f"The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is not a string."
                      + f" FCST_VALID_HOUR must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if (str(DATE_TYPE).upper() == "VALID" 
             or str(plot_type).lower() == "valid_hour_average"):
         if not FCST_VALID_HOUR:
@@ -438,13 +397,11 @@ def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
                          + f" '{str(DATE_TYPE).upper()}' and plot type is"
                          + f" '{str(plot_type).lower()}', FCST_VALID_HOUR cannot be"
                          + f" empty. Check the plotting configuration file.")
-            #sys.exit(1)
         if not re.search(r'(^[ 0-9,]+)$', FCST_VALID_HOUR):
             sys.exit(f"The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is"
                          + f" not valid. FCST_VALID_HOUR may contain numbers,"
                          + f" commas, and spaces only. Check the plotting"
                          + f" configuration file.")
-        #sys.exit(1)
     return FCST_VALID_HOUR
 
 # FCST_LEVEL
@@ -456,11 +413,9 @@ def check_FCST_LEVEL(FCST_LEVEL):
         sys.exit(f"The provided FCST_LEVEL ('{FCST_LEVEL}') is not a string."
                      + f" FCST_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not FCST_LEVEL:
         sys.exit(f"The provided FCST_LEVEL is empty. FCST_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return FCST_LEVEL
 
 # OBS_LEVEL
@@ -472,11 +427,9 @@ def check_OBS_LEVEL(OBS_LEVEL):
         sys.exit(f"The provided OBS_LEVEL ('{OBS_LEVEL}') is not a string."
                      + f" OBS_LEVEL must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not OBS_LEVEL:
         sys.exit(f"The provided OBS_LEVEL is empty. OBS_LEVEL cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     return OBS_LEVEL
 
 # var_name
@@ -488,18 +441,15 @@ def check_var_name(var_name):
         sys.exit(f"The provided var_name ('{var_name}') is not a string."
                      + f" var_name must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not var_name:
         sys.exit(f"The provided var_name is empty. var_name cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', var_name):
         sys.exit(f"The provided var_name string ('{var_name}') contains"
                      + f" invalid characters. var_name must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return var_name
 
 # VX_MASK_LIST
@@ -511,18 +461,15 @@ def check_VX_MASK_LIST(VX_MASK_LIST):
         sys.exit(f"The provided VX_MASK_LIST ('{VX_MASK_LIST}') is not a string."
                      + f" VX_MASK_LIST must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not VX_MASK_LIST:
         sys.exit(f"The provided VX_MASK_LIST is empty. VX_MASK_LIST cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', VX_MASK_LIST):
         sys.exit(f"The provided VX_MASK_LIST string ('{VX_MASK_LIST}') contains"
                      + f" invalid characters. VX_MASK_LIST must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return VX_MASK_LIST
 
 # FCST_LEAD
@@ -534,17 +481,14 @@ def check_FCST_LEAD(FCST_LEAD):
         sys.exit(f"The provided FCST_LEAD ('{FCST_LEAD}') is not a string."
                      + f" FCST_LEAD must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not FCST_LEAD:
         sys.exit(f"The provided FCST_LEAD is empty. FCST_LEAD cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ 0-9,]', FCST_LEAD):
         sys.exit(f"The provided FCST_LEAD string ('{FCST_LEAD}') contains"
                      + f" invalid characters. FCST_LEAD must be made of"
                      + f" numerics, commas and/or spaces only. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     return FCST_LEAD
 
 # LINE_TYPE
@@ -556,17 +500,14 @@ def check_LINE_TYPE(LINE_TYPE):
         sys.exit(f"The provided LINE_TYPE ('{LINE_TYPE}') is not a string."
                      + f" LINE_TYPE must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not LINE_TYPE:
         sys.exit(f"The provided LINE_TYPE is empty. LINE_TYPE cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9]', LINE_TYPE):
         sys.exit(f"The provided LINE_TYPE string ('{LINE_TYPE}') contains"
                      + f" invalid characters. LINE_TYPE must be made of"
                      + f" alphanumeric characters only. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     return LINE_TYPE
 
 # INTERP
@@ -578,17 +519,14 @@ def check_INTERP(INTERP):
         sys.exit(f"The provided INTERP ('{INTERP}') is not a string."
                      + f" INTERP must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not INTERP:
         sys.exit(f"The provided INTERP is empty. INTERP cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^A-Za-z0-9_\-]', INTERP):
         sys.exit(f"The provided INTERP string ('{INTERP}') contains"
                      + f" invalid characters. INTERP must be made of"
                      + f" alphanumeric characters, hyphens, and/or underscores"
                      + f" only. Check the plotting configuration file.")
-        #sys.exit(1)
     return INTERP
 
 # FCST_THRESH
@@ -600,35 +538,30 @@ def check_FCST_THRESH(FCST_THRESH, LINE_TYPE):
         sys.exit(f"The provided FCST_THRESH ('{FCST_THRESH}') is not a"
                      + f" string. FCST_THRESH must be a string. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
         if not FCST_THRESH:
             sys.exit(f"The provided FCST_THRESH is empty. Since the"
                          + f" provided line type is '{LINE_TYPE}', FCST_THRESH"
                          + f" cannot be empty. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'[^A-Za-z0-9<>=.,! /-]', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}') contains"
                          + f" invalid characters. FCST_THRESH must be made of"
                          + f" alphanumeric characters, comparison operators,"
                          + f" periods, hyphens, commas and/or spaces only. Check the"
                          + f" plotting configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![<=!>]).)*$', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}')"
                          + f" does not contain a valid comparison operator"
                          + f" (<,>,<=,>=,!=,==). FCST_THRESH must contain a"
                          + f" valid comparison operator.  Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![0-9]).)*$', FCST_THRESH):
             sys.exit(f"The provided FCST_THRESH string ('{FCST_THRESH}')"
                          + f" contains no numerics (digits 0-9). FCST_THRESH"
                          + f" must contain an integer or decimal in order to"
                          + f" be valid.  Check the plotting configuration"
                          + f" file.")
-            #sys.exit(1)
     return FCST_THRESH
 
 # OBS_THRESH
@@ -640,35 +573,30 @@ def check_OBS_THRESH(OBS_THRESH, FCST_THRESH, LINE_TYPE):
         sys.exit(f"The provided OBS_THRESH ('{OBS_THRESH}') is not a"
                      + f" string. OBS_THRESH must be a string. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
         if not OBS_THRESH:
             sys.exit(f"The provided OBS_THRESH is empty. Since the"
                          + f" provided line type is '{LINE_TYPE}', OBS_THRESH"
                          + f" cannot be empty. Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'[^A-Za-z0-9<>=.,! /-]', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}') contains"
                          + f" invalid characters. OBS_THRESH must be made of"
                          + f" alphanumeric characters, comparison operators,"
                          + f" periods, hyphens, commas and/or spaces only. Check the"
                          + f" plotting configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![<=!>]).)*$', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}')"
                          + f" does not contain a valid comparison operator"
                          + f" (<,>,<=,>=,!=,==). OBS_THRESH must contain a"
                          + f" valid comparison operator.  Check the plotting"
                          + f" configuration file.")
-            #sys.exit(1)
         if re.search(r'^((?![0-9]).)*$', OBS_THRESH):
             sys.exit(f"The provided OBS_THRESH string ('{OBS_THRESH}')"
                          + f" contains no numerics (digits 0-9). OBS_THRESH"
                          + f" must contain an integer or decimal in order to"
                          + f" be valid.  Check the plotting configuration"
                          + f" file.")
-            #sys.exit(1)
         if (OBS_THRESH.replace(' ','') != FCST_THRESH.replace(' ','')
                 or len(re.split(r'[\s,]+', OBS_THRESH)) 
                 != len(re.split(r'[\s,]+', FCST_THRESH))):
@@ -686,18 +614,15 @@ def check_STATS(STATS):
         sys.exit(f"The provided STATS ('{STATS}') is not a string."
                      + f" STATS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not STATS:
         sys.exit(f"The provided STATS is empty. STATS cannot be"
                      + f" empty. Check the plotting configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ A-Za-z0-9,_\-]', STATS):
         sys.exit(f"The provided STATS string ('{STATS}') contains"
                      + f" invalid characters. STATS must be made of"
                      + f" alphanumeric characters, hyphen, underscore, commas"
                      + f" and/or spaces only. Check the plotting configuration"
                      + f" file.")
-        #sys.exit(1)
     return STATS
 
 # CONFIDENCE_INTERVALS
@@ -709,7 +634,6 @@ def check_CONFIDENCE_INTERVALS(CONFIDENCE_INTERVALS):
         sys.exit(f"The provided CONFIDENCE_INTERVALS ('{CONFIDENCE_INTERVALS}') is not a string."
                      + f" CONFIDENCE_INTERVALS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if not CONFIDENCE_INTERVALS:
         print(f"WARNING: The provided CONFIDENCE_INTERVALS is empty."
                        + f" Confidence intervals will not be plotted. Set to"
@@ -725,11 +649,9 @@ def check_INTERP_PTS(INTERP_PTS):
         sys.exit(f"The provided INTERP_PTS ('{INTERP_PTS}') is not a string."
                      + f" INTERP_PTS must be a string. Check the plotting"
                      + f" configuration file.")
-        #sys.exit(1)
     if re.search(r'[^ 0-9,]', INTERP_PTS):
         sys.exit(f"The provided INTERP_PTS string ('{INTERP_PTS}') contains"
                      + f" invalid characters. INTERP_PTS must be made of"
                      + f" numerics, commas and/or spaces only. Check the"
                      + f" plotting configuration file.")
-        #sys.exit(1)
     return INTERP_PTS


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
        This PR is to remove #sys.exit(1) in all check_variables.py scripts

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
  No
* Do you have any planned upcoming annual leave/PTO?
  No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? 
  No
  
- [y ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [y] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [y ] References the feature branch for `HOMEevs` are removed from the code.
- [y ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [y ] Jobs over 15 minutes in runtime have restart capability.
- [y ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [y ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [y ] Code is using METplus wrappers structure and not calling MET executables directly.
- [y ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

   Since only plotting py files were updated, only 6 plotting jobs are required to test (precip map spatial job is excluded). 

