### PR TITLE
Analyses stats COMOUTfinal adjustment

### DIFF
--- a/jobs/JEVS_ANALYSES_STATS
+++ b/jobs/JEVS_ANALYSES_STATS
@@ -80,7 +80,7 @@ export COMOUT=${COMOUT:-$(compath.py -o ${NET}/${evs_ver})}
 mkdir -p $COMOUT
 export COMOUTsmall=${COMOUT}/${STEP}/${COMPONENT}/${RUN}.${VDATE}/${MODELNAME}/${VERIF_CASE}
 export COMOUTfinal=${COMOUT}/${STEP}/${COMPONENT}/${MODELNAME}.${VDATE}
-mkdir -p $COMOUTsmall $COMOUTfinal
+mkdir -p $COMOUTsmall 
 
 #######################################################################
 # Execute the script.

--- a/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
@@ -2,8 +2,6 @@ set -x
 
 mkdir -p $DATA/logs
 mkdir -p $DATA/stat
-export finalstat=$DATA/final
-mkdir -p $finalstat
 
 export regionnest=ccpa
 export fcstmax=$g2os_sfc_fhr_max
@@ -96,6 +94,8 @@ done
 #
  if [ $vhr = 23 -a $ccpafound -eq 1 -a $obfound -eq 1 ]
  then
+   export finalstat=$DATA/final
+   mkdir -p $finalstat
    mkdir -p $COMOUTfinal
    cp $COMOUTsmall/* $finalstat
    cd $finalstat

--- a/scripts/stats/analyses/exevs_analyses_rtma_grid2obs_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_rtma_grid2obs_stats.sh
@@ -16,8 +16,6 @@ source $config
 
 mkdir -p $DATA/logs
 mkdir -p $DATA/stat
-export finalstat=$DATA/final
-mkdir -p $DATA/final
 
 export regionnest=rtma
 export fcstmax=$g2os_sfc_fhr_max
@@ -354,6 +352,8 @@ done
 
 if [ $vhr = 23 -a $rtmafound -eq 1 -a $obfound -eq 1 ]
 then
+       export finalstat=$DATA/final
+       mkdir -p $DATA/final
        mkdir -p $COMOUTfinal
        cp $COMOUTsmall/*${regionnest}*${typtag}* $finalstat
        cd $finalstat

--- a/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
@@ -2,8 +2,6 @@ set -x
 
 mkdir -p $DATA/logs
 mkdir -p $DATA/stat
-export finalstat=$DATA/final
-mkdir -p $finalstat
 
 export regionnest=rtma
 export fcstmax=$g2os_sfc_fhr_max
@@ -93,6 +91,8 @@ fi
 
 if [ $vhr = 23 -a $rtmafound -eq 1 -a $obfound -eq 1 ]
 then
+   export finalstat=$DATA/final
+   mkdir -p $finalstat
    mkdir -p $COMOUTfinal
    cp $COMOUTsmall/* $finalstat
    cd $finalstat 

--- a/scripts/stats/analyses/exevs_analyses_rtma_ru_grid2obs_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_rtma_ru_grid2obs_stats.sh
@@ -17,8 +17,6 @@ source $config
 
 mkdir -p $DATA/logs
 mkdir -p $DATA/stat
-export finalstat=$DATA/final
-mkdir -p $DATA/final
 
 export regionnest=rtma
 export fcstmax=$g2os_sfc_fhr_max
@@ -125,6 +123,8 @@ done
 
 if [ $vhr = 23 -a $rtmafound -eq 1 -a $obfound -eq 1 ]
 then
+       export finalstat=$DATA/final
+       mkdir -p $DATA/final
        mkdir -p $COMOUTfinal
        cp $COMOUTsmall/*${regionnest}*${typtag}* $finalstat
        cd $finalstat

--- a/scripts/stats/analyses/exevs_analyses_urma_grid2obs_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_urma_grid2obs_stats.sh
@@ -16,8 +16,6 @@ source $config
 
 mkdir -p $DATA/logs
 mkdir -p $DATA/stat
-export finalstat=$DATA/final
-mkdir -p $DATA/final
 
 export regionnest=urma
 export fcstmax=$g2os_sfc_fhr_max
@@ -267,6 +265,8 @@ done
 
 if [ $vhr = 23 -a $urmafound -eq 1 -a $obfound -eq 1 ]
 then
+       export finalstat=$DATA/final
+       mkdir -p $DATA/final
        mkdir -p $COMOUTfinal
        cp $COMOUTsmall/*${regionnest}*${typtag}* $finalstat
        cd $finalstat

--- a/scripts/stats/analyses/exevs_analyses_urma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_urma_precip_stats.sh
@@ -2,8 +2,6 @@ set -x
 
 mkdir -p $DATA/logs
 mkdir -p $DATA/stat
-export finalstat=$DATA/final
-mkdir -p $finalstat
 
 export regionnest=urma
 export fcstmax=$g2os_sfc_fhr_max
@@ -95,6 +93,8 @@ done
 #
  if [ $vhr = 23 -a $urmafound -eq 1 -a $obfound -eq 1 ]
  then
+  export finalstat=$DATA/final
+  mkdir -p $finalstat
   mkdir -p $COMOUTfinal
   cp $COMOUTsmall/* $finalstat
   cd $finalstat


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

During the PR testing for 779 for testing the ccpa fix, it was noted that the COMOUTfinal directory was being written for jobs that do not include the gather step.  This will result in a creation of an empty directory that would exist for an entire day until the gather step is done.  This PR is being done to ensure that the COMOUTfinal directory is only written during the gather step (both for $DATA and $COMOUT), for all analysis grid2obs and precip jobs.  The directory was created in the J-job but shouldn't be.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28-August 1

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout bugfix/analyses_precip_ccpa
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/stats/analyses
5. In each of the driver scripts, set HOMEevs to your testing directory, and set COMIN to emc.vpppg.  For the precip jobs, also add the line `export EVSINccpa=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/${evs_ver_2d}/prep/cam`. 
6. Run each of the jobs at least once during a non-gather step.  Any hour between vhr=00 and vhr=22 will do.  You may run all the hours for completeness.  Run the jobs like this:

qsub -v vhr=$vhr jevs_analyses_${model}_${verif_case}_stats.sh, where $vhr=00 to 22, model=rtma, urma, rtma_ru, or ccpa, and verif_case=grid2obs or precip.  
7. One specific hour for each script is enough for us to check whether the final stats directory has been created.  If it doesn't exist, then the changes were successful.  
8. Run the gather job for each script (qsub -v vhr=23 $script).  The gather step will create a final stats file inside the final stats directory, including whatever was run during that day (whether it be a single hour or the whole complement of jobs).  