### PR TITLE
Updated colors for hits/FAs to be colorblind-friendly

### DIFF
--- a/ush/hurricane/false_al.py
+++ b/ush/hurricane/false_al.py
@@ -91,10 +91,10 @@ if(domain == "atlantic"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
 
-    plt.scatter(346, 47,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
-    plt.annotate("False alarms ("+str(numhits)+")", (0,0), (286,185), xycoords='axes fraction', textcoords='offset points', va='top', color='Red', fontsize=6.5)
+    plt.scatter(346, 47,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.annotate("False alarms ("+str(numhits)+")", (0,0), (286,185), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"Atlantic TC Genesis False Alarms")
 

--- a/ush/hurricane/false_al.py
+++ b/ush/hurricane/false_al.py
@@ -91,9 +91,9 @@ if(domain == "atlantic"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
 
-    plt.scatter(346, 47,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.scatter(346, 47,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
     plt.annotate("False alarms ("+str(numhits)+")", (0,0), (286,185), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"Atlantic TC Genesis False Alarms")

--- a/ush/hurricane/false_ep.py
+++ b/ush/hurricane/false_ep.py
@@ -82,9 +82,9 @@ if(domain == "eastpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
 
-    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
     plt.annotate("False alarms ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"East Pacific TC Genesis False Alarms")

--- a/ush/hurricane/false_ep.py
+++ b/ush/hurricane/false_ep.py
@@ -82,10 +82,10 @@ if(domain == "eastpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
 
-    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
-    plt.annotate("False alarms ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='Red', fontsize=6.5)
+    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.annotate("False alarms ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"East Pacific TC Genesis False Alarms")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/false_wp.py
+++ b/ush/hurricane/false_wp.py
@@ -82,10 +82,10 @@ if(domain == "westpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
 
-    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
-    plt.annotate("False alarms ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='Red', fontsize=6.5)
+    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.annotate("False alarms ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"West Pacific TC Genesis False Alarms")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/false_wp.py
+++ b/ush/hurricane/false_wp.py
@@ -82,9 +82,9 @@ if(domain == "westpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
 
-    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
     plt.annotate("False alarms ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"West Pacific TC Genesis False Alarms")

--- a/ush/hurricane/hits_al.py
+++ b/ush/hurricane/hits_al.py
@@ -91,10 +91,10 @@ if(domain == "atlantic"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
 
-    plt.scatter(346, 47,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
-    plt.annotate("Hits ("+str(numhits)+")", (0,0), (286,185), xycoords='axes fraction', textcoords='offset points', va='top', color='Green', fontsize=6.5)
+    plt.scatter(346, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
+    plt.annotate("Hits ("+str(numhits)+")", (0,0), (286,185), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
 
 #    plt.title(f"Atlantic TC Genesis Hits")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/hits_ep.py
+++ b/ush/hurricane/hits_ep.py
@@ -82,10 +82,10 @@ if(domain == "eastpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
 
-    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')      
-    plt.annotate("Hits ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='Green', fontsize=6.5)    
+    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')      
+    plt.annotate("Hits ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)    
 
 #    plt.title(f"East Pacific TC Genesis Hits")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/hits_wp.py
+++ b/ush/hurricane/hits_wp.py
@@ -82,10 +82,10 @@ if(domain == "westpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
 
-    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
-    plt.annotate("Hits ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='Green', fontsize=6.5)
+    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
+    plt.annotate("Hits ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
 
 #    plt.title(f"West Pacific TC Genesis Hits")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/tcgen_space_al.py
+++ b/ush/hurricane/tcgen_space_al.py
@@ -86,7 +86,7 @@ if(domain == "atlantic"):
     for i in range(len(hits)):
       lat  = float(hits[i,31])
       lon  = float(hits[i,32]) + 360.
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
 
     falsefile = os.environ['falsefile']
     fals  = np.loadtxt(falsefile,dtype=str)
@@ -96,12 +96,12 @@ if(domain == "atlantic"):
     for i in range(len(fals)):
       lat1  = float(fals[i,31])
       lon1  = float(fals[i,32]) + 360.
-      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
+      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
 
-    plt.scatter(346, 47.5,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')   
-    plt.scatter(346, 45,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
-    plt.annotate("Hits ("+str(numhits)+")", (0,0), (286,186), xycoords='axes fraction', textcoords='offset points', va='top', color='Green', fontsize=6.5)
-    plt.annotate("False alarms ("+str(numfals)+")", (0,0), (286,177), xycoords='axes fraction', textcoords='offset points', va='top', color='Red', fontsize=6.5)
+    plt.scatter(346, 47.5,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')   
+    plt.scatter(346, 45,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.annotate("Hits ("+str(numhits)+")", (0,0), (286,186), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
+    plt.annotate("False alarms ("+str(numfals)+")", (0,0), (286,177), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
     TCGENdays = os.environ['TCGENdays']
     modelname = os.environ['modelname']

--- a/ush/hurricane/tcgen_space_al.py
+++ b/ush/hurricane/tcgen_space_al.py
@@ -96,10 +96,10 @@ if(domain == "atlantic"):
     for i in range(len(fals)):
       lat1  = float(fals[i,31])
       lon1  = float(fals[i,32]) + 360.
-      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
 
     plt.scatter(346, 47.5,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')   
-    plt.scatter(346, 45,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.scatter(346, 45,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
     plt.annotate("Hits ("+str(numhits)+")", (0,0), (286,186), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
     plt.annotate("False alarms ("+str(numfals)+")", (0,0), (286,177), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 

--- a/ush/hurricane/tcgen_space_ep.py
+++ b/ush/hurricane/tcgen_space_ep.py
@@ -92,10 +92,10 @@ if(domain == "eastpac"):
     for i in range(len(fals)):
       lat1  = float(fals[i,31])
       lon1  = float(fals[i,32]) + 360.
-      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
 
     plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
-    plt.scatter(185, 45,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.scatter(185, 45,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
     plt.annotate("Hits ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
     plt.annotate("False alarms ("+str(numfals)+")", (0,0), (20,160), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 

--- a/ush/hurricane/tcgen_space_ep.py
+++ b/ush/hurricane/tcgen_space_ep.py
@@ -82,7 +82,7 @@ if(domain == "eastpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
 
     falsefile = os.environ['falsefile']
     fals  = np.loadtxt(falsefile,dtype=str)
@@ -92,12 +92,12 @@ if(domain == "eastpac"):
     for i in range(len(fals)):
       lat1  = float(fals[i,31])
       lon1  = float(fals[i,32]) + 360.
-      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
+      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
 
-    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
-    plt.scatter(185, 45,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
-    plt.annotate("Hits ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='Green', fontsize=6.5)
-    plt.annotate("False alarms ("+str(numfals)+")", (0,0), (20,160), xycoords='axes fraction', textcoords='offset points', va='top', color='Red', fontsize=6.5)
+    plt.scatter(185, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
+    plt.scatter(185, 45,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.annotate("Hits ("+str(numhits)+")", (0,0), (20,168), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
+    plt.annotate("False alarms ("+str(numfals)+")", (0,0), (20,160), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"East Pacific TC Genesis Hits")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/tcgen_space_wp.py
+++ b/ush/hurricane/tcgen_space_wp.py
@@ -82,7 +82,7 @@ if(domain == "westpac"):
       lon  = float(hits[i,32]) + 360.
       print(lat)
       print(lon)
-      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
+      plt.scatter(lon, lat,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
 
     falsefile = os.environ['falsefile']
     fals  = np.loadtxt(falsefile,dtype=str)
@@ -92,12 +92,12 @@ if(domain == "westpac"):
     for i in range(len(fals)):
       lat1  = float(fals[i,31])
       lon1  = float(fals[i,32]) + 360.
-      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
+      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
 
-    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='o', color='green',s=12, facecolor='none')
-    plt.scatter(160, 45.5,transform=ccrs.PlateCarree(), marker='s', color='red',s=12, facecolor='none')
-    plt.annotate("Hits ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='Green', fontsize=6.5)
-    plt.annotate("False alarms ("+str(numfals)+")", (0,0), (272,221), xycoords='axes fraction', textcoords='offset points', va='top', color='Red', fontsize=6.5)
+    plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
+    plt.scatter(160, 45.5,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.annotate("Hits ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
+    plt.annotate("False alarms ("+str(numfals)+")", (0,0), (272,221), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 
 #    plt.title(f"West Pacific TC Genesis Hits")
     TCGENdays = os.environ['TCGENdays']

--- a/ush/hurricane/tcgen_space_wp.py
+++ b/ush/hurricane/tcgen_space_wp.py
@@ -92,10 +92,10 @@ if(domain == "westpac"):
     for i in range(len(fals)):
       lat1  = float(fals[i,31])
       lon1  = float(fals[i,32]) + 360.
-      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+      plt.scatter(lon1, lat1,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
 
     plt.scatter(160, 47,transform=ccrs.PlateCarree(), marker='o', color='#2489FE',s=12, facecolor='none')
-    plt.scatter(160, 45.5,transform=ccrs.PlateCarree(), marker='s', color='#B42221',s=12, facecolor='none')
+    plt.scatter(160, 45.5,transform=ccrs.PlateCarree(), marker='x', color='#B42221',s=12)
     plt.annotate("Hits ("+str(numhits)+")", (0,0), (272,230), xycoords='axes fraction', textcoords='offset points', va='top', color='#2489FE', fontsize=6.5)
     plt.annotate("False alarms ("+str(numfals)+")", (0,0), (272,221), xycoords='axes fraction', textcoords='offset points', va='top', color='#B42221', fontsize=6.5)
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
The colors used for hits and false alarms have been changed to account for any colorblind viewers. Hits have been changed from green to blue, and false alarms have been changed from a bright red to a crimson red. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No.
* Do you have any planned upcoming annual leave/PTO? No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
1. Copy branch in local EVS workspace
2. Set $USER to olivia.ostwald OR copy data to your noscrub space:
    Data path: /lfs/h2/emc/vpppg/noscrub/olivia.ostwald/evs_tc_2024
3. Run for stats:
**jevs_hurricane_global_det_tcgen_stats.sh**
4. Once stats are complete, run for plots:
**jevs_hurricane_global_det_tcgen_plots.sh**




> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
