### PR TITLE
NAM and RAP stats fix for restart for ptype

### DIFF
--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -441,10 +441,10 @@ elif STEP == 'stats':
               )
             completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
             job_cmd_list_iterative.append(
-               "python -c "
+               f"if [ $FHR == $FHR_END ]; then python -c "
                + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-               + f"\"job{njob}\", job_type=\"{job_type}\")'"
+               + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
             )
             completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
             completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
@@ -543,10 +543,10 @@ elif STEP == 'stats':
                    )
 
             else:
-                pstat_file_exist = cutil.check_pstat_files(job_env_vars_dict)
-                if pstat_file_exist:
-                    print(f"skip this run, pstat already exist")
-                else:
+#                pstat_file_exist = cutil.check_pstat_files(job_env_vars_dict)
+#                if pstat_file_exist:
+#                    print(f"skip this run, pstat already exist")
+#                else:
                   completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
                   if f'{job_type}_job{njob}' in cutil.get_completed_jobs(os.path.join(RESTART_DIR, "completed_jobs", completed_jobs_file_full)):
                       pass
@@ -578,10 +578,10 @@ elif STEP == 'stats':
                      )
                    completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
                    job_cmd_list_iterative.append(
-                       "python -c "
+                       f"if [ $FHR == $FHR_END ]; then python -c "
                        + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                        + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-                       + f"\"job{njob}\", job_type=\"{job_type}\")'"
+                       + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
                    )
                    completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
                    completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")

--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -441,10 +441,10 @@ elif STEP == 'stats':
               )
             completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
             job_cmd_list_iterative.append(
-               f"if [ $FHR == $FHR_END ]; then python -c "
+               "python -c "
                + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-               + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
+               + f"\"job{njob}\", job_type=\"{job_type}\")'"
             )
             completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
             completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
@@ -578,10 +578,10 @@ elif STEP == 'stats':
                      )
                    completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
                    job_cmd_list_iterative.append(
-                       f"if [ $FHR == $FHR_END ]; then python -c "
+                       "python -c "
                        + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                        + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-                       + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
+                       + f"\"job{njob}\", job_type=\"{job_type}\")'"
                    )
                    completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
                    completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")

--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -543,10 +543,6 @@ elif STEP == 'stats':
                    )
 
             else:
-#                pstat_file_exist = cutil.check_pstat_files(job_env_vars_dict)
-#                if pstat_file_exist:
-#                    print(f"skip this run, pstat already exist")
-#                else:
                   completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
                   if f'{job_type}_job{njob}' in cutil.get_completed_jobs(os.path.join(RESTART_DIR, "completed_jobs", completed_jobs_file_full)):
                       pass

--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -531,10 +531,10 @@ elif STEP == 'stats':
                       )
                    completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
                    job_cmd_list_iterative.append(
-                       "python -c "
+                       f"if [ $FHR == $FHR_END ]; then python -c "
                        + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                        + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-                       + f"\"job{njob}\", job_type=\"{job_type}\")'"
+                       + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
                    )
                    completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
                    completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In the previous PR (769) to refine the restart for mesoscale plot jobs, mesoscale stats jobs were also run as a sanity check due to one of the ush scripts being used for both stats and plots.  It was revealed that when restart stats were tested, the final restart stats file was not identical to the final stats file for an uninterrupted job, and the difference was in the ptype statistics.  

Like other variables, metplus was run a number of times for variables for several different forecast hours each forecast time.  But for ptype, a completed jobs file was written after EACH metplus job, rather than after ALL the metplus jobs were complete.  Thus, because in the interrupt jobs, the interrupt was actually in the middle of ptype processing.  However, since a completed jobs file had already been written, that meant that in the restart, the code saw the completed jobs file and thus skipped ptype, since the code thought it was already finished.  This resulted in several incidences of unprocessed ptype data and thus the final stats file was missing data.  This happened both in NAM and RAP ptype output.  This PR fixes the processing by writing the completed jobs file ONLY when the ptype processing had been completed for a certain valid time.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28-August 1

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS, git checkout bugfix/mesoscale_rap_ptype_restart
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/stats/mesoscale
5. In the scripts jevs_mesoscale_nam_grid2obs_stats.sh and jevs_mesoscale_rap_grid2obs_stats.sh, set HOMEevs to your testing directory, and COMIN to point to emc.vpppg.
6. Run full uninterrupted jobs to get a baseline.  Save all this data.
7. Run the restart jobs.  Set the interrupt time to 13 minutes for each the NAM and RAP interrupt jobs.  Set to regular wallclock time for the restart.  We'll compare the final timing and the final restart stats file to the uninterrupted jobs.  
