### PR TITLE
Feature/href add checking files before run metplus

### DIFF
--- a/ush/cam/evs_href_prepare.sh
+++ b/ush/cam/evs_href_prepare.sh
@@ -263,7 +263,25 @@ if [ "$data" = "apcp24h_conus" ] ; then
       export modelpath=${COMHREF}/href.${fyyyymmdd}/ensprod
       export prod 
 
-      for prod in mean avrg pmmn lpmm ; do
+      typeset -Z2 fhr_3
+      typeset -Z2 fhr_6
+      typeset -Z2 fhr_9
+      typeset -Z2 fhr_12
+      typeset -Z2 fhr_15
+      typeset -Z2 fhr_18
+      typeset -Z2 fhr_21
+      fhr_3=$((fhr-3))
+      fhr_6=$((fhr-6))
+      fhr_9=$((fhr-9))
+      fhr_12=$((fhr-12))
+      fhr_15=$((fhr-15))
+      fhr_18=$((fhr-18))
+      fhr_21=$((fhr-21))
+
+     for prod in mean avrg pmmn lpmm ; do
+
+      if [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_3}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_6}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_9}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_12}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_15}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_18}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.conus.${prod}.f${fhr_21}.grib2 ] ; then
+
 
       #####################################################################################################################
       # Restart: first check if href.${fyyyymmdd}/href${prod}.t${fcyc}z.G227.24h.f${fhr}.nc exists 
@@ -292,7 +310,9 @@ if [ "$data" = "apcp24h_conus" ] ; then
          fi
        fi
 
-      done
+      fi
+
+     done
    done
 fi
 
@@ -321,7 +341,25 @@ if [ "$data" = "apcp24h_alaska" ] ; then
       export modelpath=${COMHREF}/href.${fyyyymmdd}/ensprod
       export prod
 
-      for prod in mean avrg pmmn lpmm ; do
+      typeset -Z2 fhr_3
+      typeset -Z2 fhr_6
+      typeset -Z2 fhr_9
+      typeset -Z2 fhr_12
+      typeset -Z2 fhr_15
+      typeset -Z2 fhr_18
+      typeset -Z2 fhr_21
+      fhr_3=$((fhr-3))
+      fhr_6=$((fhr-6))
+      fhr_9=$((fhr-9))
+      fhr_12=$((fhr-12))
+      fhr_15=$((fhr-15))
+      fhr_18=$((fhr-18))
+      fhr_21=$((fhr-21))
+
+    for prod in mean avrg pmmn lpmm ; do
+
+     if [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_3}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_6}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_9}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_12}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_15}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_18}.grib2 ] && [ -s $modelpath/href.t${fcyc}z.ak.${prod}.f${fhr_21}.grib2 ] ; then
+
       #################################################################################################
       # Restart: first check if href.${fyyyymmdd}/href${prod}.t${fcyc}z.G227.24h.f${fhr}.nc exists
       #    in the $COMOUTrestart directory, if not, run METplus to create it
@@ -342,7 +380,10 @@ if [ "$data" = "apcp24h_alaska" ] ; then
 	 [[ ! -d $WORK/href.${fyyyymmdd} ]] && mkdir -p $WORK/href.${fyyyymmdd}
          cp  $COMOUTrestart/prepare/href${prod}.${fyyyymmdd}.t${fcyc}z.G255.24h.f${fhr}.nc $WORK/href.${fyyyymmdd}/href${prod}.t${fcyc}z.G255.24h.f${fhr}.nc
        fi
-      done
+
+      fi
+ 
+    done
    done
 fi
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

   Add checking ensemble files existence before running METplus/PcpCombine in the ush/cam/evs_href_prepare.sh  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
   No
* Do you have any planned upcoming annual leave/PTO? 
   No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? 
   No
  
- [y ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [y ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [y ] References the feature branch for `HOMEevs` are removed from the code.
- [y ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [y ] Jobs over 15 minutes in runtime have restart capability.
- [y ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [y ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [y ] Code is using METplus wrappers structure and not calling MET executables directly.
- [y ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions 
> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests. 

  Only the precip stat generation job should be tested, including its restart job testing 
 
