### PR TITLE
feature/EVSv2-NFCENS_plots_separation

### DIFF
--- a/dev/drivers/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_nfcens_wave_grid2obs_plots
+#PBS -N jevs_nfcens_wave_grid2obs_plots_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -49,11 +49,12 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export OUTPUTROOT=/lfs/h2/emc/ptmp/$USER
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
 export COMOUT=${OUTPUTROOT}/${NET}/${evs_ver_2d}
+export EVAL_PERIOD="last31days"
 
 export run_mpi='yes'
 export gather='yes'
 
-export job=${PBS_JOBNAME:-jevs_nfcens_wave_grid2obs_plots}
+export job=${PBS_JOBNAME:-jevs_nfcens_wave_grid2obs_plots_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 export TMPDIR=$DATAROOT
 export SITE=$(cat /etc/cluster_name)

--- a/dev/drivers/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter:exclhost,select=2:ncpus=128:mem=500G
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last90days.sh
+++ b/dev/drivers/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last90days.sh
@@ -1,0 +1,69 @@
+#PBS -N jevs_nfcens_wave_grid2obs_plots_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=2:ncpus=128:mem=500G
+#PBS -l debug=true
+
+set -x
+
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+
+export MODELNAME=nfcens
+export OBTYPE=GDAS
+export NET=evs
+export COMPONENT=nfcens
+export STEP=plots
+export RUN=wave
+export VERIF_CASE=grid2obs
+
+############################################################
+# read version file and set model_ver
+############################################################
+versionfile=$HOMEevs/versions/run.ver
+. $versionfile
+export model_ver=$nfcens_ver
+
+############################################################
+# Load modules
+############################################################
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
+
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+############################################################
+# set some variables
+############################################################
+export envir=prod
+export SENDCOM=${SENDCOM:-YES}
+export SENDECF=${SENDECF:-YES}
+export SENDDBN=${SENDDBN:-NO}
+export KEEPDATA=${KEEPDATA:-NO}
+
+## developers directories
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export OUTPUTROOT=/lfs/h2/emc/ptmp/$USER
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
+export COMOUT=${OUTPUTROOT}/${NET}/${evs_ver_2d}
+export EVAL_PERIOD="last90days"
+
+export run_mpi='yes'
+export gather='yes'
+
+export job=${PBS_JOBNAME:-jevs_nfcens_wave_grid2obs_plots_last90days}
+export jobid=$job.${PBS_JOBID:-$$}
+export TMPDIR=$DATAROOT
+export SITE=$(cat /etc/cluster_name)
+
+############################################################
+# CALL executable job script here
+############################################################
+${HOMEevs}/jobs/JEVS_NFCENS_PLOTS
+
+#########################################################################
+# Purpose: This job creates the plots for the NFCENS wave model
+#########################################################################

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1693,8 +1693,10 @@ suite evs_nco
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats == complete
           endfamily
           family nfcens
-            task jevs_nfcens_wave_grid2obs_plots
+            task jevs_nfcens_wave_grid2obs_plots_last31days
               trigger :TIME >= 2100 and ../../stats/nfcens == complete
+	    task jevs_nfcens_wave_grid2obs_plots_last90days
+	      trigger :TIME >= 2105 and ../../stats/nfcens == complete
           endfamily
           family glwu
             task jevs_glwu_wave_grid2obs_plots

--- a/ecf/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.ecf
+++ b/ecf/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter:exclhost,select=2:ncpus=128:mem=500G
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.ecf
+++ b/ecf/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last31days.ecf
@@ -1,0 +1,63 @@
+#PBS -N evs_nfcens_wave_grid2obs_plots_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=2:ncpus=128:mem=500G
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x
+export COMPONENT=nfcens
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load gsl/${gsl_ver}
+module load libjpeg/${libjpeg_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export NET=evs
+export RUN=wave
+export VERIF_CASE=grid2obs
+export MODELNAME=nfcens
+export OBTYPE=GDAS
+export run_mpi='yes'
+export gather='yes'
+export EVAL_PERIOD="last31days"
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_NFCENS_PLOTS
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last90days.ecf
+++ b/ecf/scripts/plots/nfcens/jevs_nfcens_wave_grid2obs_plots_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_nfcens_wave_grid2obs_plots
+#PBS -N evs_nfcens_wave_grid2obs_plots_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -46,6 +46,7 @@ export MODELNAME=nfcens
 export OBTYPE=GDAS
 export run_mpi='yes'
 export gather='yes'
+export EVAL_PERIOD="last90days"
 
 ############################################################
 # Execute j-job

--- a/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
+++ b/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
@@ -150,7 +150,9 @@ export err=$?; err_chk
 #######################
 # Gather all the files 
 #######################
-periods='LAST31DAYS LAST90DAYS'
+#periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
+
 if [ $gather = yes ] ; then
   nc=$(ls ${DATA}/images/*.png | wc -l | awk '{print $1}')
   echo "Found ${nc} ${DATA}/images/*.png "

--- a/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
+++ b/scripts/plots/nfcens/exevs_nfcens_wave_grid2obs_plots.sh
@@ -8,7 +8,7 @@
 #                    NFCENSv2: Add FNMOC and GEFS model to compare against NFCENS (07/2024)
 #                    NFCENSv2: Image names was updated. (08/2024)
 #                    NFCENSv2: mpmd was addressed (03/2025)
-#
+#                    NFCENSv2: Separated last31days and last90days plots (07/2025).    
 # Usage:                                                                        
 #  Parameters: None                                                             
 #  Input files:                                                                 
@@ -150,7 +150,6 @@ export err=$?; err_chk
 #######################
 # Gather all the files 
 #######################
-#periods='LAST31DAYS LAST90DAYS'
 periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 
 if [ $gather = yes ] ; then

--- a/ush/nfcens/evs_wave_leadaverages.sh
+++ b/ush/nfcens/evs_wave_leadaverages.sh
@@ -13,7 +13,8 @@ set -x
 
 # set up plot variables
 
-periods='LAST31DAYS LAST90DAYS'
+#periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 
 inithours='00 12'
 fhrs='000,024,048,072,096,120,144,168,192,216,240'

--- a/ush/nfcens/evs_wave_leadaverages.sh
+++ b/ush/nfcens/evs_wave_leadaverages.sh
@@ -13,7 +13,6 @@ set -x
 
 # set up plot variables
 
-#periods='LAST31DAYS LAST90DAYS'
 periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 
 inithours='00 12'

--- a/ush/nfcens/evs_wave_timeseries.sh
+++ b/ush/nfcens/evs_wave_timeseries.sh
@@ -13,8 +13,8 @@ set -x
 
 # set up plot variables
 
-periods='LAST31DAYS LAST90DAYS'
-
+#periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 inithours='00 12'
 fhrs='000 024 048 072 096 120 144 168 192 216 240'
 wave_vars='HTSGW'

--- a/ush/nfcens/evs_wave_timeseries.sh
+++ b/ush/nfcens/evs_wave_timeseries.sh
@@ -13,7 +13,6 @@ set -x
 
 # set up plot variables
 
-#periods='LAST31DAYS LAST90DAYS'
 periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 inithours='00 12'
 fhrs='000 024 048 072 096 120 144 168 192 216 240'


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In this PR, the last31days plots and last 90days plots have been separated. 
  
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
Yes, July 14.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

To test this PR, you need to run the driver script for **plots** step:
1- Clone my fork in your local and checkout branch `feature/EVSv2-NFCENS_plots_separation`.
2- `ln -s` fix directory.
3- In `$COMIN`, replace the `${USER}` with `emc.vpppg` in all plots driver scripts (total: 2 scripts)
4- Run the driver scripts for plots step located at: EVS/dev/drivers/scripts/plots/nfcens/*:
`qsub jevs_nfcens_wave_grid2obs_plots_last31days.sh`
`qsub jevs_nfcens_wave_grid2obs_plots_last90days.sh`
