### PR TITLE
Fix mesoscale grid2obs stats 

### DIFF
--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -36,7 +36,7 @@ set -x
   export evs_run_mode="production"
 
 # EVS Settings
-  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS_mesoscale_grid2obs_fix/EVS
+  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 
 # EVS configuration
@@ -55,7 +55,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 
 # Developer Settings
-  export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
+  export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=01:00:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 
@@ -36,7 +36,7 @@ set -x
   export evs_run_mode="production"
 
 # EVS Settings
-  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS_mesoscale_grid2obs_fix/EVS
 
 
 # EVS configuration
@@ -55,7 +55,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 
 # Developer Settings
-  export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+  export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=01:30:00
+#PBS -l walltime=01:00:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 
@@ -36,7 +36,7 @@ set -x
   export evs_run_mode="production"
 
 # EVS Settings
-  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS_mesoscale_grid2obs_fix/EVS
 
 
 # EVS configuration
@@ -55,7 +55,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 
 # Developer Settings
-  export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+  export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -36,7 +36,7 @@ set -x
   export evs_run_mode="production"
 
 # EVS Settings
-  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS_mesoscale_grid2obs_fix/EVS
+  export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 
 
 # EVS configuration
@@ -55,7 +55,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 
 # Developer Settings
-  export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
+  export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:00:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:30:00
+#PBS -l walltime=01:00:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 

--- a/ush/mesoscale/mesoscale_create_output_dirs.py
+++ b/ush/mesoscale/mesoscale_create_output_dirs.py
@@ -16,11 +16,12 @@
 import os
 import re
 from datetime import datetime, timedelta as td
-from mesoscale_plots_grid2obs_graphx_defs import graphics as graphics_g2o
-from mesoscale_plots_precip_graphx_defs import graphics as graphics_pcp
-from mesoscale_plots_headline_graphx_defs import graphics as graphics_hdl
-from mesoscale_plots_snowfall_graphx_defs import graphics as graphics_sno
 import mesoscale_util as cutil
+if os.environ['STEP'] == 'plots':
+    from mesoscale_plots_grid2obs_graphx_defs import graphics as graphics_g2o
+    from mesoscale_plots_precip_graphx_defs import graphics as graphics_pcp
+    from mesoscale_plots_headline_graphx_defs import graphics as graphics_hdl
+    from mesoscale_plots_snowfall_graphx_defs import graphics as graphics_sno
 
 print(f"BEGIN: {os.path.basename(__file__)}")
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Changes that were made for PR #728 inadvertently affected the grid2obs stats jobs because updates made to one of the ush subroutines (mesoscale_create_output_dirs.py) for the mesoscale plots is also used by the stats as well.  This change ensures that the plots changes are referenced only when the the plots jobs are run and not when the stats jobs are run.  

Should be noted that the precip and snowfall stats routines are not affected because those jobs do not use this specific subroutine.  Only grid2obs stats are affected.  For plots, all mesoscale plot jobs use the create output dirs script.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Somewhat.  Mesoscale grid2obs stats are not being produced right now in the parallel. 

* Do you have any planned upcoming annual leave/PTO?

June 20 and 23.

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout bugfix/mesoscale_grid2obs_fix
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/stats/mesoscale
5. In the jevs_mesoscale_nam_grid2obs_stats.sh and jevs_mesoscale_rap_grid2obs_stats.sh scripts, set HOMEevs to your testing directory and COMIN to emc.vpppg.
6. Submit the jobs using qsub -v vhr=07
7. cd dev/drivers/scripts/plots/mesoscale
8. In all mesoscale det last31days jobs, as well as jevs_mesoscale_headline_plots.sh, set HOMEevs to your testing directory and COMIN to emc.vpppg.
9. Submit the following:

qsub -v vhr=01 jevs_mesoscale_grid2obs_plots_last31days.sh
qsub -v vhr=01 jevs_mesoscale_headline_plots.sh
qsub -v vhr=13 jevs_mesoscale_precip_plots_last31days.sh
qsub -v vhr=13 jevs_mesoscale_snowfall_plots_last31days.sh

It is probably not necessary to run the last90days plot jobs.  In order to expedite the PR, the last31days jobs should suffice.  If the job gets past the mesoscale_create_output_dirs.py in the script, the rest of the job should work normally.  
