### PR TITLE
Bugfix/increase memory

### DIFF
--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=04:35:00
+#PBS -l walltime=04:05:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=02:50:00
+#PBS -l walltime=02:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_hrrr_precip_stats.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=02:30:00
+#PBS -l walltime=02:40:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/stats/cam/jevs_cam_namnest_precip_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_namnest_precip_stats.sh
@@ -5,7 +5,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:20:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=200GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=210GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_hrrr_grid2obs_stats_vhr_master.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=04:35:00
+#PBS -l walltime=04:05:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/cam/jevs_cam_hrrr_precip_stats_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_hrrr_precip_stats_vhr_master.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:30:00
+#PBS -l walltime=02:40:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/cam/jevs_cam_hrrr_precip_stats_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_hrrr_precip_stats_vhr_master.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:50:00
+#PBS -l walltime=02:30:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=256GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/cam/jevs_cam_namnest_precip_stats_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_cam_namnest_precip_stats_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:20:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=200GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=210GB
 #PBS -l debug=true
 
 export model=evs


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR includes the following bugfixes:
- _Bugfix:_ jevs_cam_namnest_precip_stats has exceeded its memory limit in the past.  While there have been no recent memory exceedences, the memory limit has been increased to leave room for special situations (production switches, slow machine).  _Fix outcome:_ jevs_cam_namnest_precip_stats uses recommended memory settings.
- _Bugfix:_ Two hrrr stats job wallclock times are slightly too long.  Reduced the wallclock times based on recent runtimes. _Fix outcome:_ Maintain recommended settings for all EVS-cam wallclock times.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No
* Do you have any planned upcoming annual leave/PTO?

Yes, July 10 - August 16 2025
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### Running jobs

I recommend testing the following jobs:
```
jevs_cam_hrrr_grid2obs_stats
jevs_cam_hrrr_precip_stats
jevs_cam_namnest_precip_stats
```

[Total: 3 stats jobs]

#### Testing jobs

- **Precip jobs**: submit using `qsub -v vhr=21 $driver`
- **Grid2obs job**: submit using `qsub -v vhr=00 $driver`

#### Checking jobs
- Log files should be checked by the developer for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```