### PR TITLE
Bugfix/restrict sendmail to dcom

### DIFF
--- a/scripts/prep/cam/exevs_hireswarw_severe_prep.sh
+++ b/scripts/prep/cam/exevs_hireswarw_severe_prep.sh
@@ -131,12 +131,6 @@ i=1
    else
 
       echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required."
-      if [ $SENDMAIL = YES ]; then
-         export subject="${MODELNAME} Forecast Data Missing for EVS ${COMPONENT}"
-         echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required. METplus will not run." > mailmsg
-         echo "Job ID: $jobid" >> mailmsg
-         cat mailmsg | mail -s "$subject" $MAILTO
-      fi
 
    fi
 

--- a/scripts/prep/cam/exevs_hireswarwmem2_severe_prep.sh
+++ b/scripts/prep/cam/exevs_hireswarwmem2_severe_prep.sh
@@ -131,12 +131,6 @@ i=1
    else
 
       echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required."
-      if [ $SENDMAIL = YES ]; then
-         export subject="${MODELNAME} Forecast Data Missing for EVS ${COMPONENT}"
-         echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required. METplus will not run." > mailmsg
-         echo "Job ID: $jobid" >> mailmsg
-         cat mailmsg | mail -s "$subject" $MAILTO
-      fi
 
    fi
 

--- a/scripts/prep/cam/exevs_hireswfv3_severe_prep.sh
+++ b/scripts/prep/cam/exevs_hireswfv3_severe_prep.sh
@@ -133,12 +133,6 @@ i=1
    else
 
       echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required."
-      if [ $SENDMAIL = YES ]; then
-         export subject="${MODELNAME} Forecast Data Missing for EVS ${COMPONENT}"
-         echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required. METplus will not run." > mailmsg
-         echo "Job ID: $jobid" >> mailmsg
-         cat mailmsg | mail -s "$subject" $MAILTO
-      fi
 
    fi
 

--- a/scripts/prep/cam/exevs_href_severe_prep.sh
+++ b/scripts/prep/cam/exevs_href_severe_prep.sh
@@ -216,12 +216,7 @@ i=1
 
    else
 
-      if [ $SENDMAIL = YES ]; then
-         export subject="${MODELNAME} Forecast Data Missing for EVS ${COMPONENT}"
-         echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. At least $min_file_req files are required. METplus will not run." > mailmsg
-         echo -e "`cat missing_file_list`" >> mailmsg
-         cat mailmsg | mail -s "$subject" $MAILTO
-      fi
+      echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. At least $min_file_req files are required. METplus will not run."
 
    fi
 

--- a/scripts/prep/cam/exevs_hrrr_severe_prep.sh
+++ b/scripts/prep/cam/exevs_hrrr_severe_prep.sh
@@ -141,12 +141,6 @@ i=1
    else
 
       echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required."
-      if [ $SENDMAIL = YES ]; then
-         export subject="${MODELNAME} Forecast Data Missing for EVS ${COMPONENT}"
-         echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required. METplus will not run." > mailmsg
-         echo "Job ID: $jobid" >> mailmsg
-         cat mailmsg | mail -s "$subject" $MAILTO
-      fi
 
    fi
 

--- a/scripts/prep/cam/exevs_namnest_severe_prep.sh
+++ b/scripts/prep/cam/exevs_namnest_severe_prep.sh
@@ -149,12 +149,6 @@ i=1
    else
 
       echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required."
-      if [ $SENDMAIL = YES ]; then
-         export subject="${MODELNAME} Forecast Data Missing for EVS ${COMPONENT}"
-         echo "WARNING: Only $nfiles ${MODELNAME} forecast files found for ${vhr}Z ${INITDATE} cycle. $min_file_req files are required. METplus will not run." > mailmsg
-         echo "Job ID: $jobid" >> mailmsg
-         cat mailmsg | mail -s "$subject" $MAILTO
-      fi
 
    fi
 

