### PR TITLE
Removing "not" from mesoscale plot job output

### DIFF
--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -96,7 +96,8 @@ if [ $ncount_job -gt 0 ]; then
 fi
 
 # Tar and Copy output files to EVS COMOUT directory
-  find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##'  -T -
+##  find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##'  -T -
+tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/cape/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/ceil_vis/${EVAL_PERIOD}/*.png --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -96,7 +96,6 @@ if [ $ncount_job -gt 0 ]; then
 fi
 
 # Tar and Copy output files to EVS COMOUT directory
-##  find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##'  -T -
 tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/cape/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/ceil_vis/${EVAL_PERIOD}/*.png --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then

--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -96,7 +96,7 @@ if [ $ncount_job -gt 0 ]; then
 fi
 
 # Tar and Copy output files to EVS COMOUT directory
-tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/cape/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/ceil_vis/${EVAL_PERIOD}/*.png --transform='s#.*/##'  -T -
+tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/*.png ${DATA}/${VERIF_CASE}/out/cape/*.png ${DATA}/${VERIF_CASE}/out/ceil_vis/*.png --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_grid2obs_plots.sh
@@ -68,8 +68,6 @@ if [ $USE_CFP = YES ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
 	    launcher="mpiexec -np ${nnp} -ppn ${nproc} -depth 2 --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
-	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
@@ -90,7 +90,6 @@ for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
 done
 
 # Tar and Copy output files to EVS COMOUT directory
-#   find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
     tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then

--- a/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
@@ -90,7 +90,8 @@ for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
 done
 
 # Tar and Copy output files to EVS COMOUT directory
-   find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
+#   find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
+    tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
@@ -90,7 +90,7 @@ for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
 done
 
 # Tar and Copy output files to EVS COMOUT directory
-    tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
+    tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar  ${DATA}/${VERIF_CASE}/out/sfc_upper/*.png  --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_headline_plots.sh
@@ -65,8 +65,6 @@ if [ $USE_CFP = YES ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
 	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
-	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
@@ -68,8 +68,6 @@ if [ $USE_CFP = YES ]; then
 	    nselect=$(cat $PBS_NODEFILE | wc -l)
     	    nnp=$(($nselect * $nproc))
        	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
-	    # ---
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
@@ -35,8 +35,10 @@ if [ $evs_run_mode = production ]; then
 fi
 
 # Create Job Script 
-python $USHevs/mesoscale/mesoscale_plots_precip_create_job_scripts.py
-export err=$?; err_chk
+if [ ! -e ${RESTART_DIR}/completed_jobs/${EVAL_PERIOD}/completed_jobs.txt_${EVAL_PERIOD}_job${njob}.txt ]; then
+  python $USHevs/mesoscale/mesoscale_plots_precip_create_job_scripts.py
+  export err=$?; err_chk
+fi
 
 export njob=$((njob+1))
 
@@ -85,13 +87,14 @@ else
 fi
 
 # Copy Plots Output to Main Directory
-for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
-  cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
-  export err=$?; err_chk
-done
+if [ $ncount_job -gt 0 ]; then
+  for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
+    cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
+    export err=$?; err_chk
+  done
+fi
 
 # Tar and Copy output files to EVS COMOUT directory
-#find ${DATA}/${VERIF_CASE}/out/* -type f \( -name "*.png" -o -name "*.gif" \) -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
 tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/na/* --transform='s#.*/##'  -T - 
 
 if [ $SENDCOM = YES ]; then

--- a/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
@@ -95,7 +95,7 @@ if [ $ncount_job -gt 0 ]; then
 fi
 
 # Tar and Copy output files to EVS COMOUT directory
-tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/na/* --transform='s#.*/##'  -T - 
+tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/*.png ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/na/* --transform='s#.*/##'  -T - 
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_precip_plots.sh
@@ -35,10 +35,8 @@ if [ $evs_run_mode = production ]; then
 fi
 
 # Create Job Script 
