### PR TITLE
Refactor/split snowfall plots

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_snowfall_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_snowfall_plots_last31days.sh
@@ -1,0 +1,57 @@
+#PBS -N jevs_cam_snowfall_plots_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=00:35:00
+#PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=150GB
+#PBS -l debug=true
+
+set -x
+export model=evs
+export machine=WCOSS2
+
+# ECF Settings
+export SENDECF=YES
+export SENDCOM=YES
+export KEEPDATA=NO
+export SENDDBN=NO
+export SENDDBN_NTC=
+export job=${PBS_JOBNAME:-jevs_cam_snowfall_plots_last31days}
+export jobid=$job.${PBS_JOBID:-$$}
+export SITE=$(cat /etc/cluster_name)
+export USE_CFP=YES
+export nproc=512
+export ncpu=128
+
+# General Verification Settings
+export NET="evs"
+export STEP="plots"
+export COMPONENT="cam"
+export RUN="atmos"
+export VERIF_CASE="snowfall"
+export MODELNAME=${COMPONENT}
+
+# EVS Settings
+export HOMEevs="/lfs/h2/emc/vpppg/noscrub/$USER/EVS"
+export HOMEevs=${HOMEevs:-${PACKAGEROOT}/evs.${evs_ver}}
+export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}
+
+# Load Modules
+source $HOMEevs/versions/run.ver
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+# Developer Settings
+export envir=prod
+export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export vhr=${vhr:-${vhr}}
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+export EVAL_PERIOD="last31days"
+
+# Job Settings and Run
+. ${HOMEevs}/jobs/JEVS_CAM_PLOTS

--- a/dev/drivers/scripts/plots/cam/jevs_cam_snowfall_plots_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_snowfall_plots_last90days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_cam_snowfall_plots
+#PBS -N jevs_cam_snowfall_plots_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -17,7 +17,7 @@ export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
 export SENDDBN_NTC=
-export job=${PBS_JOBNAME:-jevs_cam_snowfall_plots}
+export job=${PBS_JOBNAME:-jevs_cam_snowfall_plots_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 export SITE=$(cat /etc/cluster_name)
 export USE_CFP=YES
@@ -51,6 +51,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export vhr=${vhr:-${vhr}}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+export EVAL_PERIOD="last90days"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_CAM_PLOTS

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2357,7 +2357,10 @@ suite evs_nco
             task jevs_cam_precip_plots_last90days
               edit VHR '21'
               trigger ../../stats/cam/jevs_cam_hireswarw_precip_stats_vhr_22 == complete and  ../../stats/cam/jevs_cam_hireswarwmem2_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_hireswfv3_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_hrrr_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_namnest_precip_stats_vhr_22 == complete
-            task jevs_cam_snowfall_plots
+            task jevs_cam_snowfall_plots_last31days
+              edit VHR '21'
+              trigger ../../stats/cam/jevs_cam_hireswarw_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswarwmem2_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswfv3_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hrrr_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_namnest_snowfall_stats_vhr_18 == complete
+            task jevs_cam_snowfall_plots_last90days
               edit VHR '21'
               trigger ../../stats/cam/jevs_cam_hireswarw_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswarwmem2_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswfv3_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hrrr_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_namnest_snowfall_stats_vhr_18 == complete
             task jevs_cam_grid2obs_plots_last31days

--- a/ecf/scripts/plots/cam/jevs_cam_snowfall_plots_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_snowfall_plots_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_cam_snowfall_plots
+#PBS -N evs_cam_snowfall_plots_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -58,6 +58,7 @@ export RUN="atmos"
 export VERIF_CASE="snowfall"
 export MODELNAME=${COMPONENT}
 export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}
+export EVAL_PERIOD="last31days"
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/plots/cam/jevs_cam_snowfall_plots_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_snowfall_plots_last90days.ecf
@@ -1,0 +1,75 @@
+#PBS -N evs_cam_snowfall_plots_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:35:00
+#PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=150GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export nproc=512
+export ncpu=128
+export USE_CFP=YES
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="snowfall"
+export MODELNAME=${COMPONENT}
+export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}
+export EVAL_PERIOD="last31days"
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_CAM_PLOTS
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_cam_snowfall_plots_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_snowfall_plots_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_cam_snowfall_plots_last31days
+#PBS -N evs_cam_snowfall_plots_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -58,7 +58,7 @@ export RUN="atmos"
 export VERIF_CASE="snowfall"
 export MODELNAME=${COMPONENT}
 export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}
-export EVAL_PERIOD="last31days"
+export EVAL_PERIOD="last90days"
 
 ############################################################
 # Execute j-job

--- a/parm/evs_config/cam/config.evs.prod.plots.cam.atmos.snowfall
+++ b/parm/evs_config/cam/config.evs.prod.plots.cam.atmos.snowfall
@@ -19,7 +19,7 @@ export MET_VERSION="${MET_VERSION%.}"
 # Logging
 export SAVE_DIR="${DATA}/${VERIF_CASE}/out/workdirs/job{njob}"
 export RESTART_DIR="${COMOUTplots}/${VERIF_CASE}/restart"
-export COMPLETED_JOBS_DIR="completed_jobs"
+export COMPLETED_JOBS_DIR="completed_jobs_${EVAL_PERIOD}"
 export LOG_TEMPLATE="${SAVE_DIR}/logs/EVS_verif_plotting_job{njob}_$($NDATE)_$$.out"
 export LOG_LEVEL="DEBUG"
 

