### PR TITLE
NAM/RAP - spc outlook grid2obs fixes/adding raob stats into RAP

### DIFF
--- a/scripts/stats/mesoscale/exevs_mesoscale_rap_grid2obs_stats.sh
+++ b/scripts/stats/mesoscale/exevs_mesoscale_rap_grid2obs_stats.sh
@@ -280,10 +280,6 @@ echo "*****************************"
      export evs_run_mode=$evs_run_mode
      source $config
      
-     if [ ${#VAR_NAME_LIST} -lt 1 ]; then
-        continue
-     fi
-     
    # Create Output Directories
      python $USHevs/mesoscale/mesoscale_create_output_dirs.py
      export err=$?; err_chk

--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -299,12 +299,12 @@ elif job_type == 'generate':
         print('testing mask file RSRS')
         if int(VHOUR) < 12:
             spc_mask_list = glob.glob(os.path.join(
-                  EVSINspcotlk,f'spc_otlk.*',
+                  EVSINspcotlk,f'atmos.*',f'spc_otlk',
                   f'spc_otlk.*.v*-{VDATE}12.G221*'
             ))  
         else:
             spc_mask_list =  glob.glob(os.path.join(
-                  EVSINspcotlk,f'spc_otlk.*',
+                  EVSINspcotlk,f'atmos.*',f'spc_otlk',
                   f'spc_otlk.*.v{VDATE}*G221*'
             ))  
         job_dependent_vars['MASK_POLY_LIST'] = {

--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -297,29 +297,25 @@ elif job_type == 'generate':
     }
     if NEST == 'spc_otlk':
         print('testing mask file RSRS')
+        if int(VHOUR) < 12:
+            spc_mask_list = glob.glob(os.path.join(
+                  EVSINspcotlk,f'spc_otlk.*',
+                  f'spc_otlk.*.v*-{VDATE}12.G221*'
+            ))  
+        else:
+            spc_mask_list =  glob.glob(os.path.join(
+                  EVSINspcotlk,f'spc_otlk.*',
+                  f'spc_otlk.*.v{VDATE}*G221*'
+            ))  
         job_dependent_vars['MASK_POLY_LIST'] = {
             'exec_value': '',
             'bash_value': '',
             'bash_conditional': '[[ ${VHOUR} -lt 12 ]]',
             'bash_conditional_value': '"' + ', '.join(
-                glob.glob(os.path.join(
-                    EVSINspcotlk,f'spc_otlk.*',
-                    f'spc_otlk.*.v*-{VDATE}12.G221*'
-                   # '''
-                   # MET_PLUS_OUT,VERIF_TYPE,'genvxmask',f'spc_otlk.{VDATE}',
-                   # f'spc_otlk_*_v*-{VDATE}1200_for{VHOUR}Z*'
-                   # '''
-                ))
+                   spc_mask_list
             ) + '"',
             'bash_conditional_else_value': '"' + ', '.join(
-                glob.glob(os.path.join(
-                    EVSINspcotlk,f'spc_otlk.*',
-                    f'spc_otlk.*.v{VDATE}*G221*'
-                   # '''
-                   # MET_PLUS_OUT,VERIF_TYPE,'genvxmask',f'spc_otlk.{VDATE}',
-                   # f'spc_otlk_*_v{VDATE}*for{VHOUR}Z*'
-                   # '''
-                ))
+                    spc_mask_list
             ) + '"'
         }
         print('maskRSRS',job_dependent_vars['MASK_POLY_LIST'])
@@ -547,43 +543,46 @@ elif STEP == 'stats':
                   if f'{job_type}_job{njob}' in cutil.get_completed_jobs(os.path.join(RESTART_DIR, "completed_jobs", completed_jobs_file_full)):
                       pass
                   else:
-                   job_cmd_list_iterative.append(
+                   if NEST == "spc_otlk" and not spc_mask_list:
+                       pass
+                   else: 
+                     job_cmd_list_iterative.append(
                        f'{metplus_launcher} -c {machine_conf} '
                        + f'-c {MET_PLUS_CONF}/'
                        + f'PointStat_fcst{COMPONENT.upper()}_'
                        + f'obs{VERIF_TYPE.upper()}.conf'
-                   )
-                   if SENDCOM == 'YES':
-                     job_cmd_list_iterative.append(
-                       f'python -c '
-                       + '\"import mesoscale_util as cutil; cutil.copy_data_to_restart('
-                       + '\\\"${DATA}\\\", \\\"${RESTART_DIR}\\\", '
-                       + f'njob=\\\"{njob}\\\", '
-                       + 'verif_case=\\\"${VERIF_CASE}\\\", '
-                       + 'verif_type=\\\"${VERIF_TYPE}\\\", '
-                       + 'vx_mask=\\\"${NEST}\\\", '
-                       + 'met_tool=\\\"point_stat\\\", '
-                       + 'vdate=\\\"${VDATE}\\\", '
-                       + 'vhour=\\\"${VHOUR}\\\", '
-                       + 'fhr_start=\\\"${FHR_START}\\\", '
-                       + 'fhr_end=\\\"${FHR_END}\\\", '
-                       + 'fhr_incr=\\\"${FHR_INCR}\\\", '
-                       + 'model=\\\"${MODELNAME}\\\", '
-                       + 'var_name=\\\"${VAR_NAME}\\\"'
-                       + ')\"'
                      )
-                   completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
-                   job_cmd_list_iterative.append(
+                     if SENDCOM == 'YES':
+                       job_cmd_list_iterative.append(
+                         f'python -c '
+                         + '\"import mesoscale_util as cutil; cutil.copy_data_to_restart('
+                         + '\\\"${DATA}\\\", \\\"${RESTART_DIR}\\\", '
+                         + f'njob=\\\"{njob}\\\", '
+                         + 'verif_case=\\\"${VERIF_CASE}\\\", '
+                         + 'verif_type=\\\"${VERIF_TYPE}\\\", '
+                         + 'vx_mask=\\\"${NEST}\\\", '
+                         + 'met_tool=\\\"point_stat\\\", '
+                         + 'vdate=\\\"${VDATE}\\\", '
+                         + 'vhour=\\\"${VHOUR}\\\", '
+                         + 'fhr_start=\\\"${FHR_START}\\\", '
+                         + 'fhr_end=\\\"${FHR_END}\\\", '
+                         + 'fhr_incr=\\\"${FHR_INCR}\\\", '
+                         + 'model=\\\"${MODELNAME}\\\", '
+                         + 'var_name=\\\"${VAR_NAME}\\\"'
+                         + ')\"'
+                       )
+                     completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
+                     job_cmd_list_iterative.append(
                        "python -c "
                        + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                        + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
                        + f"\"job{njob}\", job_type=\"{job_type}\")'"
-                   )
-                   completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
-                   completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
-                   job_cmd_list_iterative.append(
-                     f"if [ -f {completed_job_path} ] && [ $SENDCOM == YES ]; then cp -rpfv {completed_job_path} {completed_job_restart_dir}; fi"
-                   )
+                     )
+                     completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
+                     completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
+                     job_cmd_list_iterative.append(
+                       f"if [ -f {completed_job_path} ] && [ $SENDCOM == YES ]; then cp -rpfv {completed_job_path} {completed_job_restart_dir}; fi"
+                     )
     elif job_type == 'gather':
       completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
       if f'{job_type}_job{njob}' in cutil.get_completed_jobs(os.path.join(RESTART_DIR, "completed_jobs", completed_jobs_file_full)):


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

There are two related items on the Fixes and Additions document, and both are relating to the spc outlook files.  One, there needs to be a file check for the spc outlook files.  Two, there are errors in the METplus that are created when there are missing spc outlook files.  This PR fixes both of those items for NAM/RAP grid2obs.

In addition, this PR also changes where it points to the processed spc outlook files.  Since a recent CAM PR re-organized the the prep directories, this PR updates where it points to to find the spc outlook files.  

It was also noticed in testing of this PR that raob statistics are missing from RAP verification.  An additional change was made so that the raob statistics are restored to the stats output.  

A future PR will also add a prep step to for mesoscale to process the spc outlook files, so the mesoscale component doesn't rely on stuff from the CAM component.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28-August 1
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout bugfix/mesoscale_spcotlk_fixes
3. ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
4. cd dev/drivers/scripts/stats/mesoscale
5. In jevs_mesoscale_nam_grid2obs_stats.sh and jevs_mesoscale_rap_grid2obs_stats.sh, change HOMEevs to your testing directory, and change COMIN to point to emc.vpppg
6. We'll do two tests of each script, to ensure that both parts of the PR are working.  In test 1, in the dev driver, add this line to the script:

`export EVSINspcotlk=/lfs/h2/emc/vpppg/noscrub/${USER}/evs/v2.0/prep/cam`

Since it points to $USER, it's a directory that doesn't exist or contain any spc outlook files.  Thus, this test will demonstrate that there are no errors when there are missing spc outlook files.  There is a file check, and that file check is used to determine whether specific jobs are run that use spc outlook files.  

7. Run each script using qsub -v vhr=07.  Save all the data.  
8. For the 2nd test, remove the export EVSINspcotlk line from the dev driver.  Run each script again.  