-if [ ! -e ${RESTART_DIR}/completed_jobs/${EVAL_PERIOD}/completed_jobs.txt_${EVAL_PERIOD}_job${njob}.txt ]; then
-  python $USHevs/mesoscale/mesoscale_plots_precip_create_job_scripts.py
-  export err=$?; err_chk
-fi
+python $USHevs/mesoscale/mesoscale_plots_precip_create_job_scripts.py
+export err=$?; err_chk
 
 export njob=$((njob+1))
 
@@ -87,15 +85,14 @@ else
 fi
 
 # Copy Plots Output to Main Directory
-if [ $ncount_job -gt 0 ]; then
-  for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
-    cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
-    export err=$?; err_chk
-  done
-fi
+for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
+  cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
+  export err=$?; err_chk
+done
 
 # Tar and Copy output files to EVS COMOUT directory
-  find ${DATA}/${VERIF_CASE}/out/* -type f \( -name "*.png" -o -name "*.gif" \) -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
+#find ${DATA}/${VERIF_CASE}/out/* -type f \( -name "*.png" -o -name "*.gif" \) -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
+tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/na/* --transform='s#.*/##'  -T - 
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
@@ -69,8 +69,6 @@ if [ $USE_CFP = YES ]; then
             nselect=$(cat $PBS_NODEFILE | wc -l)
 	    nnp=$(($nselect * $nproc))
 	    launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-            # launcher="mpiexec -np $nproc -ppn $nproc --cpu-bind verbose,depth cfp"
-	    # ----
         elif [$machine = HERA -o $machine = ORION -o $machine = S4 -o $machine = JET ]; then
             export SLURM_KILL_BAD_EXIT=0
             launcher="srun --export=ALL --multi-prog"

--- a/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
@@ -35,10 +35,8 @@ if [ $evs_run_mode = production ]; then
 fi
 
 # Create Job Script 
-if [ ! -e ${RESTART_DIR}/completed_jobs/${EVAL_PERIOD}/completed_jobs.txt_${EVAL_PERIOD}_job${njob}.txt ]; then
-    python $USHevs/mesoscale/mesoscale_plots_snowfall_create_job_scripts.py
+python $USHevs/mesoscale/mesoscale_plots_snowfall_create_job_scripts.py
     export err=$?; err_chk
-fi
 
 export njob=$((njob+1))
 
@@ -88,15 +86,14 @@ else
 fi
 
 # Copy Plots Output to Main Directory
-if [ $ncount_job -gt 0 ]; then
-  for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
-    cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
-    export err=$?; err_chk
-  done
-fi
+for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
+  cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
+  export err=$?; err_chk
+done
 
 # Tar and Copy output files to EVS COMOUT directory
-  find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
+##  find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
+  tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
@@ -35,8 +35,10 @@ if [ $evs_run_mode = production ]; then
 fi
 
 # Create Job Script 
-python $USHevs/mesoscale/mesoscale_plots_snowfall_create_job_scripts.py
+if [ ! -e ${RESTART_DIR}/completed_jobs/${EVAL_PERIOD}/completed_jobs.txt_${EVAL_PERIOD}_job${njob}.txt ]; then
+    python $USHevs/mesoscale/mesoscale_plots_snowfall_create_job_scripts.py
     export err=$?; err_chk
+fi
 
 export njob=$((njob+1))
 
@@ -86,14 +88,15 @@ else
 fi
 
 # Copy Plots Output to Main Directory
-for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
-  cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
-  export err=$?; err_chk
-done
+if [ $ncount_job -gt 0 ]; then
+  for CHILD_DIR in ${DATA}/${VERIF_CASE}/out/workdirs/*; do
+    cp -ruv $CHILD_DIR/* ${DATA}/${VERIF_CASE}/out/.
+    export err=$?; err_chk
+  done
+fi
 
 # Tar and Copy output files to EVS COMOUT directory
-##  find ${DATA}/${VERIF_CASE}/out/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
-  tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
+tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
+++ b/scripts/plots/mesoscale/exevs_mesoscale_snowfall_plots.sh
@@ -96,7 +96,7 @@ if [ $ncount_job -gt 0 ]; then
 fi
 
 # Tar and Copy output files to EVS COMOUT directory
-tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/${EVAL_PERIOD}/*.png  --transform='s#.*/##'  -T -
+tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${DATA}/${VERIF_CASE}/out/${VERIF_CASE}/*.png  --transform='s#.*/##'  -T -
 
 if [ $SENDCOM = YES ]; then
     cp -v ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar ${COMOUTplots}/.