--- a/scripts/plots/cam/exevs_cam_snowfall_plots.sh
+++ b/scripts/plots/cam/exevs_cam_snowfall_plots.sh
@@ -102,14 +102,14 @@ if [ -d $log_dir ]; then
 fi
 
 # Tar and Copy output files to EVS COMOUT directory
-find ${DATA}/${VERIF_CASE}/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar --transform='s#.*/##' -T -
+find ${DATA}/${VERIF_CASE}/* -name "*.png" -type f -not -path "*workdirs*" -print | tar -cvf ${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar --transform='s#.*/##' -T -
 
 if [ $SENDCOM = YES ]; then
-    FILE=${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar
+    FILE=${DATA}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar
     if [ -s "$FILE" ]; then
        cp -v ${FILE} ${COMOUTplots}/.
     fi
 fi
 if [ $SENDDBN = YES ]; then
-    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job ${COMOUTplots}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.v${VDATE}.tar
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job ${COMOUTplots}/${NET}.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${EVAL_PERIOD}.v${VDATE}.tar
 fi

--- a/ush/cam/cam_plots_snowfall_create_job_scripts.py
+++ b/ush/cam/cam_plots_snowfall_create_job_scripts.py
@@ -22,6 +22,7 @@ COMPONENT = os.environ['COMPONENT']
 STEP = os.environ['STEP']
 VERIF_CASE = os.environ['VERIF_CASE']
 njob = os.environ['njob']
+eval_period = os.environ['EVAL_PERIOD']
 for VERIF_TYPE in graphics[COMPONENT][VERIF_CASE]:
     for MODELS in graphics[COMPONENT][VERIF_CASE][VERIF_TYPE]:
         for PLOT_TYPE in graphics[COMPONENT][VERIF_CASE][VERIF_TYPE][MODELS]:

--- a/ush/cam/cam_plots_snowfall_graphx_defs.py
+++ b/ush/cam/cam_plots_snowfall_graphx_defs.py
@@ -21,7 +21,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_06':{
@@ -88,7 +88,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_06':{
@@ -129,7 +129,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_06':{
@@ -196,7 +196,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_06':{
@@ -237,7 +237,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'SNOD_06':{
@@ -304,7 +304,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'SNOD_06':{
@@ -345,7 +345,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'ASNOW_06':{
@@ -412,7 +412,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'ASNOW_06':{
@@ -453,7 +453,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'SNOD_06':{
@@ -520,7 +520,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'SNOD_06':{
@@ -561,7 +561,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_24':{
@@ -628,7 +628,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_24':{
@@ -669,7 +669,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'ASNOW_24':{
@@ -710,7 +710,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'ASNOW_24':{
@@ -738,7 +738,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_24':{
@@ -805,7 +805,7 @@ graphics = {
                         'INIT_BEG':'',
                         'INIT_END':'',
                         'VX_MASK_LIST':'CONUS,CONUS_East,CONUS_West,CONUS_Central,CONUS_South',
-                        'EVAL_PERIODS':['last31days','last90days'],
+                        'EVAL_PERIODS':[os.environ['EVAL_PERIOD']],
                         'VARIABLES':{
                             'ctc':{
                                 'WEASD_24':{

--- a/ush/cam/cam_production_restart.py
+++ b/ush/cam/cam_production_restart.py
@@ -49,21 +49,10 @@ elif STEP == 'plots':
     RESTART_DIR = os.environ['RESTART_DIR']
     COMPLETED_JOBS_DIR = os.environ['COMPLETED_JOBS_DIR']
     working_dir = os.path.join(DATA, VERIF_CASE, 'out')
-    if VERIF_CASE == "grid2obs":
-        completed_jobs_dir = os.path.join(
-            RESTART_DIR, 
-            COMPLETED_JOBS_DIR
-        )
-    elif VERIF_CASE == "precip":
-        completed_jobs_dir = os.path.join(
-            RESTART_DIR, 
-            COMPLETED_JOBS_DIR
-        )
-    else:
-        completed_jobs_dir = os.path.join(
-            RESTART_DIR, 
-            COMPLETED_JOBS_DIR
-        )
+    completed_jobs_dir = os.path.join(
+        RESTART_DIR, 
+        COMPLETED_JOBS_DIR
+    )
     if os.path.exists(completed_jobs_dir):
         if any(p.is_file() for p in Path(completed_jobs_dir).rglob('*')):
             print(f"Copying restart directory {RESTART_DIR} "


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR includes the following bugfixes:
- _Cleanup:_ EVS-cam plots jobs generate graphics valid across 31-day and 90-day periods.  Precip and grid2obs jobs have already been split based on valid period, and we do the same for snowfall here.  As a result, EVS-cam plots are all split by valid period, which will make it easier to remove 31-day periods if needed to reduce computational load in the future.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No
* Do you have any planned upcoming annual leave/PTO?

Yes, July 10 - August 16 2025
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No, however there are new drivers:
jevs_cam_snowfall_plots_last31days
jevs_cam_snowfall_plots_last90days

... and a deprecated driver:
jevs_cam_snowfall_plots

Again, no timing changes are needed; each can be submitted the same way as the now-deprecated job was being submitted.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### Running jobs

I recommend testing the following jobs:
```
jevs_cam_snowfall_plots_last31days
jevs_cam_snowfall_plots_last90days
```

[Total: 2 plots jobs]

#### Testing jobs

- submit each driver using `qsub -v vhr=00 $driver`

#### Checking jobs
- Log files should be checked by the developer for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```