--- a/scripts/stats/cam/exevs_cam_nam_firewxnest_grid2obs_stats.sh
+++ b/scripts/stats/cam/exevs_cam_nam_firewxnest_grid2obs_stats.sh
@@ -49,13 +49,6 @@ do
        echo $fhr >> $DATA/fcstmiss
        let "fcstmiss=fcstmiss+1"
        echo "WARNING: File $COMINnam/nam.${aday}/nam.t${acyc}z.${regionnest}.${outtyp}${fhr}.tm00.grib2 is missing."
-       if [ $SENDMAIL = "YES" ]; then
-        export subject="NAM Firewx File Missing for EVS ${COMPONENT}"
-        echo "Warning: The NAM Firewx file is missing for valid date ${VDATE}." > mailmsg
-        echo "Missing file is $COMINnam/nam.${aday}/nam.t${acyc}z.${regionnest}.${outtyp}${fhr}.tm00.grib2" >> mailmsg
-        echo "Job ID: $jobid" >> mailmsg
-        cat mailmsg | mail -s "$subject" $MAILTO
-       fi
      fi
      fi
      let "shr=shr+1"
@@ -130,13 +123,6 @@ then
   fi
 else
   echo "WARNING: File $COMINobsproc/${MODELNAME}.${obday}/${MODELNAME}.t${obcyc}z.prepbufr.tm${tmnum} is missing."
-  if [ $SENDMAIL = "YES" ]; then
-   export subject="Prepbufr Data Missing for EVS ${COMPONENT}"
-   echo "Warning: The ${obday} prepbufr file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
-   echo "Missing file is $COMINobsproc/${MODELNAME}.${obday}/${MODELNAME}.t${obcyc}z.prepbufr.tm${tmnum}" >> mailmsg
-   echo "Job ID: $jobid" >> mailmsg
-   cat mailmsg | mail -s "$subject" $MAILTO
-  fi
 fi
 
 echo $obfound