--- a/ush/mesoscale/check_variables.py
+++ b/ush/mesoscale/check_variables.py
@@ -248,11 +248,6 @@ def check_EVAL_PERIOD(EVAL_PERIOD):
     if EVAL_PERIOD=="TEST":
         print(f"Since the EVAL_PERIOD is set to 'TEST', will use a"
                     + f" custom INIT/VALID period.")
-    else:
-        print(f"Since the EVAL_PERIOD is not set to 'TEST', will use a"
-                    + f" preset INIT/VALID period (check ush/settings.py for"
-                    + f" possible presets). EVAL_PERIOD may be dealt with"
-                    + f" differently for spatial_map plots.")
     return EVAL_PERIOD
 
 

--- a/ush/mesoscale/mesoscale_create_child_workdirs.py
+++ b/ush/mesoscale/mesoscale_create_child_workdirs.py
@@ -92,7 +92,7 @@ else:
               ]) 
         if STEP == "prep":
             print(
-                "Done making working directories for child prcoesses."
+                "Done making working directories for child processes."
             )
         elif STEP == "stats":
             print(

--- a/ush/mesoscale/mesoscale_create_child_workdirs.py
+++ b/ush/mesoscale/mesoscale_create_child_workdirs.py
@@ -88,9 +88,8 @@ else:
               if not os.path.exists(workdir):
                 os.makedirs(workdir)
               cutil.run_shell_command([
-                'find', '.', '-type', 'd', '-not', '-path',
-                '\"*workdirs*\"', '-not', '-path', '\"*job*\"', '-exec',
                 'mkdir', '-p', os.path.join(workdir,'{}'), '\\;'
+
               ]) 
         if STEP == "prep":
             print(

--- a/ush/mesoscale/mesoscale_create_child_workdirs.py
+++ b/ush/mesoscale/mesoscale_create_child_workdirs.py
@@ -89,7 +89,6 @@ else:
                 os.makedirs(workdir)
               cutil.run_shell_command([
                 'mkdir', '-p', os.path.join(workdir,'{}'), '\\;'
-
               ]) 
         if STEP == "prep":
             print(


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

There are two items on the Fixes and Additions list that request the removal of the word "not" from the output.  The word "not" should be removed as it is associated with the "not found" error and should not be included in the output.

1.  There are numerous messages in the log files regarding the init period not being "TEST", and thus noting that the EVAL_PERIOD might be treated differently for spatial plots.  This entire line is not necessary and is removed entirely from the output.  
2. When tarring the png files for the final tarball, the current process uses a find command that tars up an entire directory, but excludes the workdirs subdirectory because the png files under that directory should not be used - thus the command looks for all png files in a directory, but "not" the workdirs subdirectory (all png files from the workdirs, the MPMD subdirectories, are copied to a common directory for tarring).  Instead of using this find command, we'll just tar the requested directories to make our final tarball.  The results should be the same using this method.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28-August 1

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout mesoscale_plot_restart
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/plots/mesoscale
5) In all the jevs_mesoscale (non-SREF) plot jobs, set HOMEevs to your testing directory, set COMIN to emc.vpppg
6) Execute the plot jobs.  

qsub -v vhr=01 jevs_mesoscale_grid2obs_plots_lastXXdays.sh
qsub -v vhr=01 jevs_mesoscale_headline_plots.sh
qsub -v vhr=13 jevs_mesoscale_precip_plots_lastXXdays.sh
qsub -v vhr=13 jevs_mesoscale_snowfall_plots_lastXXdays.sh

We'll check to see that the statement about the spatial_plots is removed and also if the tarballs are of expected size and the process to tar them doesn't have any errors and does the process correctly.  
