### PR TITLE
Fix issue with let command in rtma precip analysis stats job

### DIFF
--- a/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
@@ -47,7 +47,6 @@ then
 	fi
 
 	DATE=${VDATE}${vhr}
-        let "vhrp1=vhr+1"
 	ENDDATE=`$NDATE -23 $DATE`
         while [ $DATE -ge $ENDDATE ]; do
         echo $DATE > curdate


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

There is an issue on the Fixes and Additions document that says that there is an error caused by the let command that looks like this:

`let: 08: value too great for base (error token is "08")`

This needs to be corrected.  However, it turns out that the line that caused this statement is not actually needed by the verification as vhrp1 is not used anywhere else in the script.  The line does not exist in the urma or rtma verification scripts also.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No.


* Do you have any planned upcoming annual leave/PTO?

Friday, June 20 and Monday, June 23

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS, git checkout bugfix/analyses_let_issue
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/stats/analyses
5. In the script jevs_analyses_rtma_precip_stats.sh, set HOMEevs to your testing directory, COMIN to emc.vpppg.
6. Run the script using qsub -v vhr=08 and qsub -v vhr=09.  You may continue to run for hours after that up to qsub -v vhr=14.  Data should look unchanged from emc.vpppg (you need to look in the small stats directory evs/v2.0/stats/analyses/atmos.YYYYMMDD/rtma/precip).  
