### PR TITLE
Analyses plots - remove WARNING statements for missing plots

### DIFF
--- a/scripts/plots/analyses/exevs_analyses_grid2obs_plots.sh
+++ b/scripts/plots/analyses/exevs_analyses_grid2obs_plots.sh
@@ -167,7 +167,7 @@ do
 	fi
         elif [ ! -e  ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
         fi
 
 	if [ ! -e $COMOUTplots/$varb/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
@@ -189,7 +189,7 @@ do
 	fi
         elif [ ! -e  ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
 	fi
 
  fi
@@ -227,7 +227,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.buk_${smregion}.png ]
         then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
         fi
 
 	if [ ! -e $COMOUTplots/$varb/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
@@ -249,7 +249,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
 	fi
  fi
 done
@@ -286,7 +286,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.buk_${smregion}.png ]
         then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
         fi
 
 	if [ ! -e $COMOUTplots/$varb/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
@@ -308,7 +308,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
 	fi
  fi
 done
@@ -357,7 +357,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.ctc.${smvar}_${smlev}.last31days.perfdiag.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
         fi
 
 	for stat in csi fbias
@@ -392,7 +392,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}.${smvar}_${smlev}.last31days.threshmean.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
         fi
 
 	if [ $var = VISsfc ]
@@ -418,7 +418,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
 	fi
 
         done
@@ -447,7 +447,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data",$varb,$region,$anl
 	fi
 
         done
@@ -495,7 +495,7 @@ if [ $plot = yes ]; then
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}.${smvar}_${smlev}.last31days.threshmean.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$var,$region,$anl
+	echo "Note: No plot made due to lack of data",$var,$region,$anl
         fi
 
         for thresh in 10 50 90
@@ -519,7 +519,7 @@ if [ $plot = yes ]; then
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "WARNING: NO PLOT FOR",$var,$region,$anl
+	echo "Note: No plot made due to lack of data",$var,$region,$anl
 	fi
 
         done

--- a/scripts/plots/analyses/exevs_analyses_grid2obs_plots.sh
+++ b/scripts/plots/analyses/exevs_analyses_grid2obs_plots.sh
@@ -167,7 +167,7 @@ do
 	fi
         elif [ ! -e  ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
         fi
 
 	if [ ! -e $COMOUTplots/$varb/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
@@ -189,7 +189,7 @@ do
 	fi
         elif [ ! -e  ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
 	fi
 
  fi
@@ -227,7 +227,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.buk_${smregion}.png ]
         then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
         fi
 
 	if [ ! -e $COMOUTplots/$varb/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
@@ -249,7 +249,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
 	fi
  fi
 done
@@ -286,7 +286,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.vhrmean.buk_${smregion}.png ]
         then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
         fi
 
 	if [ ! -e $COMOUTplots/$varb/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
@@ -308,7 +308,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.bcrmse_me.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last31days",$varb,$region,$anl
 	fi
  fi
 done
@@ -357,7 +357,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.ctc.${smvar}_${smlev}.last31days.perfdiag.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in the region in the last 31 days",$varb,$region,$anl
         fi
 
 	for stat in csi fbias
@@ -392,7 +392,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}.${smvar}_${smlev}.last31days.threshmean.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
         fi
 
 	if [ $var = VISsfc ]
@@ -418,7 +418,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made. The threshold does not occur over the region in the last 31 days",$varb,$region,$anl,$thresh
 	fi
 
         done
@@ -447,7 +447,7 @@ do
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$varb,$region,$anl
+	echo "Note: No plot made. The threshold does not occur over the region in the last 31 days",$varb,$region,$anl,$thresh
 	fi
 
         done
@@ -495,7 +495,7 @@ if [ $plot = yes ]; then
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}.${smvar}_${smlev}.last31days.threshmean.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$var,$region,$anl
+	echo "Note: No plot made due to lack of data in region for last 31 days",$var,$region,$anl
         fi
 
         for thresh in 10 50 90
@@ -519,7 +519,7 @@ if [ $plot = yes ]; then
 	fi
         elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
 	then
-	echo "Note: No plot made due to lack of data",$var,$region,$anl
+	echo "Note: No plot made. The threshold does not occur over the region in the last 31 days",$var,$region,$anl,$thresh
 	fi
 
         done

--- a/ush/analyses/time_series.py
+++ b/ush/analyses/time_series.py
@@ -467,9 +467,9 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
             pivot_ci_upper2 = pivot_ci_upper2.reindex(idx, fill_value=np.nan)
     if (metric2_name and (pivot_metric1.empty or pivot_metric2.empty)):
         print_varname = df['FCST_VAR'].tolist()[0]
-        logger.warning(
-            f"Could not find (and cannot plot) {metric1_name} and/or"
-            + f" {metric2_name} stats for {print_varname} at any level. "
+        logger.info(
+            f"Unable to plot {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any level due to lack of data. "
             + f"Continuing ..."
         )
         plt.close(num)
@@ -478,9 +478,9 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
         return None
     elif not metric2_name and pivot_metric1.empty:
         print_varname = df['FCST_VAR'].tolist()[0]
-        logger.warning(
-            f"Could not find (and cannot plot) {metric1_name}"
-            + f" stats for {print_varname} at any level. "
+        logger.info(
+            f"Unable to plot {metric1_name}"
+            + f" stats for {print_varname} at any level due to lack of data. "
             + f"Continuing ..."
         )
         plt.close(num)


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In a recent PR for analyses, it was noted that there was a WARNING for a plot that is missing due to lack of data needed to create a plot.  To remove the word WARNING, it was replaced with a Note and described that there is no plot due to lack of data to create a plot.  This often happens when there is a lack of data.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28-Aug 1
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout feature/analyses_missing_plot_fix
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/plots/analyses
5. In the plot script, set the HOMEevs to your testing directory, and set COMIN to point to emc.vpppg.
6. Run the script using `qsub jevs_analyses_grid2obs_plots_last31days.sh`.  Use VDATE=20250708 for this test regardless of what day you test.  
