### PR TITLE
Analyses precip  - check for corrupt dcom files

### DIFF
--- a/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
@@ -88,7 +88,12 @@ then
   mkdir -p $COMOUTsmall
   cp $DATA/PointStat/* $COMOUTsmall
 else
-  echo "NO CCPA OR OBS DATA"
+  if [ $obfound -eq 0 ]; then
+    echo "CoCoRaHS data either missing or corrupted; METplus will not run"
+  fi
+  if [ $ccpafound -eq 0 ]; then
+     echo "CCPA precip data is missing; METplus will not run"
+  fi
   echo "CCPAFOUND, OBFOUND", $ccpafound, $obfound
 fi
 

--- a/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_ccpa_precip_stats.sh
@@ -30,19 +30,23 @@ then
        export masks=$maskdir/Bukovsky_RTMA_CONUS.nc
        mkdir -p $DATA/ccpa
 
-	if [ -e $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv ]
-	then
-	 obfound=1
-	else
-	 echo "WARNING: $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv is missing, METplus will not run"
-          if [ $SENDMAIL = "YES" ]; then
-	    export subject="CoCoRaHS Data Missing for EVS ${COMPONENT}"
-	    echo "Warning: The CoCoRaHS file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
-	    echo "Missing file is $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv" >> mailmsg
-	    echo "Job ID: $jobid" >> mailmsg
-	    cat mailmsg | mail -s "$subject" $MAILTO
-	  fi
-	fi
+# Check if DCOM file is missing or corrupt
+
+        export CSV_FILE=$DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv
+
+        if python ${USHevs}/analyses/check_csv.py "$CSV_FILE"; then
+           obfound=1
+        else
+           obfound=0
+           echo "WARNING: $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv is missing or corrupt, METplus will not run"
+           if [ $SENDMAIL = "YES" ]; then
+               export subject="CoCoRaHS Data Missing for EVS ${COMPONENT}"
+               echo "Warning: The CoCoRaHS file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
+               echo "Missing file is $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv" >> mailmsg
+               echo "Job ID: $jobid" >> mailmsg
+               cat mailmsg | mail -s "$subject" $MAILTO
+           fi
+        fi
 
 	DATE=${VDATE}${vhr}
 	ENDDATE=`$NDATE -23 $DATE`

--- a/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
@@ -30,18 +30,22 @@ then
        export masks=$maskdir/Bukovsky_RTMA_CONUS.nc
        mkdir -p $DATA/pcp${modnam}
 
-	if [ -e $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv ]
-	then
-	 obfound=1
+# Check if DCOM file is corrupt
+
+        export CSV_FILE=$DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv
+
+	if python ${USHevs}/analyses/check_csv.py "$CSV_FILE"; then
+	  obfound=1
 	else
-         echo "WARNING: $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv is missing, METplus will not run"
-         if [ $SENDMAIL = "YES" ]; then
-            export subject="CoCoRaHS Data Missing for EVS ${COMPONENT}"
-            echo "Warning: The CoCoRaHS file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
-            echo "Missing file is $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv" >> mailmsg
-            echo "Job ID: $jobid" >> mailmsg
-            cat mailmsg | mail -s "$subject" $MAILTO
-         fi
+          obfound=0
+	  echo "WARNING: $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv is missing or corrupt, METplus will not run"
+	  if [ $SENDMAIL = "YES" ]; then
+             export subject="CoCoRaHS Data Missing for EVS ${COMPONENT}"
+	     echo "Warning: The CoCoRaHS file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
+	     echo "Missing file is $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv" >> mailmsg
+	     echo "Job ID: $jobid" >> mailmsg
+	     cat mailmsg | mail -s "$subject" $MAILTO
+	  fi
 	fi
 
 	DATE=${VDATE}${vhr}
@@ -83,7 +87,12 @@ then
   mkdir -p $COMOUTsmall
   cp $DATA/PointStat/* $COMOUTsmall
 else
-  echo "NO RTMA OR OBS DATA"
+  if [ $obfound -eq 0 ]; then
+   echo "CoCoRaHS data either missing or corrupted; METplus will not run"
+  fi
+  if [ $rtmafound -eq 0 ]; then
+   echo "RTMA precip data is missing; METplus will not run"
+  fi
   echo "RTMAFOUND, OBFOUND", $rtmafound, $obfound
 fi
 

--- a/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_rtma_precip_stats.sh
@@ -30,7 +30,7 @@ then
        export masks=$maskdir/Bukovsky_RTMA_CONUS.nc
        mkdir -p $DATA/pcp${modnam}
 
-# Check if DCOM file is corrupt
+# Check if DCOM file is missing or corrupt
 
         export CSV_FILE=$DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv
 

--- a/scripts/stats/analyses/exevs_analyses_urma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_urma_precip_stats.sh
@@ -87,7 +87,12 @@ then
   mkdir -p $COMOUTsmall
   cp $DATA/PointStat/* $COMOUTsmall
 else
-  echo "NO URMA OR OBS DATA"
+  if [ $obfound -eq 0 ]; then
+     echo "CoCoRaHS data either missing or corrupted; METplus will not run"
+  fi
+  if [ $urmafound -eq 0 ]; then
+     echo "URMA precip data is missing; METplus will not run"
+  fi
   echo "URMAFOUND, OBFOUND", $urmafound, $obfound
 fi
 

--- a/scripts/stats/analyses/exevs_analyses_urma_precip_stats.sh
+++ b/scripts/stats/analyses/exevs_analyses_urma_precip_stats.sh
@@ -30,20 +30,24 @@ then
        export masks=$maskdir/Bukovsky_RTMA_CONUS.nc
        mkdir -p $DATA/pcp${modnam}
 
-	if [ -e $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv ]
-	then
-	 obfound=1
-        else 
-	 echo "WARNING: $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv is missing, METplus will not run"
-          if [ $SENDMAIL = "YES" ]; then
-	    export subject="CoCoRaHS Data Missing for EVS ${COMPONENT}"
-            echo "Warning: The CoCoRaHS file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
-            echo "Missing file is $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv" >> mailmsg
-   	    echo "Job ID: $jobid" >> mailmsg
-	    cat mailmsg | mail -s "$subject" $MAILTO
-         fi
-	fi
+# Check if DCOM file is missing or corrupt
 
+       export CSV_FILE=$DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv
+
+       if python ${USHevs}/analyses/check_csv.py "$CSV_FILE"; then
+          obfound=1
+       else
+          obfound=0
+          echo "WARNING: $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv is missing or corrupt, METplus will not run"
+          if [ $SENDMAIL = "YES" ]; then
+              export subject="CoCoRaHS Data Missing for EVS ${COMPONENT}"
+              echo "Warning: The CoCoRaHS file is missing for valid date ${VDATE}. METplus will not run." > mailmsg
+              echo "Missing file is $DCOMIN/${VDATE}/validation_data/CoCoRaHS/cocorahs.${VDATE}.dailyprecip.csv" >> mailmsg
+              echo "Job ID: $jobid" >> mailmsg
+              cat mailmsg | mail -s "$subject" $MAILTO
+           fi
+        fi
+ 
         DATE=${VDATE}${vhr}
         ENDDATE=`$NDATE -23 $DATE`
         while [ $DATE -ge $ENDDATE ]; do

--- a/ush/analyses/check_csv.py
+++ b/ush/analyses/check_csv.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import csv
+import sys
+
+def check_csv(filepath):
+        try:
+            with open(filepath, 'r', newline='') as f:
+              reader = csv.reader(f)
+              header = next(reader)
+              num_cols = len(header)
+
+              for i, row in enumerate(reader):
+               if len(row) != num_cols:
+                  print(f"Warning: Inconsistent column count on line {i+2}. Expected {num_cols}, got {len(row)}.", file=sys.stderr)
+                  return 1 # Corrupt
+            return 0 # Good
+        except FileNotFoundError:
+              print(f"Warning: File not found at {filepath}", file=sys.stderr)
+              return 1
+        except Exception as e:
+              print(f"An error occurred: {e}", file=sys.stderr)
+              return 1
+
+if __name__ == "__main__":
+     if len(sys.argv) < 2:
+        print("Usage: python check_csv.py <filepath>", file=sys.stderr)
+        sys.exit(1)
+                                                                                                                                                                                                     
+     result = check_csv(sys.argv[1])
+     sys.exit(result) # Exit code 0 for good, 1 for corrupt


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

On the Fixes and Additions document, a check for corrupted dcom files was requested.  This script modifies the file check for the CoCoRaHS comma-delimited file so that it does a robust check for its existence as well as whether it is corrupt (checking for correct number of records in each line).  It also enhances the comments near the end so the user is aware whether it is the CoCoRaHS precip observation file or the precip analysis file that is missing.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28 to August 1

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [ x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs (except those expected in testing when encountering missing or corrupted data.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout feature/analyses_dcom_corrupt
3. cd dev/drivers/scripts/stats/analyses
4. For the scripts jevs_analyses_xxxx_precip_stats.sh (xxxx=ccpa, rtma, urma) files,  set HOMEevs to your testing directory, and set COMIN to point to the emc.vpppg directory.  
5. Set VDATE=20250719, and also set export `DCOMIN=/lfs/h2/emc/vpppg/noscrub/perry.shafran`.  The directory /lfs/h2/emc/vpppg/noscrub/perry.shafran/20250719/validation_data/CoCoRaHS has three files:

```
-rw-r--r-- 1 perry.shafran vpppg 2093262 Jul 23 15:12 cocorahs.20250719.dailyprecip.csv
-rw-r--r-- 1 perry.shafran vpppg 2093242 Jul 23 14:17 cocorahs.20250719.dailyprecip.csv_corrupt
-rw-r--r-- 1 perry.shafran vpppg 2093262 Jul 21 18:26 cocorahs.20250719.dailyprecip.csv_good

```

We have a good file and a corrupt file (the corrupt file has a few lines where I either removed a record or added a comma).  For a test of good data, we'll leave the directory as it is.  

6. Test 1: Testing of good data.  Run qsub -v vhr=12 all three precip jobs.  There should be no errors in the job log and there should be a stat file in the COMOUTsmall directory.  
7. Test 2: Testing of corrupt CoCoRaHS data.  You must inform me before you run this job, and I will set the CoCoRaHS data to be the corrupt file.  Run all three precip scripts with qsub -v vhr=12.  You should see some warning statements throughout the script denoting that the file is corrupt, and METplus will not run.  If SENDMAIL is set to YES, missing file emails will be sent to myself and Andrew.  You may want to either turn SENDMAIL to NO, or you can change the recipients to just your own email to test the emails.  
8. Test 3: Testing of missing CoCoRaHS data.  Let me know when you run this job, and I will remove the file cocorahs.20250719.dailyprecip.csv from the directory.  Run all three precip scripts with qsub -v vhr=12.  Again, you'll see warning statements and file emails.  
9. Test 4: Testing of missing precip analysis data.  Since some parts of the script were modified to print out statements to denote whether the obs or the analysis is missing, this test is necessary.  Let me know before you run this job and I will restore the good csv file to the directory.  Set export COMINccpa=/lfs/some/fake/directory (or COMINrtma or COMINurma, depending on the job you are running).  Run all three precip scripts with qsub -v vhr=12.  You'll see warning statements and receive 24 missing file emails for the missing precip analyses.  (Recommend NOT running all hours or else you'll receive 24x24=576 missing file emails.

Running vhr=12 should suffice for this test, because if it works for one, it would work exactly the same for all hours.  

I also want you to note that if you run this at a later date, I'll need to bring in new data to the CoCoRaHS directory in my noscrub directory.  Analysis precip files may disappear if you run any later.  This is not a big deal, I'll just change the directory and the data within so you have that day's file, a good file and a corrupt file.  