### PR TITLE
Mesoscale grid2obs stats: Updating child workdirs script to remove not from stats grid2obs jobs

### DIFF
--- a/ush/mesoscale/mesoscale_create_child_workdirs.py
+++ b/ush/mesoscale/mesoscale_create_child_workdirs.py
@@ -73,8 +73,6 @@ else:
               if not os.path.exists(workdir):
                   os.makedirs(workdir)
               cutil.run_shell_command([
-                  'find', '.', '-type', 'd', '-not', '-path', 
-                  '\"*workdirs*\"', '-not', '-path', '\"*job*\"', '-exec', 
                   'mkdir', '-p', os.path.join(workdir,'{}'), '\\;'
               ]) 
           elif STEP == "plots":

--- a/ush/mesoscale/mesoscale_util.py
+++ b/ush/mesoscale/mesoscale_util.py
@@ -760,8 +760,8 @@ def copy_data_to_restart(data_dir, restart_dir, met_tool=None, net=None,
                       + f" {dest_path} because the path does not already exist.")
                 continue
             if len(glob.glob(origin_path)) == len(glob.glob(os.path.join(dest_path, copy_file))):
-                print(f"Not copying restart files to restart_directory"
-                      + f" {dest_path} because they already exist.")
+                print(f"The files in"
+                      + f" {dest_path} already exist.")
             else:
                 run_shell_command(
                     ['cp', '-rpv', origin_path, os.path.join(dest_path,'.')]

--- a/ush/mesoscale/mesoscale_util.py
+++ b/ush/mesoscale/mesoscale_util.py
@@ -759,10 +759,7 @@ def copy_data_to_restart(data_dir, restart_dir, met_tool=None, net=None,
                 print(f"FATAL ERROR: Could not copy METplus output to COMOUT directory"
                       + f" {dest_path} because the path does not already exist.")
                 continue
-            if len(glob.glob(origin_path)) == len(glob.glob(os.path.join(dest_path, copy_file))):
-                print(f"The files in"
-                      + f" {dest_path} already exist.")
-            else:
+            if not len(glob.glob(origin_path)) == len(glob.glob(os.path.join(dest_path, copy_file))):
                 run_shell_command(
                     ['cp', '-rpv', origin_path, os.path.join(dest_path,'.')]
                 )


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In PR 776, the word "not", a known buzzword for NCO and EE2 reviewers, was removed in the job log in several sections of the mesoscale plots output.  This particular PR does the same for the stats job.  The word "not" is currently in a command that creates the child working directories, but this PR does the same thing in a more simple manner and removes the word "not" from the command and thus the job log.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

July 28 to August 1

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions:

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout feature/mesoscale_stats_remove_not
3. cd dev/drivers/scripts/stats/mesoscale
4. In the jobs jevs_mesoscale_nam_grid2obs_stats.sh and jevs_mesoscale_rap_grid2obs_stats.sh, set the HOMEevs to your working directory and COMIN to emc.vpppg.  
5. Run the jobs:  qsub -v vhr=08 jevs_mesoscale_xxx_grid2obs_stats.sh, where xxx=nam or rap.

We'll check the job lot for the word "not".  

It is advised to test these jobs after PR 786 is complete and merged into the repository.  
