### PR TITLE
Analyses precip ccpa fix

### DIFF
--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
@@ -14,7 +14,7 @@ cd $PBS_O_WORKDIR
 
 export model=evs
 
-export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS_analyses_precip_ccpa_fix/EVS
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
 source $HOMEevs/versions/run.ver
 
@@ -47,8 +47,8 @@ source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
-export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}/prep/cam
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
+export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}/prep/cam
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 export vhr

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
@@ -48,7 +48,6 @@ export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
-export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}/prep/cam
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 export vhr

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
@@ -14,7 +14,7 @@ cd $PBS_O_WORKDIR
 
 export model=evs
 
-export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS_analyses_precip_ccpa_fix/EVS
 
 source $HOMEevs/versions/run.ver
 
@@ -47,8 +47,8 @@ source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
-export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/${evs_ver_2d}/prep/cam
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
+export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}/prep/cam
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 export vhr

--- a/parm/metplus_config/stats/analyses/precip/PointStat_fcstCCPA_obsCOCORAHS_ASCIIprecip.conf
+++ b/parm/metplus_config/stats/analyses/precip/PointStat_fcstCCPA_obsCOCORAHS_ASCIIprecip.conf
@@ -41,7 +41,7 @@ FCST_PCP_COMBINE_RUN = True
 #FCST_PCP_COMBINE_INPUT_TEMPLATE = {lead?fmt=%HH}
 
 FCST_PCP_COMBINE_INPUT_DIR = {ENV[EVSINccpa]} 
-FCST_PCP_COMBINE_INPUT_TEMPLATE = ccpa.{valid?fmt=%Y%m%d}/ccpa.t{valid?fmt=%H}z.01h.hrap.conus.gb2
+FCST_PCP_COMBINE_INPUT_TEMPLATE = atmos.{valid?fmt=%Y%m%d}/ccpa/ccpa.t{valid?fmt=%H}z.01h.hrap.conus.gb2
 
 FCST_PCP_COMBINE_OUTPUT_DIR = {OUTPUT_BASE}/PCPCombine
 FCST_PCP_COMBINE_OUTPUT_TEMPLATE = {ENV[MODELNAME]}.{ENV[VDATE]}{ENV[vhr]}.qpe_{FCST_PCP_COMBINE_OUTPUT_ACCUM}h.nc

--- a/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
@@ -52,16 +52,16 @@ then
 	echo $DATE > curdate
 	DAY=`cut -c 1-8 curdate`
 	HOUR=`cut -c 9-10 curdate`
-	if [ -e $EVSINccpa/ccpa.${DAY}/ccpa.t${HOUR}z.01h.hrap.conus.gb2 ]
+	if [ -e $EVSINccpa/atmos.${DAY}/ccpa/ccpa.t${HOUR}z.01h.hrap.conus.gb2 ]
         then
          let "ccpanum=ccpanum+1"
-	 cp $EVSINccpa/ccpa.${DAY}/ccpa.t${HOUR}z.01h.hrap.conus.gb2  $DATA/ccpa
+	 cp $EVSINccpa/atmos.${DAY}/ccpa/ccpa.t${HOUR}z.01h.hrap.conus.gb2  $DATA/ccpa
         else
-         echo  "WARNING: $EVSINccpa/ccpa.${DAY}/ccpa.t${HOUR}z.01h.hrap.conus.gb2 is missing, METplus will not run"
+         echo  "WARNING: $EVSINccpa/atmos.${DAY}/ccpa/ccpa.t${HOUR}z.01h.hrap.conus.gb2 is missing, METplus will not run"
          if [ $SENDMAIL = "YES" ]; then
            export subject="CONUS Precip Analysis Missing for EVS ${COMPONENT}"
            echo "Warning: The CONUS Analysis file is missing for valid date ${DAY}. METplus will not run." > mailmsg
-           echo "Missing file is $EVSINccpa/ccpa.${DAY}/ccpa.t${HOUR}z.01h.hrap.conus.gb2" >> mailmsg
+           echo "Missing file is $EVSINccpa/atmos.${DAY}/ccpa/ccpa.t${HOUR}z.01h.hrap.conus.gb2" >> mailmsg
            echo "Job ID: $jobid" >> mailmsg
            cat mailmsg | mail -s "$subject" $MAILTO
          fi


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Recently, a change was made to the CAM prep procedures that changes the structure of the prep directories.  The analysis ccpa precip verification was pointing to the CAM prep output as input for CCPA verification.  This PR points to the new CAM prep structure.  

Also, the EVSIN line was inadvertently left in the dev driver script.  

A future PR will be created to create the CCPA hourly precipitation independently of the CAM.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Somewhat.  Currently the analysis precip jobs are failing because it is not pointing to the correct directory.

* Do you have any planned upcoming annual leave/PTO?

Jul 28 to Aug 1

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout bugfix/analyses_precip_ccpa
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/stats/analyses
5. In the file jevs_analyses_ccpa_precip_stats.sh, point to your testing directory.  Add the line export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/${evs_ver_2d}/prep/cam for testing purposes.  You can update COMIN to emc.vpppg.
6. Run qsub -v vhr=12 jevs_analyses_ccpa_precip_stats.sh.  We'll check to see if there is a stats file in the small stats directory.
