### PR TITLE
global_ens: fix Bugzilla 1606 and subprocess syntax

### DIFF
--- a/ush/global_ens/global_ens_atmos_util.py
+++ b/ush/global_ens/global_ens_atmos_util.py
@@ -1308,13 +1308,12 @@ def condense_model_stat_files(logger, input_dir, output_file, model, obs,
             )
             for model_stat_file in model_stat_files:
                 logger.debug(f"Getting data from {model_stat_file}")
-                ps = subprocess.Popen(
+                ps = subprocess.run(
                     'grep -R "'+model+' " '+model_stat_file+grep_opts,
-                    shell=True, stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT, encoding='UTF-8'
+                    shell=True, capture_output=True, encoding='UTF-8'
                 )
                 logger.debug(f"Ran {ps.args}")
-                all_grep_output = all_grep_output+ps.communicate()[0]
+                all_grep_output = all_grep_output+ps.stdout
             logger.debug(f"Condensed {model} .stat file at "
                          +f"{output_file}")
             with open(output_file, 'w') as f:

--- a/ush/global_ens/ush_gens_plot_py/global_det_atmos_util.py
+++ b/ush/global_ens/ush_gens_plot_py/global_det_atmos_util.py
@@ -1886,13 +1886,12 @@ def condense_model_stat_files(logger, input_dir, output_file, model, obs,
             )
             for model_stat_file in model_stat_files:
                 logger.debug(f"Getting data from {model_stat_file}")
-                ps = subprocess.Popen(
+                ps = subprocess.run(
                     'grep -R "'+model+' " '+model_stat_file+grep_opts,
-                    shell=True, stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT, encoding='UTF-8'
+                    shell=True, capture_output=True, encoding='UTF-8'
                 )
                 logger.debug(f"Ran {ps.args}")
-                all_grep_output = all_grep_output+ps.communicate()[0]
+                all_grep_output = all_grep_output+ps.stdout
             logger.debug(f"Condensed {model} .stat file at "
                          +f"{output_file}")
             with open(output_file, 'w') as f:

--- a/ush/global_ens/ush_gens_plot_py/lead_average.py
+++ b/ush/global_ens/ush_gens_plot_py/lead_average.py
@@ -704,6 +704,7 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         connect_points = True
     else:
         connect_points = False
+    n_mods = 0
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -711,6 +712,8 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
             )
         else:
             model_plot_name = model_list[m]
+        if str(model_list[m]) not in pivot_metric1:
+            continue
         y_vals_metric1 = pivot_metric1[str(model_list[m])].values
         y_vals_metric1_mean = np.nanmean(y_vals_metric1)
         if metric2_name is not None:
@@ -746,9 +749,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
+                n_mods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min

--- a/ush/global_ens/ush_gens_plot_py/plot_util.py
+++ b/ush/global_ens/ush_gens_plot_py/plot_util.py
@@ -2165,9 +2165,13 @@ def equalize_samples(logger, df, group_by):
     df_equalized_groups = df_equalized.groupby(group_by)
     # Check that groups are indeed equally sized for each independent variable
     df_groups_sizes = df_equalized_groups.size()
-    df_groups_sizes.index = df_groups_sizes.index.set_levels(
-        df_groups_sizes.index.levels[-1].astype(str), level=-1
-    )
+    if df_groups_sizes.empty:
+        logger.debug(f"equalize_samples: no data in groups {group_by}")
+        return df, False
+    else:
+        df_groups_sizes.index = df_groups_sizes.index.set_levels(
+            df_groups_sizes.index.levels[-1].astype(str), level=-1
+        )
     data_are_equalized = np.all([
         np.unique(df_groups_sizes.xs(str(unique_indep_var), level=1)).size == 1
         for unique_indep_var 

--- a/ush/global_ens/ush_gens_plot_py/stat_by_level.py
+++ b/ush/global_ens/ush_gens_plot_py/stat_by_level.py
@@ -550,6 +550,7 @@ def plot_stat_by_level(df: pd.DataFrame, logger: logging.Logger,
     else:
         handles = []
         labels = []
+    n_mods = 0
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -557,6 +558,8 @@ def plot_stat_by_level(df: pd.DataFrame, logger: logging.Logger,
             )
         else:
             model_plot_name = model_list[m]
+        if str(model_list[m]) not in pivot_metric1:
+            continue
         x_vals_metric1 = pivot_metric1[str(model_list[m])].values
         x_vals_metric1_mean = np.nanmean(x_vals_metric1)
         if metric2_name is not None:
@@ -587,9 +590,10 @@ def plot_stat_by_level(df: pd.DataFrame, logger: logging.Logger,
             else:
                 x_vals_metric_min = np.nanmin(x_vals_metric1)
                 x_vals_metric_max = np.nanmax(x_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 x_mod_min = x_vals_metric_min
                 x_mod_max = x_vals_metric_max
+                n_mods+=1
             else:
                 x_mod_min = np.nanmin([x_mod_min, x_vals_metric_min])
                 x_mod_max = np.nanmax([x_mod_max, x_vals_metric_max])

--- a/ush/global_ens/ush_gens_plot_py/time_series.py
+++ b/ush/global_ens/ush_gens_plot_py/time_series.py
@@ -660,6 +660,7 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
     else:
         handles = []
         labels = []
+    n_mods = 0
     for m in range(len(mod_setting_dicts)):
         if model_list[m] in model_colors.model_alias:
             model_plot_name = (
@@ -667,6 +668,8 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
             )
         else:
             model_plot_name = model_list[m]
+        if str(model_list[m]) not in pivot_metric1:
+            continue
         y_vals_metric1 = pivot_metric1[str(model_list[m])].values
         y_vals_metric1_mean = np.nanmean(y_vals_metric1)
         if metric2_name is not None:
@@ -702,10 +705,10 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
                 else:
                     y_vals_metric_min = np.nanmin(y_vals_metric1)
                     y_vals_metric_max = np.nanmax(y_vals_metric1)
-            if m == 0:
+            if n_mods == 0:
                 y_mod_min = y_vals_metric_min
                 y_mod_max = y_vals_metric_max
-                counts = pivot_counts[str(model_list[m])].values
+                n_mods+=1
             else:
                 if math.isinf(y_mod_min):
                     y_mod_min = y_vals_metric_min


### PR DESCRIPTION
## Description of Changes
This PR addresses Issue #636 and fixes Bugzilla 1606. It also fixes a known issue for subprocess.Popen.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d
COMOUT - set to your test output directory
KEEPDATA - set to YES

(2) Run selected plots jobs
Run the following jobs in dev/drivers/scripts/plots/global_ens for any VDATE:

qsub jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_precip_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_profile3_past90days_plots.sh

After the jobs completed, log files should be free of errors or warnings.