--- a/scripts/stats/cam/exevs_cam_radar_stats.sh
+++ b/scripts/stats/cam/exevs_cam_radar_stats.sh
@@ -112,8 +112,11 @@ fi
 ###################################################################
 shopt -s nullglob
 for CHILD_DIR in ${DATA}/workdirs/*; do
-    cp -ruv ${CHILD_DIR}/* ${DATA}/.
-    export err=$?; err_chk
+    files=("$CHILD_DIR"/*)
+    if [ ${#files[@]} -gt 0 ]; then
+        cp -ruv "$CHILD_DIR"/* "${DATA}/."
+        export err=$?; err_chk
+    fi
 done
 shopt -u nullglob
 
@@ -155,7 +158,7 @@ if [ $vhr = 23 ]; then
          HREF_MODS="href_pmmn href_prob"
 
          for HREF_MOD in ${HREF_MODS}; do
-	    export HREF_MOD
+       export HREF_MOD
             run_metplus.py -c $PARMevs/metplus_config/machine.conf $PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/StatAnalysis_fcstHREF_obsMRMS_gatherByDay.conf
             export err=$?; err_chk
          done

--- a/scripts/stats/cam/exevs_cam_severe_stats.sh
+++ b/scripts/stats/cam/exevs_cam_severe_stats.sh
@@ -31,15 +31,7 @@ if [ -s $EVSINspclsr/${obs_lsr_file} ]; then
    obs_lsr_found=1
 
 else
-   if [ $SENDMAIL = YES ]; then
-      export subject="SPC LSR Prep Data Missing for EVS ${COMPONENT}"
-      echo "Warning: The ${REP_DATE} SPC LSR file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
-      echo "Missing file is $EVSINspclsr/${obs_lsr_file}" >> mailmsg
-      echo "Job ID: $jobid" >> mailmsg
-      cat mailmsg | mail -s "$subject" $MAILTO
-   else
-      echo "WARNING: The ${REP_DATE} SPC LSR file is missing for valid date ${VDATE}. METplus will not run."
-   fi
+   echo "WARNING: The ${REP_DATE} SPC LSR file is missing for valid date ${VDATE}. METplus will not run."
 
 fi
 
@@ -47,15 +39,7 @@ if [ -s $EVSINspclsr/${obs_ppf_file} ]; then
    obs_ppf_found=1
 
 else
-   if [ $SENDMAIL = YES ]; then
-      export subject="SPC LSR Prep Data Missing for EVS ${COMPONENT}"
-      echo "Warning: The ${REP_DATE} SPC PPF file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
-      echo "Missing file is $EVSINspclsr/${obs_ppf_file}" >> mailmsg
-      echo "Job ID: $jobid" >> mailmsg
-      cat mailmsg | mail -s "$subject" $MAILTO
-   else
-      echo "WARNING: The ${REP_DATE} SPC PPF file is missing for valid date ${VDATE}. METplus will not run."
-   fi
+   echo "WARNING: The ${REP_DATE} SPC PPF file is missing for valid date ${VDATE}. METplus will not run."
 
 fi
 
@@ -146,14 +130,7 @@ done
 
 # Send missing data alert if any forecast files are missing
 if [ -s $DATA/missing_fcst_list ]; then
-   if [ $SENDMAIL = YES ]; then
-      export subject="${MODELNAME} SSPF Prep Data Missing for EVS ${COMPONENT}"
-      echo "Warning: ${MODELNAME} SSPF forecast file(s) is missing for valid date ${VDATE}12. METplus will not run." > mailmsg
-      echo -e "`cat $DATA/missing_fcst_list`" >> mailmsg
-      echo "Job ID: $jobid" >> mailmsg
-      cat mailmsg | mail -s "$subject" $MAILTO
-   fi
-
+   echo "Warning: ${MODELNAME} SSPF forecast file(s) is missing for valid date ${VDATE}12. METplus will not run."
 fi
 
 

--- a/ush/cam/cam_check_input_data.py
+++ b/ush/cam/cam_check_input_data.py
@@ -437,7 +437,10 @@ if proceed:
         print(f"WARNING: The following forecasts were not found:")
         for missing_fcst_path in missing_fcst_paths:
             print(missing_fcst_path)
-        if send_mail and str(SENDMAIL) == "YES":
+        # Only send mail if missing file is from dcom
+        dcom_missing_fcst_paths = [p for p in missing_fcst_paths if '/dcom/' in p or '\\dcom\\' in p]
+        dcom_missing_fcst_files = [f for f, p in zip(missing_fcst_files, missing_fcst_paths) if '/dcom/' in p or '\\dcom\\' in p]
+        if dcom_missing_fcst_paths and send_mail and str(SENDMAIL) == "YES":
             if 'MAILTO' in os.environ:
                MAILTO = os.environ['MAILTO']
             else:
@@ -448,7 +451,7 @@ if proceed:
             missing_data_flag+=1
             data_info = [
                 cutil.get_data_type(fname) 
-                for fname in missing_fcst_files
+                for fname in dcom_missing_fcst_files
             ]
             fcst_names = []
             unk_names = []
@@ -459,12 +462,12 @@ if proceed:
             for i, info in enumerate(data_info):
                 if info[1] == "fcst":
                     fcst_names.append(info[0])
-                    fcst_fnames.append(missing_fcst_files[i])
-                    fcst_pnames.append(missing_fcst_paths[i])
+                    fcst_fnames.append(dcom_missing_fcst_files[i])
+                    fcst_pnames.append(dcom_missing_fcst_paths[i])
                 elif info[1] == "unk":
                     unk_names.append(info[0])
-                    unk_fnames.append(missing_fcst_files[i])
-                    unk_pnames.append(missing_fcst_paths[i])
+                    unk_fnames.append(dcom_missing_fcst_files[i])
+                    unk_pnames.append(dcom_missing_fcst_paths[i])
                 else:
                     print(f"FATAL ERROR: Undefined data type for missing data file: {info[1]}"
                           + f"\nPlease edit the get_data_type() function in"
@@ -562,7 +565,10 @@ if proceed:
         print(f"WARNING: The following analyses were not found:")
         for missing_anl_path in missing_anl_paths:
             print(missing_anl_path)
-        if send_mail and str(SENDMAIL) == "YES":
+        # Only send mail if missing file is from dcom
+        dcom_missing_anl_paths = [p for p in missing_anl_paths if '/dcom/' in p or '\\dcom\\' in p]
+        dcom_missing_anl_files = [f for f, p in zip(missing_anl_files, missing_anl_paths) if '/dcom/' in p or '\\dcom\\' in p]
+        if dcom_missing_anl_paths and send_mail and str(SENDMAIL) == "YES":
             if 'MAILTO' in os.environ:
                MAILTO = os.environ['MAILTO']
             else:
@@ -573,7 +579,7 @@ if proceed:
             missing_data_flag+=1
             data_info = [
                 cutil.get_data_type(fname) 
-                for fname in missing_anl_files
+                for fname in dcom_missing_anl_files
             ]
             anl_names = []
             unk_names = []
@@ -584,12 +590,12 @@ if proceed:
             for i, info in enumerate(data_info):
                 if info[1] == "anl":
                     anl_names.append(info[0])
-                    anl_fnames.append(missing_anl_files[i])
-                    anl_pnames.append(missing_anl_paths[i])
+                    anl_fnames.append(dcom_missing_anl_files[i])
+                    anl_pnames.append(dcom_missing_anl_paths[i])
                 elif info[1] == "unk":
                     unk_names.append(info[0])
-                    unk_fnames.append(missing_anl_files[i])
-                    unk_pnames.append(missing_anl_paths[i])
+                    unk_fnames.append(dcom_missing_anl_files[i])
+                    unk_pnames.append(dcom_missing_anl_paths[i])
                 else:
                     print(f"FATAL ERROR: Undefined data type for missing data file: {info[1]}"
                           + f"\nPlease edit the get_data_type() function in"
@@ -748,7 +754,10 @@ if proceed:
         print(f"WARNING: The following input data were not found:")
         for missing_gen_path in missing_gen_paths:
             print(missing_gen_path)
-        if send_mail and str(SENDMAIL) == "YES":
+        # Only send mail if missing file is from dcom
+        dcom_missing_gen_paths = [p for p in missing_gen_paths if '/dcom/' in p or '\\dcom\\' in p]
+        dcom_missing_gen_files = [f for f, p in zip(missing_gen_files, missing_gen_paths) if '/dcom/' in p or '\\dcom\\' in p]
+        if dcom_missing_gen_paths and send_mail and str(SENDMAIL) == "YES":
             if 'MAILTO' in os.environ:
                MAILTO = os.environ['MAILTO']
             else:
@@ -759,7 +768,7 @@ if proceed:
             missing_data_flag+=1
             data_info = [
                 cutil.get_data_type(fname) 
-                for fname in missing_gen_files
+                for fname in dcom_missing_gen_files
             ]
             gen_names = []
             unk_names = []
@@ -770,12 +779,12 @@ if proceed:
             for i, info in enumerate(data_info):
                 if info[1] == "gen":
                     gen_names.append(info[0])
-                    gen_fnames.append(missing_gen_files[i])
-                    gen_pnames.append(missing_gen_paths[i])
+                    gen_fnames.append(dcom_missing_gen_files[i])
+                    gen_pnames.append(dcom_missing_gen_paths[i])
                 elif info[1] == "unk":
                     unk_names.append(info[0])
-                    unk_fnames.append(missing_gen_files[i])
-                    unk_pnames.append(missing_gen_paths[i])
+                    unk_fnames.append(dcom_missing_gen_files[i])
+                    unk_pnames.append(dcom_missing_gen_paths[i])
                 else:
                     print(f"FATAL ERROR: Undefined data type for missing data file: {info[1]}"
                           + f"\nPlease edit the get_data_type() function in"

--- a/ush/cam/evs_cam_stats_radar.sh
+++ b/ush/cam/evs_cam_stats_radar.sh
@@ -215,13 +215,7 @@ done
 
 # Send missing data alert if any forecast files are missing
 if [ $nmiss -ge 1 ]; then
-   if [ $SENDMAIL = YES ]; then
-      export subject="${DOM} ${MODELNAME} Data Missing for EVS ${COMPONENT}"
-      echo "Warning: ${DOM} ${MODELNAME} forecast files are missing for valid date ${VDATE}${vhr}. METplus will not run." > mailmsg
-      echo -e "`cat $DATA/job${JOBNUM}_missing_fcst_list`" >> mailmsg
-      echo "Job ID: $jobid" >> mailmsg
-      cat mailmsg | mail -s "$subject" $MAILTO
-   fi
+    echo "Warning: ${DOM} ${MODELNAME} forecast files are missing for valid date ${VDATE}${vhr}. METplus will not run."
 fi
 
 
@@ -248,13 +242,7 @@ if [ -s $EVSINmrms/${obs_file} ]; then
    obs_found=1
 
 else
-   if [ $SENDMAIL = YES ]; then
-      export subject="MRMS Prep Data Missing for EVS ${COMPONENT}"
-      echo "WARNING: The MRMS ${MRMS_PRODUCT} file is missing for valid date ${VDATE}${vhr}. METplus will not run." > mailmsg
-      echo "Missing file is $EVSINmrms/${obs_file}" >> mailmsg
-      echo "Job ID: $jobid" >> mailmsg
-      cat mailmsg | mail -s "$subject" $MAILTO
-   fi
+    echo "WARNING: The MRMS ${MRMS_PRODUCT} file is missing for valid date ${VDATE}${vhr}. METplus will not run."
 fi
 
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR includes the following bugfixes:
- _Bugfix:_ EVS-cam jobs output mail messages for any missing files required for verification.  NCO is only interested in missing `dcom/` files, and we plan to eventually send emails to NCO Dataflow only.  This bugfix removes mail message blocks for all message types except for `dcom/`.  _Fix outcome:_  EVS-cam mail messages are only sent for missing `dcom/` files.
- _Bugfix:_ An ERROR occurred in EVS-cam radar stats jobs when trying to copy from empty workdirs.  The fix includes a check that a workdir contains files before running cp. _Fix outcome:_ No error occurs when workdirs are empty; only non-empty directories are copied.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No
* Do you have any planned upcoming annual leave/PTO?

Yes, July 10 - August 16 2025
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No

Again, no timing changes are needed; each can be submitted the same way as the now-deprecated job was being submitted.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - as needed, set to a nonexistent directory, e.g. `/lfs/h2/emc/vpppg/noscrub/BOGUS/${NET}/$evs_ver_2d`
**COMOUT** - set to your test output directory
**SENDMAIL** - set to `"YES"` if it's not already
**MAILTO** - set to `"marcel.caron@noaa.gov"` (_optional: you may also add your own email_)
**KEEPDATA** - (_optional_) set to `"YES"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory
- In each driver script, also export the following variables:
**COMINhiresw** - set to a nonexistent directory, e.g. `"/lfs/h1/ops/prod/com/hiresw/BOGUS"`
**COMINhrrr** - set to a nonexistent directory, e.g. `"/lfs/h1/ops/prod/com/hrrr/BOGUS"`
**COMINnam** - set to a nonexistent directory, e.g. `"/lfs/h1/ops/prod/com/nam/BOGUS"`
**COMINobsproc** - set to a nonexistent directory, e.g. `"/BOGUS"`
**COMINccpa** - set to a nonexistent directory, e.g. `"/BOGUS"`
**DCOMINmrms** - set to a nonexistent directory, e.g. `"/BOGUS"`
**DCOMINnohrsc** - set to a nonexistent directory, e.g. `"/BOGUS"`

#### Running jobs

I recommend testing the following jobs:
```
jevs_cam_hireswarw_severe_prep
jevs_cam_href_severe_prep
```
```
jevs_cam_hireswarw_precip_stats
jevs_cam_hireswarw_snowfall_stats
jevs_cam_hireswarw_radar_stats
jevs_cam_hireswarw_severe_stats
jevs_cam_nam_firewxnest_grid2obs_stats
```
[Total: 2 prep; 5 stats jobs]

#### Testing jobs
**prep**
- submit using `qsub -v vhr=07 $driver`

**stats**
- submit jevs_cam_hireswarw_precip_stats using `qsub -v vhr=21 $driver`
- submit jevs_cam_hireswarw_severe_stats using `qsub -v vhr=08 $driver`
- submit all other drivers using `qsub -v vhr=12 $driver`

#### Checking jobs
- Log files should be checked by the developer for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- _Note_: WARNINGs are expected
- Also ensure mail messages are produced for missing dcom files only