### PR TITLE
feature/global_ens_wave_plots_separation

### DIFF
--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_ens_wave_grid2obs_plots
+#PBS -N jevs_global_ens_wave_grid2obs_plots_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -48,11 +48,12 @@ export SENDMAIL=YES
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}
-
+export EVAL_PERIOD="last31days"
 export run_mpi='yes'
 export gather='yes'
 
-export job=${PBS_JOBNAME:-jevs_global_ens_wave_g2o_prep}
+
+export job=${PBS_JOBNAME:-jevs_global_ens_wave_grid2obs_plots_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 export TMPDIR=$DATAROOT
 export SITE=$(cat /etc/cluster_name)

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last90days.sh
@@ -1,0 +1,68 @@
+#PBS -N jevs_global_ens_wave_grid2obs_plots_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=108:mem=110G
+#PBS -l debug=true
+
+set -x
+
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+
+############################################################
+# read version file and set model_ver
+############################################################
+versionfile=$HOMEevs/versions/run.ver
+. $versionfile
+export model_ver=$gefs_ver
+export MODELNAME=gefs
+export OBTYPE=GDAS
+export NET=evs
+export COMPONENT=global_ens
+export STEP=plots
+export RUN=wave
+export VERIF_CASE=grid2obs
+
+############################################################
+## Load modules
+#############################################################
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+############################################################
+# set some variables
+############################################################
+export envir=prod
+export SENDCOM=${SENDCOM:-YES}
+export SENDECF=${SENDECF:-YES}
+export SENDDBN=NO
+export KEEPDATA=${KEEPDATA:-NO}
+export SENDMAIL=YES
+
+## developers directories
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
+export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}
+export EVAL_PERIOD="last90days"
+export run_mpi='yes'
+export gather='yes'
+
+
+export job=${PBS_JOBNAME:-jevs_global_ens_wave_grid2obs_plots_last90days}
+export jobid=$job.${PBS_JOBID:-$$}
+export TMPDIR=$DATAROOT
+export SITE=$(cat /etc/cluster_name)
+
+############################################################
+# CALL executable job script here
+############################################################
+${HOMEevs}/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_PLOTS
+
+#########################################################################
+# Purpose: This job creates the plots for the global_ens GEFS-Wave model
+#########################################################################

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1164,8 +1164,10 @@ suite evs_nco
               trigger :TIME >= 0930 and ../../../../06/evs/stats/narre == complete
           endfamily
           family global_ens
-            task jevs_global_ens_wave_grid2obs_plots
+            task jevs_global_ens_wave_grid2obs_plots_last31days
               trigger :TIME >= 1130 and ../../../../06/evs/stats/global_ens/jevs_global_ens_wave_grid2obs_stats == complete
+	    task jevs_global_ens_wave_grid2obs_plots_last90days
+              trigger :TIME >= 1135 and ../../../../06/evs/stats/global_ens/jevs_global_ens_wave_grid2obs_stats == complete
           endfamily
         endfamily    # 06 plots
       endfamily  # evs

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_ens_wave_grid2obs_plots
+#PBS -N evs_global_ens_wave_grid2obs_plots_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -52,6 +52,7 @@ export MODELNAME=gefs
 export OBTYPE=GDAS
 export run_mpi='yes'
 export gather='yes'
+export EVAL_PERIOD="last31days"
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last31days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last90days.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_wave_grid2obs_plots_last90days.ecf
@@ -1,0 +1,69 @@
+#PBS -N evs_global_ens_wave_grid2obs_plots_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=108:mem=110G
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x
+export COMPONENT=global_ens
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load gsl/${gsl_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export NET=evs
+export RUN=wave
+export VERIF_CASE=grid2obs
+export MODELNAME=gefs
+export OBTYPE=GDAS
+export run_mpi='yes'
+export gather='yes'
+export EVAL_PERIOD="last90days"
+
+############################################################
+# Execute j-job
+############################################################
+${HOMEevs}/jobs/JEVS_GLOBAL_ENS_WAVE_GRID2OBS_PLOTS
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
@@ -14,6 +14,10 @@
 # 6- Updated all image names to be lastXXdays instead of pastXXdays. tar files have lastXXdays for waves plots.
 # 7- added obs name to image title.
 # 8- Updated walltime for global_ens wave prep.
+# 
+# Updates on 202507:
+# Separated last31days and last90days plots.
+#
 #
 # Purpose of Script: Run the grid2obs plots for any global wave model           
 #                    (deterministic and ensemble: GEFS-Wave, GFS-Wave, NWPS)    
@@ -136,7 +140,8 @@ fi
 #######################
 # Gather all the files 
 #######################
-periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
+
 if [ $gather = yes ] ; then
   echo "copying all images into one directory"
   for FILE in ${DATA}/wave/*png ; do

--- a/ush/global_ens/evs_wave_leadaverages.sh
+++ b/ush/global_ens/evs_wave_leadaverages.sh
@@ -13,7 +13,7 @@ set -x
 
 # set up plot variables
 
-periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 
 validhours='00 12'
 fhrs='000,024,048,072,096,120,144,168,192,216,240,264,288,312,336,360,384'

--- a/ush/global_ens/evs_wave_timeseries.sh
+++ b/ush/global_ens/evs_wave_timeseries.sh
@@ -13,7 +13,7 @@ set -x
 
 # set up plot variables
 
-periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 
 validhours='00 12'
 fhrs='000 024 048 072 096 120 144 168


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In this PR, the last31days plots and last 90days plots have been separated for global_ens wave.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
Yes, July 14.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No.
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- To test this PR, you need to run the driver script for these two plots jobs:
```
jevs_global_ens_wave_grid2obs_plots_last31days
jevs_global_ens_wave_grid2obs_plots_last90days
```
2- Clone my fork in your local and checkout branch `feature/global_ens_wave_plots_separation`.
3- ln -s fix directory.
4- In `$COMIN`, replace the `${USER}` with `emc.vpppg` in all plots driver scripts (total: 2 scripts)
5- Run the driver scripts for the mentioned plots jobs:
```
qsub jevs_global_ens_wave_grid2obs_plots_last31days.sh
qsub jevs_global_ens_wave_grid2obs_plots_last90days.sh
```
