### PR TITLE
global_ens: modify atmos plots jobs for MPMD processes

### DIFF
--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile1_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile1_past90days_plots.sh
@@ -31,7 +31,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export envir=prod
 
-export KEEPDATA=YES
+export KEEPDATA=NO
 export SENDDBN=NO
 
 export vhr=00

--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile1_past90days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_atmos_gefs_profile1_past90days_plots.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:55:00
-#PBS -l place=vscatter:exclhost,select=5:ncpus=88:mpiprocs=88:mem=200GB
+#PBS -l place=vscatter:exclhost,select=5:ncpus=88:mpiprocs=88:mem=250GB
 #PBS -l debug=true
 
 set -x
@@ -31,7 +31,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export envir=prod
 
-export KEEPDATA=NO
+export KEEPDATA=YES
 export SENDDBN=NO
 
 export vhr=00

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2grid_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2grid_plots.sh
@@ -1,48 +1,46 @@
 #!/bin/ksh
 #*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens grid2grid 
-#          plotting python script
+# Purpose: set up environment, paths, and run the global_ens grid2grid 
+#          plotting python scripts
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP
-#******************************************************************************
-set -x 
+# Updated: 07/22/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#*******************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-
-export eval_period='TEST'
-export interp_pnts='' 
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=$VERIF_CASE 
 model_list='ECME CMCE GEFS'
+VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
+valid_time='valid00z_12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0,12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link reguired stat files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -51,194 +49,166 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
-																  
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0,12"
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-
-verif_case=$VERIF_CASE
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in acc me_mae crpss rmse_spread ; do 
-if [ $stats = acc ] ; then
-  stat_list='acc'
-  line_tp='sal1l2'
-  #verif_type='anom'
-elif [ $stats = bias ] ; then
-  stat_list='bias'
-  line_tp='sl1l2'
-  #verif_type='pres'
-elif [ $stats = mae ] ; then
-  stat_list='mae'
-  line_tp='sl1l2'
-  #verif_type='pres'
-elif [ $stats = me_mae  ] ; then
-  stat_list='me, mae'
-  line_tp='ecnt'
-  #verif_type='pres'
-elif [ $stats = crps  ] ; then
-  stat_list='crps'
-  line_tp='ecnt'
-  #verif_type='pres'
-elif [ $stats = crpss ] ; then
-  stat_list='crpss'
-  line_tp='ecnt'
-  #verif_type='pres'
-elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-  #verif_type='pres'
-else
-  err_exit "$stats is not a valid metric"
-fi   
-
-for score_type in time_series lead_average ; do
-
-  if [ $score_type = time_series ] ; then
-    export fcst_init_hour="0,12"
-    export fcst_valid_hour="0,12"
-    valid_time='valid00z_12z'
-    init_time='init00z_12z'
-    export fcst_leads="120 240 360"
+  if [ $stats = acc ] ; then
+    stat_list='acc'
+    line_tp='sal1l2'
+  elif [ $stats = bias ] ; then
+    stat_list='bias'
+    line_tp='sl1l2'
+  elif [ $stats = mae ] ; then
+    stat_list='mae'
+    line_tp='sl1l2'
+  elif [ $stats = me_mae ] ; then
+    stat_list='me, mae'
+    line_tp='ecnt'
+  elif [ $stats = crps ] ; then
+    stat_list='crps'
+    line_tp='ecnt'
+  elif [ $stats = crpss ] ; then
+    stat_list='crpss'
+    line_tp='ecnt'
+  elif [ $stats = rmse_spread ] ; then
+    stat_list='rmse, spread'
+    line_tp='ecnt'
   else
-    export fcst_init_hour="0,12"
-    export fcst_valid_hour="0,12"
-    valid_time='valid00z_12z'
-    init_time='init00z_12z'
-    export fcst_leads="vs_lead" 
-  fi
+    err_exit "$stats is not a valid metric"
+  fi   
+
+  for score_type in time_series lead_average ; do
+    if [ $score_type = time_series ] ; then
+      export fcst_leads="120 240 360"
+    else
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
+	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in HGT TMP UGRD VGRD PRMSL ; do 
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in HGT TMP UGRD VGRD PRMSL ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = HGT ] ; then
+        if [ $VAR = HGT ] ; then
           FCST_LEVEL_values="P500 P700 P1000"
-       elif [ $VAR = TMP ] ; then
+        elif [ $VAR = TMP ] ; then
           FCST_LEVEL_values="P500 P850"
-       elif [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
+        elif [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
           FCST_LEVEL_values="P850 P250 Z10"
-       elif [ $VAR = PRMSL ] ; then
+        elif [ $VAR = PRMSL ] ; then
           FCST_LEVEL_values="L0"
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-	 #***************************
-	 # Build sub-task scripts
-	 #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-        if [ $stats = acc ] ; then
-	   verif_type=anom
-        else
-           if [ $FCST_LEVEL_value = L0 ] || [ $FCST_LEVEL_value = Z10 ] ;  then
-             verif_type=sfc
-           else
-	     verif_type=pres
-	   fi
-	fi 
-	if [ $FCST_LEVEL_value = P250 ]; then
-	   models='CMCE, GEFS'
-	else
-	   models='ECME, CMCE, GEFS'
-	fi
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
         fi
 
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=$FCST_LEVEL_value
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do
+	    export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+            export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+            mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    #************************
+	    # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-	 thresh=' '
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            if [ $stats = acc ] ; then
+              verif_type=anom
+            else
+              if [ $FCST_LEVEL_value = L0 ] || [ $FCST_LEVEL_value = Z10 ] ; then
+                verif_type=sfc
+              else
+    		verif_type=pres
+	      fi
+	    fi
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    if [ $FCST_LEVEL_value = P250 ]; then
+	      models='CMCE, GEFS'
+            else
+	      models='ECME, CMCE, GEFS'
+	    fi
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh	    
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh           
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+            echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
+	    thresh=''
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+            # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-    done #end of VAR
+            # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-  done #end of fcst_lead
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 192 -ppn 96 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 192 -ppn 96 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for stats in acc me_mae crpss rmse_spread ; do
     if [ $stats = rmse_spread ]; then
@@ -246,6 +216,7 @@ for stats in acc me_mae crpss rmse_spread ; do
     else
         evs_graphic_stats=$stats
     fi
+
     for domain in g003 nhem shem tropics conus ; do
         if [ $domain = g003 ] ; then
             domain_new="glb"
@@ -254,6 +225,7 @@ for stats in acc me_mae crpss rmse_spread ; do
         else
 	    domain_new=$domain
         fi
+
         for var in hgt tmp ugrd vgrd prmsl ; do
             if [ $var = hgt ] ; then
                 levels='500 700 1000'
@@ -268,11 +240,13 @@ for stats in acc me_mae crpss rmse_spread ; do
                 levels='l0'
                 unit=''
             fi
+
             for level in $levels ; do
                 if [ $level = 10 ] ; then
                     unit='m'
 	        fi
-                if [ $level = 1000 ] || [ $level = 850 ] ||  [ $level = 500  ] ||  [ $level = 250  ] ||  [ $level = 700 ] ; then
+
+                if [ $level = 1000 ] || [ $level = 850 ] || [ $level = 500 ] || [ $level = 250 ] || [ $level = 700 ] ; then
                     plevel=p${level}
                 elif [ $level = 10 ] ; then
                     plevel=z${level}
@@ -283,6 +257,7 @@ for stats in acc me_mae crpss rmse_spread ; do
                         plevel=$level
 	            fi
                 fi
+
                 if [ $var = prmsl ] ; then
                     if [ -f "lead_average_regional_${domain}_valid_00z_12z_${var}_${stats}.png" ]; then
                         mv lead_average_regional_${domain}_valid_00z_12z_${var}_${stats}.png evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
@@ -292,6 +267,7 @@ for stats in acc me_mae crpss rmse_spread ; do
                         mv lead_average_regional_${domain}_valid_00z_12z_${level}${unit}_${var}_${stats}.png evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
                     fi
                 fi
+
                 for lead in 120 240 360; do
                     if [ $var = prmsl ] ; then
                         if [ -f "time_series_regional_${domain}_valid_00z_12z_${var}_${stats}_f${lead}.png" ]; then
@@ -302,17 +278,17 @@ for stats in acc me_mae crpss rmse_spread ; do
                             mv time_series_regional_${domain}_valid_00z_12z_${level}${unit}_${var}_${stats}_f${lead}.png evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.timeseries_valid00z_12z_f${lead}.g003_${domain_new}.png
                         fi
                     fi
-                done #lead
-            done #level
-        done #var
-    done  #domain
-done     #stats
+                done # lead
+            done # level
+        done # var
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_plots.sh
@@ -1,50 +1,43 @@
 #!/bin/ksh
-
 #*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens grid2obs 
-#          plotting python script
+# Purpose: set up environment, paths, and run the global_ens grid2obs 
+#          plotting python scripts
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
+# Updated: 07/01/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#*******************************************************************************
 set -x 
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-
-export eval_period='TEST'
-export interp_pnts=''
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=$VERIF_CASE
 model_list='ECME CMCE GEFS'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0,12"
+export interp_pnts=''
 
-
-#*************************************************************
-# Virtual link required stat files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -53,189 +46,161 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0,12"
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-
-verif_case=$VERIF_CASE
-
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
-#for stats in acc me_mae crpss rmse_spread ets_fbias sratio_pod_csi ; do 
-for stats in acc me_mae crpss rmse_spread  ; do 
- if [ $stats = acc ] ; then
-  stat_list='acc'
-  line_tp='sal1l2'
-  VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m'
-  score_types='time_series lead_average'
- elif [ $stats = me_mae  ] ; then
-  stat_list='me, mae'
-  line_tp='ecnt'
-  VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m RH2m'
-  score_types='time_series lead_average'
- elif [ $stats = crpss ] ; then
-  stat_list='crpss'
-  line_tp='ecnt'
-  score_types='time_series lead_average'
-  VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m'
- elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-  VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m RH2m'
-  score_types='time_series lead_average'
- else
-  err_exit "$stats is not a valid metric"
- fi   
+for stats in acc me_mae crpss rmse_spread ; do 
+  if [ $stats = acc ] ; then
+    stat_list='acc'
+    line_tp='sal1l2'
+    VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m'
+    score_types='time_series lead_average'
+  elif [ $stats = me_mae ] ; then
+    stat_list='me, mae'
+    line_tp='ecnt'
+    VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m RH2m'
+    score_types='time_series lead_average'
+  elif [ $stats = crpss ] ; then
+    stat_list='crpss'
+    line_tp='ecnt'
+    VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m'
+    score_types='time_series lead_average'
+  elif [ $stats = rmse_spread ] ; then
+    stat_list='rmse, spread'
+    line_tp='ecnt'
+    VARs='PRMSL TMP2m DPT2m UGRD10m VGRD10m RH2m'
+    score_types='time_series lead_average'
+  else
+    err_exit "$stats is not a valid metric"
+  fi   
 
- for score_type in $score_types ; do
-
-  export fcst_init_hour="0,12"
-  export fcst_valid_hour="0,12"
-  valid_time='valid00z_12z'
-  init_time='init00z_12z'
-
-  if [ $score_type = time_series ] ; then
-    export fcst_leads="120 240 360"
-  else 
-    export fcst_leads="vs_lead" 
-  fi
+  for score_type in $score_types ; do
+    if [ $score_type = time_series ] ; then
+      export fcst_leads="120 240 360"
+    else 
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
+	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in $VARs ; do 
-
-       if [ $VAR = PRMSL ]; then
-           VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
-       else
-           VX_MASK_LIST="G003, NHEM, SHEM, TROPICS"
-       fi
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
-	    
-       if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
-          FCST_LEVEL_values="Z2"
-       elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] ; then
-          FCST_LEVEL_values="Z10"
-       elif [ $VAR = PRMSL ] || [ $VAR = CAPEsfc ] ; then
-          FCST_LEVEL_values="L0"
-       fi
-
-       if [ $VAR = RH2m ] ; then
-          models='CMCE, GEFS'
-       elif [ $VAR = DPT2m ] ; then
-          models='ECME, GEFS'
-       else
-          models='ECME, CMCE, GEFS'
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-        verif_type=conus_sfc
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+      for VAR in $VARs ; do 
+        if [ $VAR = PRMSL ]; then
+          VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
         else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          VX_MASK_LIST="G003, NHEM, SHEM, TROPICS"
+        fi
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+	    
+        if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
+          FCST_LEVEL_values="Z2"
+        elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] ; then
+          FCST_LEVEL_values="Z10"
+        elif [ $VAR = PRMSL ] || [ $VAR = CAPEsfc ] ; then
+          FCST_LEVEL_values="L0"
         fi
 
+        if [ $VAR = RH2m ] ; then
+          models='CMCE, GEFS'
+        elif [ $VAR = DPT2m ] ; then
+          models='ECME, GEFS'
+        else
+          models='ECME, CMCE, GEFS'
+        fi
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=$FCST_LEVEL_value
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type} 
+            export prune_dir=$WORKtask/data
+            export save_dir=$WORKtask/out
+            export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+            export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+            mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+            mkdir -p $save_dir
+            mkdir -p $WORKtask/logs
+            mkdir -p $plot_dir
 
-         thresh_fcst=' '
-	 thresh_obs=' '
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=conus_sfc" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            thresh_fcst=''
+	    thresh_obs=''
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+            # Copy png files to plots_all_dir
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+	    # Cat the plotting log file
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-    done #end of VAR
-
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 88 -ppn 44 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 88 -ppn 44 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for var in prmsl tmp dpt ugrd vgrd rh; do
     if [ $var = rh ]; then
@@ -243,11 +208,13 @@ for var in prmsl tmp dpt ugrd vgrd rh; do
     else
         stats_list='acc me_mae crpss rmse_spread'
     fi
+
     if [ $var = prmsl ]; then
         domain_list='g003 nhem shem tropics conus'
     else
         domain_list='g003 nhem shem tropics'
     fi
+
     if [ $var = tmp ] || [ $var = dpt ] || [ $var = rh ]; then
         levels='2m'
     elif [ $var = ugrd ] || [ $var = vgrd ] ; then
@@ -257,6 +224,7 @@ for var in prmsl tmp dpt ugrd vgrd rh; do
     elif [ $var = prmsl ] ; then
         levels='z0'
     fi
+
     for domain in $domain_list ; do
         if [ $domain = g003 ] ; then
             domain_new="glb"
@@ -265,12 +233,14 @@ for var in prmsl tmp dpt ugrd vgrd rh; do
         else
             domain_new=$domain
         fi
+
         for stats in $stats_list ; do
             if [ $stats = rmse_spread ]; then
                 evs_graphic_stats="rmse_sprd"
             else
                 evs_graphic_stats=$stats
             fi
+
             for level in $levels ; do
                 if [ $level = '2m' ]; then
                     evs_graphic_level='z2'
@@ -279,6 +249,7 @@ for var in prmsl tmp dpt ugrd vgrd rh; do
                 else
                     evs_graphic_level=$level
                 fi
+
                 if [ $var = prmsl ] ; then
                     if [ -f "lead_average_regional_${domain}_valid_00z_12z_${var}_${stats}.png" ]; then
                         mv lead_average_regional_${domain}_valid_00z_12z_${var}_${stats}.png evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
@@ -288,6 +259,7 @@ for var in prmsl tmp dpt ugrd vgrd rh; do
                         mv lead_average_regional_${domain}_valid_00z_12z_${level}${unit}_${var}_${stats}.png evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
                     fi
                 fi
+
                 for lead in 120 240 360; do
                     if [ $var = prmsl ] ; then
                         if [ -f "time_series_regional_${domain}_valid_00z_12z_${var}_${stats}_f${lead}.png" ]; then
@@ -298,16 +270,16 @@ for var in prmsl tmp dpt ugrd vgrd rh; do
                             mv time_series_regional_${domain}_valid_00z_12z_${level}${unit}_${var}_${stats}_f${lead}.png evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.timeseries_valid00z_12z_f${lead}.g003_${domain_new}.png
                         fi
                     fi
-                done #lead
-            done #level
-        done #stats
-    done  #domain
-done     #stats
+                done # lead
+            done # level
+        done # stats
+    done # domain
+done # var
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then 
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_separate_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_grid2obs_separate_plots.sh
@@ -1,45 +1,42 @@
 #!/bin/ksh
-#******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens grid2grid  
-#          plotting python script separated by different validation times
+#*******************************************************************************
+# Purpose: set up environment, paths, and run the global_ens grid2obs  
+#          plotting python scripts separated by different valid times
 #
-# Last updated: 02/20/2025 L. Gwen Chen (lichuan.chen@noaa.gov)
-#               11/17/2023 Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
-set -x 
+# Updated: 07/21/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          02/20/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#*******************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-export interp_pnts=' '
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=$VERIF_CASE
 model_list='ECME CMCE GEFS'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hours="0 12"
+export interp_pnts=''
 
-
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
   hrs=$((n*24))
@@ -50,211 +47,203 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
  
-export fcst_init_hour="0, 12"
-export fcst_valid_hours="0 12"
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=$VERIF_CASE
-
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for fcst_valid_hour in $fcst_valid_hours ; do
-
   init_time=init${fcst_valid_hour}z
   valid_time=valid${fcst_valid_hour}z
 
-for stats in acc me_mae crpss rmse_spread ets fbias sratio_pod_csi ; do 
- if [ $stats = acc ] ; then
-  stat_list='acc'
-  line_tp='sal1l2'
-  VARs='TMP2m DPT2m UGRD10m VGRD10m'
-  score_types='time_series lead_average'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
- elif [ $stats = me_mae  ] ; then
-  stat_list='me, mae'
-  line_tp='ecnt'
-  VARs='TMP2m DPT2m UGRD10m VGRD10m RH2m'
-  score_types='time_series lead_average'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
- elif [ $stats = crpss ] ; then
-  stat_list='crpss'
-  line_tp='ecnt'
-  score_types='time_series lead_average'
-  VARs='TMP2m DPT2m UGRD10m VGRD10m'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
- elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-  VARs='TMP2m DPT2m UGRD10m VGRD10m RH2m'
-  score_types='time_series lead_average'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
- elif [ $stats = ets ] ; then
-  stat_list='ets'
-  line_tp='ctc'
-  VARs='CAPEsfc'
-  score_types='time_series lead_average'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
- elif [ $stats = fbias ] ; then
-  stat_list='fbias'
-  line_tp='ctc'
-  VARs='CAPEsfc'
-  score_types='time_series lead_average'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
-elif [ $stats = sratio_pod_csi ] ; then
-  stat_list='sratio, pod, csi'
-  line_tp='ctc'
-  VARs='CAPEsfc'
-  score_types='performance_diagram'
-  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
- else
-  err_exit "$stats is not a valid metric"
- fi   
+  for stats in acc me_mae crpss rmse_spread ets fbias sratio_pod_csi ; do 
+    if [ $stats = acc ] ; then
+      stat_list='acc'
+      line_tp='sal1l2'
+      VARs='TMP2m DPT2m UGRD10m VGRD10m'
+      score_types='time_series lead_average'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
+    elif [ $stats = me_mae ] ; then
+      stat_list='me, mae'
+      line_tp='ecnt'
+      VARs='TMP2m DPT2m UGRD10m VGRD10m RH2m'
+      score_types='time_series lead_average'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
+    elif [ $stats = crpss ] ; then
+      stat_list='crpss'
+      line_tp='ecnt'
+      VARs='TMP2m DPT2m UGRD10m VGRD10m'
+      score_types='time_series lead_average'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
+    elif [ $stats = rmse_spread ] ; then
+      stat_list='rmse, spread'
+      line_tp='ecnt'
+      VARs='TMP2m DPT2m UGRD10m VGRD10m RH2m'
+      score_types='time_series lead_average'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
+    elif [ $stats = ets ] ; then
+      stat_list='ets'
+      line_tp='ctc'
+      VARs='CAPEsfc'
+      score_types='time_series lead_average'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
+    elif [ $stats = fbias ] ; then
+      stat_list='fbias'
+      line_tp='ctc'
+      VARs='CAPEsfc'
+      score_types='time_series lead_average'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
+    elif [ $stats = sratio_pod_csi ] ; then
+      stat_list='sratio, pod, csi'
+      line_tp='ctc'
+      VARs='CAPEsfc'
+      score_types='performance_diagram'
+      VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
+    else
+      err_exit "$stats is not a valid metric"
+    fi   
 
- for score_type in $score_types ; do
-
-  if [ $score_type = time_series ] || [ $score_type = performance_diagram ] ; then
-    export fcst_leads="120 240 360"
-  else 
-    export fcst_leads="vs_lead" 
-  fi
+    for score_type in $score_types ; do
+      if [ $score_type = time_series ] || [ $score_type = performance_diagram ] ; then
+        export fcst_leads="120 240 360"
+      else 
+        export fcst_leads="vs_lead" 
+      fi
  
-  for lead in $fcst_leads ; do 
+      for lead in $fcst_leads ; do 
+        if [ $lead = vs_lead ] ; then
+	  export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+        else
+          export fcst_lead=$lead
+        fi
 
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
-        export fcst_lead=$lead
-   fi
-
-    for VAR in $VARs ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+        for VAR in $VARs ; do 
+          var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
-          FCST_LEVEL_values="Z2"
-       elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] ; then
-          FCST_LEVEL_values="Z10"
-       elif [ $VAR = CAPEsfc ] ; then
-	  FCST_LEVEL_values="L0"
-       fi
+          if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
+            FCST_LEVEL_values="Z2"
+          elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] ; then
+            FCST_LEVEL_values="Z10"
+          elif [ $VAR = CAPEsfc ] ; then
+	    FCST_LEVEL_values="L0"
+          fi
        
-       if [ $VAR = CAPEsfc ] && [ $line_tp = ctc ] ; then
-           if [ $score_type = performance_diagram ]; then
-               thresh_list='all'
-           else
-               thresh_list='ge250 ge500 ge1000 ge2000'
-           fi
-       else
-           thresh_list='NA'
-       fi
+          if [ $VAR = CAPEsfc ] && [ $line_tp = ctc ] ; then
+            if [ $score_type = performance_diagram ]; then
+              thresh_list='all'
+            else
+              thresh_list='ge250 ge500 ge1000 ge2000'
+            fi
+          else
+            thresh_list='NA'
+          fi
 
-       if [ $VAR = RH2m ] || [ $VAR = CAPEsfc ] ; then
-          models='CMCE, GEFS'
-       elif [ $VAR = DPT2m ] ; then
-          models='ECME, GEFS'
-       else
-          models='ECME, CMCE, GEFS'
-       fi
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-	OBS_LEVEL_value=$FCST_LEVEL_value
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+          if [ $VAR = RH2m ] || [ $VAR = CAPEsfc ] ; then
+            models='CMCE, GEFS'
+          elif [ $VAR = DPT2m ] ; then
+            models='ECME, GEFS'
+          else
+            models='ECME, CMCE, GEFS'
+          fi
 
-      for thresh in $thresh_list ; do 
+          for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	    OBS_LEVEL_value=$FCST_LEVEL_value
+            level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh  
+            for thresh in $thresh_list ; do 
+              export WORKtask=$DATA/run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}
+	      export prune_dir=$WORKtask/data
+	      export save_dir=$WORKtask/out
+	      export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	      export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	      mkdir -p $WORKtask
+	      mkdir -p $prune_dir
+	      mkdir -p $save_dir
+	      mkdir -p $WORKtask/logs
+	      mkdir -p $plot_dir
 
-        verif_type=conus_sfc
+              #************************
+              # Build sub-task scripts
+              #************************
+              > run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
 
-        echo "export PLOT_TYPE=$score_type" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-        echo "export field=${var}_${level}" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
+	      echo "export verif_case=$verif_case" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export verif_type=conus_sfc" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export ush_dir=$ush_dir" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export prune_dir=$prune_dir" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export save_dir=$save_dir" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export plot_dir=$plot_dir" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export output_base_dir=$output_base_dir" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export log_metplus=$log_metplus" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export log_level=DEBUG" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+              echo "export date_type=VALID" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export eval_period=TEST" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export valid_beg=$valid_beg" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export valid_end=$valid_end" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export init_beg=$init_beg" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export init_end=$init_end" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export fcst_level=$FCST_LEVEL_value" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export obs_level=$OBS_LEVEL_value" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export var_name=$VAR" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export line_type=$line_tp" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+              echo "export interp=NEAREST" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+              echo "export confidence_intervals=False" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "export PLOT_TYPE=$score_type" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
 
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-        echo "export verif_case=$verif_case" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-        echo "export verif_type=$verif_type" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-
-        echo "export log_level=DEBUG" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-        echo "export eval_period=TEST" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-
-        #if [ $score_type = valid_hour_average ] ; then
-        #  echo "export date_type=INIT" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-        #else
-        #  echo "export date_type=VALID" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-        #fi
-
-	export date_type=VALID
-
-         echo "export var_name=$VAR" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-
-         echo "export line_type=$line_tp" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-         echo "export interp=NEAREST" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-         echo "export score_py=$score_type" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-
-         if [ $VAR = CAPEsfc ] && [ $line_tp = ctc ] ; then
-              if [ $score_type = performance_diagram ]; then
+              if [ $VAR = CAPEsfc ] && [ $line_tp = ctc ] ; then
+                if [ $score_type = performance_diagram ]; then
                   thresh_fcst='>=250, >=500, >=1000, >=2000'
                   thresh_obs='>=250, >=500, >=1000, >=2000'
-              else
+                else
 	          thresh_fcst=$(echo ${thresh/ge/>=})
 	          thresh_obs=$(echo ${thresh/ge/>=})
-              fi
-	 elif [ $thresh = NA ]; then 
-	      thresh_fcst=' '
-	      thresh_obs=' '
-	 fi
+                fi
+	      elif [ $thresh = NA ]; then 
+	        thresh_fcst=''
+	        thresh_obs=''
+	      fi
 
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
+              sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
 
-         chmod +x  run_py.${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
-         echo "${DATA}/run_py.${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh" >> run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh
+              chmod +x $WORKtask/run_py.${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+              echo "$WORKtask/run_py.${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
 
-         chmod +x  run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh 
-         echo " ${DATA}/run_${fcst_valid_hour}_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.${line_tp}.sh" >> run_all_poe.sh
+	      # Copy png files to plots_all_dir
+	      echo "cp $plot_dir/*.png $plots_all_dir" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
 
-      done #end of thresh_list
-     done #end of FCST_LEVEL_value
-    done #end of VAR
-  done #end of fcst_lead
- done #end of score_type
-done #end of stats 
-done #fcst_valid_hour 
+              # Cat the plotting log file
+	      echo "if [ -s $log_metplus ]; then" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+              echo "  cat $log_metplus" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+	      echo "fi" >> run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh
+
+              chmod +x run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh 
+              echo "${DATA}/run_${fcst_valid_hour}.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${thresh}.sh" >> run_all_poe.sh
+
+            done # end of thresh
+          done # end of FCST_LEVEL_value
+        done # end of VAR
+      done # end of lead
+    done # end of score_type
+  done # end of stats 
+done # end of fcst_valid_hour 
 
 chmod +x run_all_poe.sh
 
-
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 108 -ppn 54 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 108 -ppn 54 -depth 2 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for ihr in 00z 12z ; do
     for domain in conus conus_east conus_west conus_south conus_central ; do
@@ -269,18 +258,19 @@ for ihr in 00z 12z ; do
         else
             evs_graphic_domain=$domain
         fi
-        for lead in 120 240 360; do
+
+        for lead in 120 240 360 ; do
             if [ -f "performance_diagram_regional_${domain}_valid_${ihr}_cape_f${lead}__ge250ge500ge1000ge2000.png" ]; then
-                mv performance_diagram_regional_${domain}_valid_${ihr}_cape_f${lead}__ge250ge500ge1000ge2000.png  evs.global_ens.ctc.cape_l0.last${past_days}days.perfdiag_valid${ihr}_f${lead}.g212_buk_${evs_graphic_domain}.png
+                mv performance_diagram_regional_${domain}_valid_${ihr}_cape_f${lead}__ge250ge500ge1000ge2000.png evs.global_ens.ctc.cape_l0.last${past_days}days.perfdiag_valid${ihr}_f${lead}.g212_buk_${evs_graphic_domain}.png
             fi
-        done #lead
-    done #domain
-done #ihr
+        done # lead
+    done # domain
+done # ihr
 
 for stats in ets fbias ; do
     for ihr in 00z 12z ; do
         for thresh in ge250 ge500 ge1000 ge2000 ; do
-            for domain in conus conus_east conus_west conus_south conus_central  ; do
+            for domain in conus conus_east conus_west conus_south conus_central ; do
                 if [ $domain = conus_east ]; then
                     evs_graphic_domain="conus_e"
                 elif [ $domain = conus_west ]; then
@@ -292,18 +282,20 @@ for stats in ets fbias ; do
                 else
                     evs_graphic_domain=$domain
                 fi
+
                 if [ -f "lead_average_regional_${domain}_valid_${ihr}_cape_${stats}_${thresh}.png" ]; then
-                    mv lead_average_regional_${domain}_valid_${ihr}_cape_${stats}_${thresh}.png  evs.global_ens.${stats}_${thresh}.cape_l0.last${past_days}days.fhrmean_valid${ihr}_f384.g212_buk_${evs_graphic_domain}.png
+                    mv lead_average_regional_${domain}_valid_${ihr}_cape_${stats}_${thresh}.png evs.global_ens.${stats}_${thresh}.cape_l0.last${past_days}days.fhrmean_valid${ihr}_f384.g212_buk_${evs_graphic_domain}.png
                 fi
+
                 for lead in 120 240 360 ; do
                     if [ -f "time_series_regional_${domain}_valid_${ihr}_cape_${stats}_f${lead}_${thresh}.png" ]; then
-                        mv time_series_regional_${domain}_valid_${ihr}_cape_${stats}_f${lead}_${thresh}.png  evs.global_ens.${stats}_${thresh}.cape_l0.last${past_days}days.timeseries_valid${ihr}_f${lead}.g212_buk_${evs_graphic_domain}.png
+                        mv time_series_regional_${domain}_valid_${ihr}_cape_${stats}_f${lead}_${thresh}.png evs.global_ens.${stats}_${thresh}.cape_l0.last${past_days}days.timeseries_valid${ihr}_f${lead}.g212_buk_${evs_graphic_domain}.png
                     fi
-                done #lead
-            done #domain
-        done #thresh
-    done #ihr
-done #stats
+                done # lead
+            done # domain
+        done # thresh
+    done # ihr
+done # stats
 
 for ihr in 00z 12z ; do
     for var in tmp dpt ugrd vgrd rh ; do
@@ -312,11 +304,13 @@ for ihr in 00z 12z ; do
         elif [ $var = ugrd ] || [ $var = vgrd ] ; then
             levels='10m'
         fi
+
         if [ $var = rh ]; then
             stats_list="me_mae rmse_spread"
         else
             stats_list="acc me_mae crpss rmse_spread"
         fi
+
         for domain in conus conus_east conus_west conus_south conus_central alaska ; do
             if [ $domain = conus ]; then
                 evs_graphic_domain="buk_conus"
@@ -331,36 +325,41 @@ for ihr in 00z 12z ; do
             else
                 evs_graphic_domain=$domain
             fi
+
             if [ $domain = alaska ]; then
                 grid="g003"
             else
                 grid="g212"
             fi
+
             for stats in $stats_list ; do
                 if [ $stats = rmse_spread ]; then
                     evs_graphic_stats="rmse_sprd"
                 else
                     evs_graphic_stats=$stats
                 fi
+
                 for level in $levels ; do
                     if [ $level = '2m' ]; then
                         evs_graphic_level='z2'
                     elif [ $level = '10m' ]; then
                         evs_graphic_level='z10'
                     fi
+
                     if [ -f "lead_average_regional_${domain}_valid_${ihr}_${level}_${var}_${stats}.png" ]; then
-                        mv lead_average_regional_${domain}_valid_${ihr}_${level}_${var}_${stats}.png  evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.fhrmean_valid${ihr}_f384.${grid}_${evs_graphic_domain}.png
+                        mv lead_average_regional_${domain}_valid_${ihr}_${level}_${var}_${stats}.png evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.fhrmean_valid${ihr}_f384.${grid}_${evs_graphic_domain}.png
                     fi
+
                     for lead in 120 240 360; do
                         if [ -f "time_series_regional_${domain}_valid_${ihr}_${level}_${var}_${stats}_f${lead}.png" ]; then
-                            mv time_series_regional_${domain}_valid_${ihr}_${level}_${var}_${stats}_f${lead}.png  evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.timeseries_valid${ihr}_f${lead}.${grid}_${evs_graphic_domain}.png
+                            mv time_series_regional_${domain}_valid_${ihr}_${level}_${var}_${stats}_f${lead}.png evs.global_ens.${evs_graphic_stats}.${var}_${evs_graphic_level}.last${past_days}days.timeseries_valid${ihr}_f${lead}.${grid}_${evs_graphic_domain}.png
                         fi
-                    done #lead
-                done #level
-            done #stats
-        done  #domain
-    done     #var
-done     #ihr
+                    done # lead
+                done # level
+            done # stats
+        done # domain
+    done # var
+done # ihr
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}_separate.past${past_days}days.v${VDATE}.tar *.png
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_precip_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_precip_plots.sh
@@ -1,30 +1,28 @@
 #!/bin/ksh
-#******************************************************************************
+#**************************************************************************
 # Purpose: set up environment, paths, and run the global_ens precip
-#          plotting python script
+#          plotting python scripts
 #
-# Last updated: 03/14/2025 L. Gwen Chen (lichuan.chen@noaa.gov)
-#               11/17/2023 Binbin Zhou Lynker@EMC/NCEP
-#******************************************************************************
+# Updated: 07/23/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          03/14/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#**************************************************************************
 set -x 
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=$VERIF_CASE
+verif_type=ccpa
 model_list='ECME CMCE GEFS'
 models='ECME, CMCE, GEFS'
+VX_MASK_LIST="CONUS, CONUS_East, CONUS_South, CONUS_Central, CONUS_West"
+valid_time='valid_12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
@@ -33,12 +31,16 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="12"
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
   hrs=$((n*24))
@@ -48,17 +50,6 @@ while [ $n -le $past_days ] ; do
   export err=$?; err_chk
   n=$((n+1))
 done 
-
-VX_MASK_LIST="CONUS, CONUS_East, CONUS_South, CONUS_Central, CONUS_West"
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="12"
-
-export plot_dir=$DATA/out/precip/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=$VERIF_CASE
-verif_type=ccpa
 
 #*****************************************
 # Build a POE script to collect sub-tasks
@@ -111,49 +102,39 @@ for stats in ets fbias crps me rmse bs bss fss ; do
   fi   
 
   if [ $stats = fss ] ; then
-   interp_pnts='1 9 25 49 81 121'
+    interp_pnts='1 9 25 49 81 121'
   else
-   interp_pnts='1'
+    interp_pnts='1'
   fi 
 
   for score_type in time_series lead_average ; do
-
     if [ $score_type = time_series ] ; then
-      export fcst_init_hour="0,12"
-      export fcst_valid_hour="12"
-      valid_time='valid_12z'
-      init_time='init00z_12z'
       export fcst_leads="120 240 360"
     else
-      export fcst_init_hour="0,12"
-      export fcst_valid_hour="12"
-      valid_time='valid_12z'
-      init_time='init00z_12z'
       export fcst_leads="vs_lead" 
     fi
  
     for lead in $fcst_leads ; do 
-
       if [ $lead = vs_lead ] ; then
 	export fcst_lead="24, 48, 72, 96, 120, 144, 168, 192, 216, 240, 264, 288, 312, 336, 360, 384"
       else
         export fcst_lead=$lead
       fi
 
-      for VAR in $VARs; do 
+      for VAR in $VARs ; do 
         var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
         FCST_LEVEL_values="A24"
 
         if [ $VAR = APCP24_gt1 ] ; then
-	   threshes='>1'
+	  threshes='>1'
         elif [ $VAR = APCP24_gt5 ] ; then
-           threshes='>5'	       
+          threshes='>5'	       
         elif [ $VAR = APCP24_gt10 ] ; then
-           threshes='>10'
+          threshes='>10'
         elif [ $VAR = APCP24_gt25 ] ; then
-           threshes='>25'
+          threshes='>25'
         elif [ $VAR = APCP24_gt50 ] ; then
-           threshes='>50'
+          threshes='>50'
         fi
 
         for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
@@ -161,69 +142,89 @@ for stats in ets fbias crps me rmse bs bss fss ; do
           level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
           for interp_pnt in $interp_pnts ; do 
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/precip/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-          #***************************
-          # Build sub-task scripts
-          #***************************
-          > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh  
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh  
 
-          echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export line_type=$line_tp" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          if [ $score_type = valid_hour_average ] ; then
-            echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          else
-            echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          fi
+	    if [ $stats = fss ] ; then
+              echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+              interp_pnt_config=$interp_pnt
+            else	   
+	      echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+              interp_pnt_config=''
+	    fi
 
-          echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export line_type=$line_tp" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    if [ $line_tp = pstd ] ; then
+	      thresh_fcst='==0.10000'
+	      thresh_obs=$threshes
+            else
+	      thresh_fcst=$threshes
+              thresh_obs=$threshes
+	    fi
 
-	  if [ $stats = fss ] ; then
-            echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-            interp_pnt_config=$interp_pnt
-          else	   
-	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-            interp_pnt_config=''
-	  fi
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnt_config!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-	  echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-	  if [ $line_tp = pstd ] ; then
-	    thresh_fcst='==0.10000'
-	    thresh_obs=$threshes
-          else
-	    thresh_fcst=$threshes
-            thresh_obs=$threshes
-	  fi
+	    # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnt_config!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          chmod +x run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_all_poe.sh
 
-          chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh 
-          echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_all_poe.sh
-
-          done #end of interp_pnts
-        done #end of FCST_LEVEL_value
-      done #end of VAR
-    done #end of fcst_lead
-  done #end of score_type
-done #end of stats 
+          done # end of interp_pnt
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#**************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
@@ -231,15 +232,10 @@ else
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-  echo "Start: $log_file"
-  cat $log_file
-  echo "End: $log_file"
-fi
-
-cd $plot_dir
+#*************************************************
+# Change plot file names to meet the EVS standard
+#*************************************************
+cd $plots_all_dir
 
 for domain in conus conus_east conus_west conus_south conus_central ; do
     if [ $domain = conus ]; then
@@ -314,11 +310,11 @@ for domain in conus conus_east conus_west conus_south conus_central ; do
                             mv time_series_regional_${domain}_valid_12z_24h_apcp_24_${stat}${nbhrd_graphic}${lead_graphic}${thresh_graphic}.png evs.global_ens.${stat}${nbhrd_graphic}${thresh_graphic}.apcp_a24.last${past_days}days.timeseries_valid12z${lead_graphic}.g212_${evs_graphic_domain}.png
                         fi
                     fi
-                done
-            done
-        done
-    done
-done
+                done # lead
+            done # nbrhd
+        done # thresh
+    done # stat
+done # domain
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile1_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile1_plots.sh
@@ -1,50 +1,49 @@
 #!/bin/ksh
 #*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens profile1  
-#          plotting python script
-#  Note: The profile plots are split to 4 smaller scripts: profile1,2,3,4.
-#        The profile1 is for ECNT scores at different levels 
+# Purpose: set up environment, paths, and run the global_ens profile1  
+#          plotting python scripts
+# Note:    The profile plots are split to 4 smaller scripts: profile1,2,3,4.
+#          profile1 is for ECNT scores at different levels. 
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
-set -x 
+# Updated: 07/24/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#*******************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts='' 
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=grid2obs
+verif_type=upper_air
 model_list='ECME CMCE GEFS'
+VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
+valid_time='valid00z_12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0,12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -53,162 +52,140 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0,12"
-valid_time='valid00z_12z'
-init_time='init00z_12z'
-
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=grid2obs
-verif_type=upper_air
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in rmse_spread me ; do 
-
-if [ $stats = me ] ; then
-  stat_list='me'
-  line_tp='ecnt'
-elif [ $stats = mae ] ; then
-  stat_list='mae'
-  line_tp='ecnt'
-elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-else
-  err_exit "$stats is not a valid metric"
-fi   
-
- for score_type in time_series lead_average ; do
-
-  if [ $score_type = time_series ] ; then
-    export fcst_leads="120 240 360"
+  if [ $stats = me ] ; then
+    stat_list='me'
+    line_tp='ecnt'
+  elif [ $stats = mae ] ; then
+    stat_list='mae'
+    line_tp='ecnt'
+  elif [ $stats = rmse_spread ] ; then
+    stat_list='rmse, spread'
+    line_tp='ecnt'
   else
-    export fcst_leads="vs_lead" 
-  fi
+    err_exit "$stats is not a valid metric"
+  fi   
+
+  for score_type in time_series lead_average ; do
+    if [ $score_type = time_series ] ; then
+      export fcst_leads="120 240 360"
+    else
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
+	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in HGT TMP UGRD VGRD RH ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in HGT TMP UGRD VGRD RH ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
+        if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
           FCST_LEVEL_values="P1000 P925 P850 P700 P500 P300 P250 P200 P100 P50 P10"
-       elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
+        elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
           FCST_LEVEL_values="P1000 P925 P850 P700 P500 P250 P200 P100 P50 P10"
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-	 if [ $FCST_LEVEL_value = P10 ] || [ $FCST_LEVEL_value = P250 ]; then
-	    models='CMCE, GEFS'
-	 else
-            models='ECME, CMCE, GEFS'
-	 fi
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
         fi
 
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=$FCST_LEVEL_value
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	  if [ $FCST_LEVEL_value = P10 ] || [ $FCST_LEVEL_value = P250 ]; then
+	    models='CMCE, GEFS'
+	  else
+	    models='ECME, CMCE, GEFS'
+	  fi
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do 
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-	 thresh=' '
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    thresh=''
 
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+	    chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+	    # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+            # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-    done #end of VAR
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 440 -ppn 88 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 440 -ppn 88 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for stats in rmse_spread me ; do
     if [ $stats = rmse_spread ]; then
@@ -216,6 +193,7 @@ for stats in rmse_spread me ; do
     else
         evs_graphic_stats=$stats
     fi
+
     for domain in g003 nhem shem tropics conus ; do
         if [ $domain = g003 ] ; then
             domain_new=glb
@@ -224,34 +202,38 @@ for stats in rmse_spread me ; do
         else
             domain_new=$domain
         fi
-        for var in hgt tmp ugrd vgrd rh ; do
+        
+	for var in hgt tmp ugrd vgrd rh ; do
             if [ $var = hgt ] || [ $var = ugrd ] || [ $var = vgrd ] ; then
                 levels='1000 925 850 700 500 300 250 200 100 50 10'
             elif [ $var = tmp ] || [ $var = rh ] ; then
-                levels='1000 925 850 700 500  250 200 100 50 10'
+                levels='1000 925 850 700 500 250 200 100 50 10'
             fi
-            for level in $levels ; do
+            
+	    for level in $levels ; do
                 plevel=p${level}
                 if [ -f "lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png" ]; then
-                    mv lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png  evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
+                    mv lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
                 fi
-                for lead in 120 240 360; do
+                
+		for lead in 120 240 360; do
                     if [ -f "time_series_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}_f${lead}.png" ]; then
-                        mv time_series_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}_f${lead}.png  evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.timeseries_valid00z_12z_f${lead}.g003_${domain_new}.png
+                        mv time_series_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}_f${lead}.png evs.global_ens.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.timeseries_valid00z_12z_f${lead}.g003_${domain_new}.png
                     fi
-                done #lead
-            done #level
-        done #var
-    done  #domain
-done     #stats
+	        done # lead
+            done # level
+        done # var
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v  evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
+
 if [ $SENDDBN = YES ]; then 
     $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar
 fi

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile2_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile2_plots.sh
@@ -1,50 +1,49 @@
 #!/bin/ksh
 #*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens profile2 
-#          plotting python script
-#  Note: The profile plots are split to 4 smaller scripts: profile1,2,3,4.
-#        The profile2 is for MAE for different levels
+# Purpose: set up environment, paths, and run the global_ens profile2 
+#          plotting python scripts
+# Note:    The profile plots are split to 4 smaller scripts: profile1,2,3,4.
+#          profile2 is for MAE at different levels
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP
-#******************************************************************************
-set -x 
+# Updated: 07/28/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#*******************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts='' 
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=grid2obs
+verif_type=upper_air
 model_list='ECME CMCE GEFS'
+VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
+valid_time='valid00z_12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0,12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -53,162 +52,134 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0,12"
-valid_time='valid00z_12z'
-init_time='init00z_12z'
-
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=grid2obs
-verif_type=upper_air
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
-for stats in  mae ; do 
-
-if [ $stats = me ] ; then
-  stat_list='me'
-  line_tp='ecnt'
-elif [ $stats = mae ] ; then
-  stat_list='mae'
-  line_tp='ecnt'
-elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-else
-  err_exit "$stats is not a valid metric"
-fi   
-
- for score_type in time_series lead_average ; do
-
-  if [ $score_type = time_series ] ; then
-    export fcst_leads="120 240 360"
+for stats in mae ; do 
+  if [ $stats = mae ] ; then
+    stat_list='mae'
+    line_tp='ecnt'
   else
-    export fcst_leads="vs_lead" 
-  fi
+    err_exit "$stats is not a valid metric"
+  fi   
+
+  for score_type in time_series lead_average ; do
+    if [ $score_type = time_series ] ; then
+      export fcst_leads="120 240 360"
+    else
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
+        export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in HGT TMP UGRD VGRD RH ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in HGT TMP UGRD VGRD RH ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
+        if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
           FCST_LEVEL_values="P1000 P925 P850 P700 P500 P300 P250 P200 P100 P50 P10"
-       elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
+        elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
           FCST_LEVEL_values="P1000 P925 P850 P700 P500 P250 P200 P100 P50 P10"
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-	 if [ $FCST_LEVEL_value = P10 ] || [ $FCST_LEVEL_value = P250 ]; then
-	    models='CMCE, GEFS'
-	 else
-	    models='ECME, CMCE, GEFS'
-         fi
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
         fi
 
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=$FCST_LEVEL_value
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	  if [ $FCST_LEVEL_value = P10 ] || [ $FCST_LEVEL_value = P250 ]; then
+	    models='CMCE, GEFS'
+	  else
+	    models='ECME, CMCE, GEFS'
+	  fi
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do
+	    export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+            export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+            mkdir -p $plot_dir				
 
-	 thresh=' '
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    thresh=''
 
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+	    # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+	    # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-    done #end of VAR
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 212 -ppn 53 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 212 -ppn 53 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for stats in mae ; do
     for domain in g003 nhem shem tropics conus ; do
@@ -219,32 +190,35 @@ for stats in mae ; do
         else
             domain_new=$domain
         fi
+
         for var in hgt tmp ugrd vgrd rh ; do
             if [ $var = hgt ] || [ $var = ugrd ] || [ $var = vgrd ] ; then
                 levels='1000 925 850 700 500 300 250 200 100 50 10'
             elif [ $var = tmp ] || [ $var = rh ] ; then
                 levels='1000 925 850 700 500 250 200 100 50 10'
             fi
+
             for level in $levels ; do
                 plevel=p${level}
                 if [ -f "lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png" ]; then
-                    mv lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png  evs.global_ens.${stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
+                    mv lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png evs.global_ens.${stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain_new}.png
                 fi
+
                 for lead in 120 240 360; do
                     if [ -f "time_series_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}_f${lead}.png" ]; then
-                        mv time_series_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}_f${lead}.png  evs.global_ens.${stats}.${var}_${plevel}.last${past_days}days.timeseries_valid00z_12z_f${lead}.g003_${domain_new}.png
+                        mv time_series_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}_f${lead}.png evs.global_ens.${stats}.${var}_${plevel}.last${past_days}days.timeseries_valid00z_12z_f${lead}.g003_${domain_new}.png
                     fi
-                done #lead
-            done #level
-        done #var
-    done  #domain
-done     #stats
+                done # lead
+            done # level
+        done # var
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile3_plots.sh
@@ -1,50 +1,49 @@
 #!/bin/ksh
 #*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens profile3
-#          plotting python script
-#  Note: The profile plots are split to 4 smaller scripts: profile1,2,3,4.
-#        The profile3 is for ECNT score profiles 
+# Purpose: set up environment, paths, and run the global_ens profile3
+#          plotting python scripts
+# Note:    The profile plots are split to 4 smaller scripts: profile1,2,3,4.
+#          profile3 is for vertical profiles of ECNT scores 
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP
-#******************************************************************************
-set -x 
+# Updated: 07/28/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#*******************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts='' 
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=grid2obs
+verif_type=upper_air
 model_list='ECME CMCE GEFS'
+VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
+valid_time='valid12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -53,150 +52,130 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="12"
-valid_time='valid12z'
-init_time='init00z_12z'
-
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=grid2obs
-verif_type=upper_air
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in rmse_spread me ; do 
+  if [ $stats = me ] ; then
+    stat_list='me'
+    line_tp='ecnt'
+  elif [ $stats = mae ] ; then
+    stat_list='mae'
+    line_tp='ecnt'
+  elif [ $stats = rmse_spread ] ; then
+    stat_list='rmse, spread'
+    line_tp='ecnt'
+  else
+    err_exit "$stats is not a valid metric"
+  fi   
 
-if [ $stats = me ] ; then
-  stat_list='me'
-  line_tp='ecnt'
-elif [ $stats = mae ] ; then
-  stat_list='mae'
-  line_tp='ecnt'
-elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-else
-  err_exit "$stats is not a valid metric"
-fi   
-
- for score_type in stat_by_level ; do
-
-  export fcst_leads="0 12 24 36 48 60 72 84 96 108 120 132 144 156 168 180 192 204 216 228 240 252 264 276 288 300 312 324 336 348 360 372 384"
+  for score_type in stat_by_level ; do
+    export fcst_leads="0 12 24 36 48 60 72 84 96 108 120 132 144 156 168 180 192 204 216 228 240 252 264 276 288 300 312 324 336 348 360 372 384"
  
-  for lead in $fcst_leads ; do 
+    for lead in $fcst_leads ; do 
+      export fcst_lead=$lead
 
-    export fcst_lead=$lead
+      if [ $fcst_lead = 372 ] || [ $fcst_lead = 384 ]; then
+	models='CMCE, GEFS'
+      else
+	models='ECME, CMCE, GEFS'
+      fi
 
-    for VAR in HGT TMP UGRD VGRD RH ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in HGT TMP UGRD VGRD RH ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ]; then
+        if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ]; then
           FCST_LEVEL_value="P1000,P925,P850,P700,P500,P300,P250,P200,P100,P50,P10"
-       elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
+        elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
           FCST_LEVEL_value="P1000,P925,P850,P700,P500,P250,P200,P100,P50,P10"
-       fi
-
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh  
-
-	if [ $fcst_lead = 372 ] || [ $fcst_lead = 384 ]; then
-           models='CMCE, GEFS'
-	else
-           models='ECME, CMCE, GEFS'
-	fi
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
         fi
 
+	OBS_LEVEL_value=$FCST_LEVEL_value
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+        for line_type in $line_tp ; do
+	  export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${line_type}
+          export prune_dir=$WORKtask/data
+          export save_dir=$WORKtask/out
+          export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+          export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+          mkdir -p $WORKtask
+          mkdir -p $prune_dir
+          mkdir -p $save_dir
+          mkdir -p $WORKtask/logs
+          mkdir -p $plot_dir	    
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          #************************
+          # Build sub-task scripts
+          #************************
+          > run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh  
 
-	 thresh=' '
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  thresh=''
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
+          chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_all_poe.sh
+          # Copy png files to plots_all_dir            
+	  echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-      done #end of line_type
+	  # Cat the plotting log file            
+	  echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh            
+	  echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-    done #end of VAR
+          chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh 
+          echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_all_poe.sh
 
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+        done # end of line_type
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 330 -ppn 55 --cpu-bind verbose,depth --depth 2 cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 330 -ppn 55 --cpu-bind verbose,depth --depth 2 cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for stats in rmse_spread me ; do
     if [ $stats = rmse_spread ]; then
@@ -204,6 +183,7 @@ for stats in rmse_spread me ; do
     else
         evs_graphic_stats=$stats
     fi
+
     for domain in g003 nhem shem tropics conus ; do
         if [ $domain = g003 ] ; then
             domain_new=glb
@@ -212,28 +192,29 @@ for stats in rmse_spread me ; do
         else
             domain_new=$domain
         fi
-        for var in hgt tmp ugrd vgrd rh ; do
+
+	for var in hgt tmp ugrd vgrd rh ; do
             leads="0 12 24 36 48 60 72 84 96 108 120 132 144 156 168 180 192 204 216 228 240 252 264 276 288 300 312 324 336 348 360 372 384"
-            for lead in $leads ; do
+
+	    for lead in $leads ; do
                 lead_new=$(printf "%03d" "${lead}")
                 if [ -f "stat_by_level_regional_${domain}_valid_12z_${var}_${stats}_f${lead}.png" ]; then
-                    mv stat_by_level_regional_${domain}_valid_12z_${var}_${stats}_f${lead}.png  evs.global_ens.${evs_graphic_stats}.${var}_all.last${past_days}days.vertprof_valid12z_f${lead_new}.g003_${domain_new}.png
+                    mv stat_by_level_regional_${domain}_valid_12z_${var}_${stats}_f${lead}.png evs.global_ens.${evs_graphic_stats}.${var}_all.last${past_days}days.vertprof_valid12z_f${lead_new}.g003_${domain_new}.png
                 fi
-            done #lead
-        done #var
-    done  #domain
-done     #stats
+            done # lead
+        done # var
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 
 if [ $SENDDBN = YES ]; then 
     $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar
 fi
-
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile4_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_profile4_plots.sh
@@ -1,50 +1,49 @@
 #!/bin/ksh
 #*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens profile4
-#          plotting python script
-#  Note: The profile plots are split to 4 smaller scripts: profile1,2,3,4.
-#        The profile4 is for MAE profiles
+# Purpose: set up environment, paths, and run the global_ens profile4
+#          plotting python scripts
+# Note:    The profile plots are split to 4 smaller scripts: profile1,2,3,4.
+#          profile4 is for MAE vertical profiles
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP
-#******************************************************************************
-set -x 
+# Updated: 07/29/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#*******************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts='' 
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=grid2obs
+verif_type=upper_air
 model_list='ECME CMCE GEFS'
+VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
+valid_time='valid12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required  stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -53,150 +52,124 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="G003, NHEM, SHEM, TROPICS, CONUS"
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="12"
-valid_time='valid12z'
-init_time='init00z_12z'
-
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=grid2obs
-verif_type=upper_air
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
-for stats in  mae; do 
+for stats in mae ; do 
+  if [ $stats = mae ] ; then
+    stat_list='mae'
+    line_tp='ecnt'
+  else
+    err_exit "$stats is not a valid metric"
+  fi   
 
-if [ $stats = me ] ; then
-  stat_list='me'
-  line_tp='ecnt'
-elif [ $stats = mae ] ; then
-  stat_list='mae'
-  line_tp='ecnt'
-elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-else
-  err_exit "$stats is not a valid metric"
-fi   
-
- for score_type in stat_by_level ; do
-
-  export fcst_leads="0 12 24 36 48 60 72 84 96 108 120 132 144 156 168 180 192 204 216 228 240 252 264 276 288 300 312 324 336 348 360 372 384"
+  for score_type in stat_by_level ; do
+    export fcst_leads="0 12 24 36 48 60 72 84 96 108 120 132 144 156 168 180 192 204 216 228 240 252 264 276 288 300 312 324 336 348 360 372 384"
  
-  for lead in $fcst_leads ; do 
+    for lead in $fcst_leads ; do 
+      export fcst_lead=$lead
 
-    export fcst_lead=$lead
+      if [ $fcst_lead = 372 ] || [ $fcst_lead = 384 ]; then
+	models='CMCE, GEFS'
+      else
+	models='ECME, CMCE, GEFS'
+      fi
 
-    for VAR in HGT TMP UGRD VGRD RH ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in HGT TMP UGRD VGRD RH ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
+        if [ $VAR = HGT ] || [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
           FCST_LEVEL_value="P1000,P925,P850,P700,P500,P300,P250,P200,P100,P50,P10"
-       elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
+        elif [ $VAR = TMP ] || [ $VAR = RH ] ; then
           FCST_LEVEL_value="P1000,P925,P850,P700,P500,P250,P200,P100,P50,P10"
-       fi
-
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh  
-
-	if [ $fcst_lead = 372 ] || [ $fcst_lead = 384 ]; then
-	   models='CMCE, GEFS'
-	else
-	   models='ECME, CMCE, GEFS'
-	fi
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
         fi
 
+	OBS_LEVEL_value=$FCST_LEVEL_value
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+        for line_type in $line_tp ; do
+	  export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${line_type}
+          export prune_dir=$WORKtask/data
+          export save_dir=$WORKtask/out
+          export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+          export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+          mkdir -p $WORKtask
+          mkdir -p $prune_dir
+          mkdir -p $save_dir
+          mkdir -p $WORKtask/logs
+          mkdir -p $plot_dir	  
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          #************************
+          # Build sub-task scripts
+          #************************
+          > run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh  
 
-	 thresh=' '
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  thresh=''
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
+          chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+          echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_all_poe.sh
+	  # Copy png files to plots_all_dir          
+	  echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-      done #end of line_type
+	  # Cat the plotting log file          
+	  echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh          
+	  echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
+	  echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh
 
-    done #end of VAR
+          chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh 
+          echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${line_type}.sh" >> run_all_poe.sh
 
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+        done # end of line_type
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 160 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 160 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for stats in mae ; do
     for domain in g003 nhem shem tropics conus ; do
@@ -207,23 +180,25 @@ for stats in mae ; do
         else
             domain_new=$domain
         fi
+
         for var in hgt tmp ugrd vgrd rh ; do
             leads="0 12 24 36 48 60 72 84 96 108 120 132 144 156 168 180 192 204 216 228 240 252 264 276 288 300 312 324 336 348 360 372 384"
-            for lead in $leads ; do
+        
+	    for lead in $leads ; do
                 lead_new=$(printf "%03d" "${lead}")
                 if [ -f "stat_by_level_regional_${domain}_valid_12z_${var}_${stats}_f${lead}.png" ]; then
-                    mv stat_by_level_regional_${domain}_valid_12z_${var}_${stats}_f${lead}.png  evs.global_ens.${stats}.${var}_all.last${past_days}days.vertprof_valid12z_f${lead_new}.g003_${domain_new}.png
+                    mv stat_by_level_regional_${domain}_valid_12z_${var}_${stats}_f${lead}.png evs.global_ens.${stats}.${var}_all.last${past_days}days.vertprof_valid12z_f${lead_new}.g003_${domain_new}.png
                 fi
-            done #lead
-        done #var
-    done  #domain
-done     #stats
+            done # lead
+        done # var
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_sea_ice_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_sea_ice_plots.sh
@@ -1,49 +1,48 @@
 #!/bin/ksh
-#*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens sea ice score
-#          plotting python script. Only GEFS scores are  in the plots
+#**************************************************************************
+# Purpose: set up environment, paths, and run the global_ens seaice 
+#          plotting python scripts. Plots only contain GEFS metrics.
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
+# Updated: 07/29/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#**************************************************************************
 set -x 
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts=''
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=satellite
+verif_type=ghrsst_ncei_avhrr_anl
 model_list='GEFS'
 models='GEFS'
+VX_MASK_LIST="ARCTIC, ANTARCTIC"
+valid_time='valid00z'
+init_time='init00z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0"
+export fcst_valid_hour="0"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -52,213 +51,199 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="ARCTIC, ANTARCTIC"
-																  
-export fcst_init_hour="0"
-export fcst_valid_hour="0"
-valid_time='valid00z'
-init_time='init00z'
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-
-verif_case=satellite
-verif_type=ghrsst_ncei_avhrr_anl
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in rmse me csi sratio_pod_csi ; do 
- if [ $stats = rmse  ] ; then
-   stat_list='rmse'
-   line_tp='ecnt'
-   VARs='ICEC'
-   threshes=''
-   score_types='time_series lead_average'
- elif [ $stats = me  ] ; then
-   stat_list='me'
-   line_tp='ecnt'
-   VARs='ICEC'
-   threshes=''
-   score_types='time_series lead_average'
- elif [ $stats = csi  ] ; then
+  if [ $stats = rmse ] ; then
+    stat_list='rmse'
+    line_tp='ecnt'
+    VARs='ICEC'
+    threshes=''
+    score_types='time_series lead_average'
+  elif [ $stats = me ] ; then
+    stat_list='me'
+    line_tp='ecnt'
+    VARs='ICEC'
+    threshes=''
+    score_types='time_series lead_average'
+  elif [ $stats = csi ] ; then
     stat_list='csi'
     line_tp='ctc'	  
     VARs='ICEC_gt10 ICEC_gt40 ICEC_gt80'
     threshes=''
     score_types='time_series lead_average'
- elif [ $stats = sratio_pod_csi ] ; then
+  elif [ $stats = sratio_pod_csi ] ; then
     stat_list='sratio, pod, csi'
     line_tp='ctc'
     VARs='ICEC'
     threshes='>10, >40, >80'
     score_types='performance_diagram'
- else
-   err_exit "$stats is not a valid metric"
- fi   
-
- for score_type in $score_types ; do
-
-  if [ $score_type = time_series ] || [ $score_type = performance_diagram ] ; then
-    export fcst_leads="24 48 72 96 120 144 168 192 216 240 264 288 312 336 360 384"
   else
-    export fcst_leads="vs_lead" 
-  fi
+    err_exit "$stats is not a valid metric"
+  fi   
+
+  for score_type in $score_types ; do
+    if [ $score_type = time_series ] || [ $score_type = performance_diagram ] ; then
+      export fcst_leads="24 48 72 96 120 144 168 192 216 240 264 288 312 336 360 384"
+    else
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
 	export fcst_lead="24, 48, 72, 96, 120, 144, 168, 192, 216, 240, 264, 288, 312, 336, 360, 384"
-   else
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in $VARs ; do 
+      for VAR in $VARs ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+        FCST_LEVEL_values="Z0"
 
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
-	    
-       FCST_LEVEL_values="Z0"
-
-       if [ $VAR = ICEC_gt10 ] ; then
-	   threshes='>10'
-       elif [ $VAR = ICEC_gt40 ] ; then
-           threshes='>40'	       
-       elif [ $VAR = ICEC_gt80 ] ; then
-           threshes='>80'
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value="*,*"
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+        if [ $VAR = ICEC_gt10 ] ; then
+	  threshes='>10'
+        elif [ $VAR = ICEC_gt40 ] ; then
+          threshes='>40'	       
+        elif [ $VAR = ICEC_gt80 ] ; then
+          threshes='>80'
         fi
 
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value="*,*"
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do
+	    export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir		     
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-     
-	 thresh_fcst=$threshes
-	 thresh_obs=$threshes
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    thresh_fcst=$threshes
+	    thresh_obs=$threshes
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+            # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+            # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-    done #end of VAR
-
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-cd $plot_dir
+#*************************************************
+# Change plot file names to meet the EVS standard
+#*************************************************
+cd $plots_all_dir
 
 for domain in arctic antarctic ; do
     for lead in 24 48 72 96 120 144 168 192 216 240 264 288 312 336 360 384; do
         lead_new=$(printf "%03d" "${lead}")
-        if [ -f "performance_diagram_regional_${domain}_valid_00z_z0_icec_z0_mean_f${lead}__gt10gt40gt80.png" ]; then
-            mv performance_diagram_regional_${domain}_valid_00z_z0_icec_z0_mean_f${lead}__gt10gt40gt80.png  evs.global_ens.ctc.icec_z0.last${past_days}days.perfdiag_${valid_time}_f${lead_new}.g003_${domain}.png
-        fi
-    done #lead
-done #domain
 
-for stats in  rmse me csi ; do
+	if [ -f "performance_diagram_regional_${domain}_valid_00z_z0_icec_z0_mean_f${lead}__gt10gt40gt80.png" ]; then
+            mv performance_diagram_regional_${domain}_valid_00z_z0_icec_z0_mean_f${lead}__gt10gt40gt80.png evs.global_ens.ctc.icec_z0.last${past_days}days.perfdiag_${valid_time}_f${lead_new}.g003_${domain}.png
+        fi
+    done # lead
+done # domain
+
+for stats in rmse me csi ; do
     if [ $stats = csi ]; then
         threshs="gt10 gt40 gt80"
     else
         threshs="NA"
     fi
+
     for thresh in $threshs; do
         if [ $thresh = NA ]; then
             thresh_graphic=""
         else
             thresh_graphic=$(echo "_${thresh}")
         fi
-        for domain in arctic antarctic ; do
+
+	for domain in arctic antarctic ; do
             if [ -f "lead_average_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}${thresh_graphic}.png" ]; then
-                mv lead_average_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}${thresh_graphic}.png  evs.global_ens.${stats}${thresh_graphic}.icec_z0.last${past_days}days.fhrmean_valid00z_f384.g003_${domain}.png
+                mv lead_average_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}${thresh_graphic}.png evs.global_ens.${stats}${thresh_graphic}.icec_z0.last${past_days}days.fhrmean_valid00z_f384.g003_${domain}.png
             fi
+
             for lead in 24 48 72 96 120 144 168 192 216 240 264 288 312 336 360 384; do
                 lead_new=$(printf "%03d" "${lead}")
-                if [ -f "time_series_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}_f${lead}${thresh_graphic}.png" ]; then
-                    mv time_series_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}_f${lead}${thresh_graphic}.png  evs.global_ens.${stats}${thresh_graphic}.icec_z0.last${past_days}days.timeseries_valid00z_f${lead_new}.g003_${domain}.png
+
+		if [ -f "time_series_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}_f${lead}${thresh_graphic}.png" ]; then
+                    mv time_series_regional_${domain}_valid_00z_z0_icec_z0_mean_${stats}_f${lead}${thresh_graphic}.png evs.global_ens.${stats}${thresh_graphic}.icec_z0.last${past_days}days.timeseries_valid00z_f${lead_new}.g003_${domain}.png
                 fi
-            done #lead
-        done #domain
-    done  #thresh
-done     #stats
+            done # lead
+        done # domain
+    done # thresh
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_snowfall_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_snowfall_plots.sh
@@ -1,46 +1,46 @@
 #!/bin/ksh
-#*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens snowfall score 
-#          plotting python script
+#**************************************************************************
+# Purpose: set up environment, paths, and run the global_ens snowfall 
+#          plotting python scripts
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
-set -x 
+# Updated: 07/30/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#**************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=precip
+verif_type=ccpa
 model_list='ECME CMCE GEFS'
+VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
+valid_time='valid_12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="12"
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -49,22 +49,9 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-#VX_MASK_LIST="CONUS"
-VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
-																  
-export fcst_init_hour="0,12"
-export fcst_valid_hour="12"
-
-export plot_dir=$DATA/out/precip/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=precip
-verif_type=ccpa
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in ets fbias crps fss ; do 
@@ -78,7 +65,7 @@ for stats in ets fbias crps fss ; do
     line_tp='ctc'
     VARs='WEASD_24_gt0p0254 SNOD_24_gt0p0254 WEASD_24_gt0p1016 SNOD_24_gt0p1016 WEASD_24_gt0p2032 SNOD_24_gt0p2032 WEASD_24_gt0p3048 SNOD_24_gt0p3048'
     threshes=''
-  elif [ $stats = crps  ] ; then
+  elif [ $stats = crps ] ; then
     stat_list='crps'
     line_tp='ecnt'
     VARs='WEASD_24 SNOD_24'
@@ -98,147 +85,136 @@ for stats in ets fbias crps fss ; do
    interp_pnts='1'
   fi 
 
- for score_type in time_series lead_average ; do
-
-  if [ $score_type = time_series ] ; then
-    export fcst_init_hour="0,12"
-    export fcst_valid_hour="12"
-    valid_time='valid_12z'
-    init_time='init00z_12z'
-    export fcst_leads="120 240 360"
-  else
-    export fcst_init_hour="0,12"
-    export fcst_valid_hour="12"
-    valid_time='valid_12z'
-    init_time='init00z_12z'
-    export fcst_leads="vs_lead" 
-  fi
+  for score_type in time_series lead_average ; do
+    if [ $score_type = time_series ] ; then
+      export fcst_leads="120 240 360"
+    else
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
 	export fcst_lead="24, 48, 72, 96, 120, 144, 168, 192, 216, 240, 264, 288, 312, 336, 360, 384"
-   else
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in  $VARs; do 
+      for VAR in $VARs ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+        FCST_LEVEL_values="L0"
 
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
-	    
-       FCST_LEVEL_values="L0"
-
-       if [ $VAR = WEASD_24_gt0p0254 ] || [ $VAR = SNOD_24_gt0p0254 ]; then
-           threshes='>0.0254'
-       elif [ $VAR = WEASD_24_gt0p1016 ] || [ $VAR = SNOD_24_gt0p1016 ]; then
-           threshes='>0.1016'
-       elif [ $VAR = WEASD_24_gt0p2032 ] || [ $VAR = SNOD_24_gt0p2032 ]; then
-           threshes='>0.2032'
-       elif [ $VAR = WEASD_24_gt0p3048 ] || [ $VAR = SNOD_24_gt0p3048 ]; then
-           threshes='>0.3048'
-       fi
-
-       if [ $VAR = SNOD_24_gt0p0254 ] || [ $VAR = SNOD_24_gt0p1016 ] || [ $VAR = SNOD_24_gt0p2032 ] || [ $VAR = SNOD_24_gt0p3048 ] || [ $VAR = SNOD_24 ] ; then
-	  models='CMCE, GEFS'
-       else
-	  models='ECME, CMCE, GEFS'
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=A24
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for interp_pnt in $interp_pnts ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh  
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+        if [ $VAR = WEASD_24_gt0p0254 ] || [ $VAR = SNOD_24_gt0p0254 ]; then
+          threshes='>0.0254'
+        elif [ $VAR = WEASD_24_gt0p1016 ] || [ $VAR = SNOD_24_gt0p1016 ]; then
+          threshes='>0.1016'
+        elif [ $VAR = WEASD_24_gt0p2032 ] || [ $VAR = SNOD_24_gt0p2032 ]; then
+          threshes='>0.2032'
+        elif [ $VAR = WEASD_24_gt0p3048 ] || [ $VAR = SNOD_24_gt0p3048 ]; then
+          threshes='>0.3048'
         fi
 
+        if [ $VAR = SNOD_24_gt0p0254 ] || [ $VAR = SNOD_24_gt0p1016 ] || [ $VAR = SNOD_24_gt0p2032 ] || [ $VAR = SNOD_24_gt0p3048 ] || [ $VAR = SNOD_24 ] ; then
+	  models='CMCE, GEFS'
+        else
+	  models='ECME, CMCE, GEFS'
+        fi
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=A24
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export line_type=$line_tp" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-         if [ $stats = fss ] ; then
-            echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-            interp_pnt_config=$interp_pnt
-         else	   
-	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-            intero_pnt_config=''
-	 fi
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+          for interp_pnt in $interp_pnts ; do
+	    export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}
+	    export prune_dir=$WORKtask/data
+            export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/precip/${valid_beg}-${valid_end}
+            mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir		     
+
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh  
+
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export line_type=$line_tp" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+
+            if [ $stats = fss ] ; then
+              echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+              interp_pnt_config=$interp_pnt
+            else	   
+	      echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+              interp_pnt_config=''
+	    fi
      
-         thresh_fcst=$threshes
-         thresh_obs=$threshes
+            thresh_fcst=$threshes
+            thresh_obs=$threshes
 
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnt_config!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnt_config!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
+            # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_all_poe.sh
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_all_poe.sh
 
-      done #end of interp_pnts
-
-     done #end of FCST_LEVEL_value
-
-    done #end of VAR
-
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of interp_pnt
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats
 
 chmod +x run_all_poe.sh
 
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
+#*************************************************
+# Change plot file names to meet the EVS standard
+#*************************************************
+cd $plots_all_dir
 
-cd $plot_dir
-
-for var in weasd snod; do
+for var in weasd snod ; do
     for domain in conus conus_east conus_west conus_south conus_central ; do
         if [ $domain = conus_east ]; then
             evs_graphic_domain="buk_conus_e"
@@ -251,17 +227,20 @@ for var in weasd snod; do
         elif [ $domain = conus ]; then
             evs_graphic_domain="buk_conus"
         fi
-        for stats in  crps ets fbias fss ; do
+
+	for stats in crps ets fbias fss ; do
             if [ $stats = crps ]; then
                 threshs="NA"
             else
                 threshs="gt0.0254 gt0.1016 gt0.2032 gt0.3048"
             fi
+
             if [ $stats = fss ]; then
                 nbrhds="1 3 5 7 9 11"
             else
                 nbrhds="NA"
             fi
+
             for thresh in $threshs; do
                 if [ $thresh = NA ]; then
                     thresh_graphic=""
@@ -270,32 +249,35 @@ for var in weasd snod; do
                     thresh_graphic=$(echo "_${thresh}")
                     evs_thresh_graphic=$(echo $thresh_graphic | sed -e "s/0\./0p/g")
                 fi
+
                 for nbrhd in $nbrhds; do
                     if [ $nbrhd = NA ]; then
                         nbhrd_graphic=""
                     else
                         nbhrd_graphic=$(echo "_width${nbrhd}")
                     fi
+
                     if [ -f "lead_average_regional_${domain}_valid_12z_${var}_l0_${stats}${nbhrd_graphic}${thresh_graphic}.png" ]; then
                         mv lead_average_regional_${domain}_valid_12z_${var}_l0_${stats}${nbhrd_graphic}${thresh_graphic}.png evs.global_ens.${stats}${nbhrd_graphic}${evs_thresh_graphic}.${var}_a24.last${past_days}days.fhrmean_valid12z_f384.g212_${evs_graphic_domain}.png
                     fi
+
                     for lead in 120 240 360; do
                         lead_graphic=$(echo "_f${lead}")
                         if [ -f "time_series_regional_${domain}_valid_12z_${var}_l0_${stats}${nbhrd_graphic}${lead_graphic}${thresh_graphic}.png" ]; then
                             mv time_series_regional_${domain}_valid_12z_${var}_l0_${stats}${nbhrd_graphic}${lead_graphic}${thresh_graphic}.png evs.global_ens.${stats}${nbhrd_graphic}${evs_thresh_graphic}.${var}_a24.last${past_days}days.timeseries_valid12z${lead_graphic}.g212_${evs_graphic_domain}.png
                         fi
-                    done #lead 
-                done #nbrhd
-            done # threshs
-        done #stats
-    done #domain
-done #vars
+                    done # lead 
+                done # nbrhd
+            done # thresh
+        done # stats
+    done # domain
+done # var
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_sst_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_gefs_sst_plots.sh
@@ -1,49 +1,48 @@
 #!/bin/ksh
-#*******************************************************************************
-# Purpose: setup environment, paths, and run the global_ens SST score
-#          plotting python script. Only GEFS scores are  in the plots
+#**************************************************************************
+# Purpose: set up environment, paths, and run the global_ens sst
+#          plotting python scripts. Plots only contain GEFS metrics.
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
+# Updated: 07/31/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#**************************************************************************
 set -x 
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts=' '
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=grid2grid
+verif_type=sfc
 model_list='GEFS'
 models='GEFS'
+VX_MASK_LIST="G003, NHEM, SHEM, TROPICS"
+valid_time='valid00z'
+init_time='init00_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -52,139 +51,123 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="G003, NHEM, SHEM, TROPICS"
-																  
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0"
-valid_time='valid00z'
-init_time='init00_12z'
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=grid2grid
-verif_type=sfc
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in rmse me ; do 
- if [ $stats = rmse  ] ; then
-   stat_list='rmse'
-   line_tp='ecnt'
- elif [ $stats = me  ] ; then
-   stat_list='me'
-   line_tp='ecnt'
-
- else
-   err_exit "$stats is not a valid metric"
- fi   
-
- for score_type in time_series lead_average ; do
-
-  if [ $score_type = time_series ] ; then
-    export fcst_leads="120 240 360"
+  if [ $stats = rmse ] ; then
+    stat_list='rmse'
+    line_tp='ecnt'
+  elif [ $stats = me ] ; then
+    stat_list='me'
+    line_tp='ecnt'
   else
-    export fcst_leads="vs_lead" 
-  fi
+    err_exit "$stats is not a valid metric"
+  fi   
+
+  for score_type in time_series lead_average ; do
+    if [ $score_type = time_series ] ; then
+      export fcst_leads="120 240 360"
+    else
+      export fcst_leads="vs_lead" 
+    fi
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="24,36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
+	export fcst_lead="24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in  SST ; do 
+      for VAR in SST ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+        FCST_LEVEL_values="Z0"
 
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
-	    
-       FCST_LEVEL_values="Z0"
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value="0,*,*"
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+          for line_type in $line_tp ; do 
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-	OBS_LEVEL_value="0,*,*"
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+	    echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      for line_type in $line_tp ; do 
+	    thresh_fcst=''
+            thresh_obs=''
 
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        fi
-
-
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-     
-	 thresh_fcst=''
-         thresh_obs=''
-
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
-
-      done #end of line_type
-
-     done #end of FCST_LEVEL_value
-
-    done #end of VAR
-
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
+#******************************************************
+# Run the POE script in sequence to generate png files
+#******************************************************
 ${DATA}/run_all_poe.sh
 export err=$?; err_chk
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-cd $plot_dir
+#*************************************************
+# Change plot file names to meet the EVS standard
+#*************************************************
+cd $plots_all_dir
 
 for stats in rmse me ; do
    for domain in g003 nhem shem tropics ; do
@@ -193,22 +176,24 @@ for stats in rmse me ; do
        else
            domain_new=$domain
        fi
+
        if [ -f "lead_average_regional_${domain}_valid_00z_sfc_tmp_z0_mean_${stats}.png" ]; then
-          mv lead_average_regional_${domain}_valid_00z_sfc_tmp_z0_mean_${stats}.png  evs.global_ens.${stats}.sst_z0.last${past_days}days.fhrmean_valid00z_f384.g003_${domain_new}.png
+          mv lead_average_regional_${domain}_valid_00z_sfc_tmp_z0_mean_${stats}.png evs.global_ens.${stats}.sst_z0.last${past_days}days.fhrmean_valid00z_f384.g003_${domain_new}.png
        fi
+
        for lead in 120 240 360; do
            if [ -f "time_series_regional_${domain}_valid_00z_sfc_tmp_z0_mean_${stats}_f${lead}.png" ]; then
-              mv time_series_regional_${domain}_valid_00z_sfc_tmp_z0_mean_${stats}_f${lead}.png  evs.global_ens.${stats}.sst_z0.last${past_days}days.timeseries_valid00z_f${lead}.g003_${domain_new}.png
+              mv time_series_regional_${domain}_valid_00z_sfc_tmp_z0_mean_${stats}_f${lead}.png evs.global_ens.${stats}.sst_z0.last${past_days}days.timeseries_valid00z_f${lead}.g003_${domain_new}.png
            fi
-       done #lead
-    done  #domain
-done     #stats
+       done # lead
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then 
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2grid_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2grid_plots.sh
@@ -1,49 +1,47 @@
 #!/bin/ksh
-#*******************************************************************************
-# Purpose: setup environment, paths, and run the NAEFS  grid2grid verification
-#          score plotting python script
+#**************************************************************************
+# Purpose: set up environment, paths, and run the NAEFS grid2grid
+#          plotting python scripts
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
-set -x 
+# Updated: 07/22/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP
+#**************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-
-export interp_pnts='' 
-
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=$VERIF_CASE
 model_list='NAEFS CMCE GEFS'
 models='NAEFS, CMCE, GEFS'
+VX_MASK_LIST="NHEM, SHEM, TROPICS"
+init_time='init00z_12z'
+valid_time='valid00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0,12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -52,160 +50,145 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-VX_MASK_LIST="NHEM, SHEM, TROPICS"
-																  
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0,12"
-init_time=init00z_12z
-valid_time=valid00z_12z
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=$VERIF_CASE
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in acc me_mae crps rmse_spread ; do 
-if [ $stats = acc ] ; then
-  stat_list='acc'
-  line_tp='sal1l2'
-elif [ $stats = bias ] ; then
-  stat_list='bias'
-  line_tp='sl1l2'
-elif [ $stats = mae ] ; then
-  stat_list='mae'
-  line_tp='sl1l2'
-elif [ $stats = me_mae  ] ; then
-  stat_list='me, mae'
-  line_tp='ecnt'
-elif [ $stats = crps  ] ; then
-  stat_list='crps'
-  line_tp='ecnt'
-elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-else
-  err_exit "$stats is not a valid metric"
-fi   
+  if [ $stats = acc ] ; then
+    stat_list='acc'
+    line_tp='sal1l2'
+  elif [ $stats = bias ] ; then
+    stat_list='bias'
+    line_tp='sl1l2'
+  elif [ $stats = mae ] ; then
+    stat_list='mae'
+    line_tp='sl1l2'
+  elif [ $stats = me_mae ] ; then
+    stat_list='me, mae'
+    line_tp='ecnt'
+  elif [ $stats = crps ] ; then
+    stat_list='crps'
+    line_tp='ecnt'
+  elif [ $stats = rmse_spread ] ; then
+    stat_list='rmse, spread'
+    line_tp='ecnt'
+  else
+    err_exit "$stats is not a valid metric"
+  fi   
 
- for score_type in lead_average ; do
-
-  export fcst_leads="vs_lead" 
+  for score_type in lead_average ; do
+    export fcst_leads="vs_lead" 
  
-  for lead in $fcst_leads ; do 
-
-   if [ $lead = vs_lead ] ; then
-	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-   else
+    for lead in $fcst_leads ; do 
+      if [ $lead = vs_lead ] ; then
+	export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
+      else
         export fcst_lead=$lead
-   fi
+      fi
 
-    for VAR in HGT TMP  ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in HGT TMP ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = HGT ] ; then
+        if [ $VAR = HGT ] ; then
           FCST_LEVEL_values="P500 P1000"
-       elif [ $VAR = TMP ] ; then
+        elif [ $VAR = TMP ] ; then
           FCST_LEVEL_values="P850"
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-        if [ $stats = acc ] ; then
-	   verif_type=anom
-        else
-	   verif_type=pres
-	fi 
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
         fi
 
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=$FCST_LEVEL_value
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do 
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-	 thresh=' '
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            if [ $stats = acc ] ; then
+	      verif_type=anom
+            else
+	      verif_type=pres
+	    fi
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh	   
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh           
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+            echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    thresh=''
 
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh!g" -e "s!thresh_obs!$thresh!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+            # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+            # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-    done #end of VAR
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 12 -ppn 12 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 12 -ppn 12 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
-
-cd $plot_dir
+#*************************************************
+# Change plot file names to meet the EVS standard
+#*************************************************
+cd $plots_all_dir
 
 for stats in acc me_mae crps rmse_spread ; do
     if [ $stats = rmse_spread ]; then
@@ -213,24 +196,26 @@ for stats in acc me_mae crps rmse_spread ; do
     else
         evs_graphic_stats=$stats
     fi
-    for domain in  nhem shem tropics  ; do
-        for var in hgt tmp  ; do
+
+    for domain in nhem shem tropics ; do
+        for var in hgt tmp ; do
             if [ $var = hgt ] ; then
-                levels='500  1000'
+                levels='500 1000'
                 unit='mb'
             elif [ $var = tmp ] ; then
                 levels='850'
                 unit='mb'
             fi
+
             for level in $levels ; do
                 plevel=p${level}
                 if [ -f "lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png" ]; then
-                    mv lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png  evs.naefs.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain}.png
+                    mv lead_average_regional_${domain}_valid_00z_12z_${level}mb_${var}_${stats}.png evs.naefs.${evs_graphic_stats}.${var}_${plevel}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${domain}.png
                 fi
-            done #level
-        done #var
-    done  #domain
-done     #stats
+            done # level
+        done # var
+    done # domain
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_grid2obs_plots.sh
@@ -1,49 +1,43 @@
 #!/bin/ksh
-#*******************************************************************************
-# Purpose: setup environment, paths, and run the NAEFS grid2obs verification 
-#          score plotting python script
+#**************************************************************************
+# Purpose: set up environment, paths, and run the NAEFS grid2obs 
+#          plotting python scripts
 #
-# Last updated: 11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
-set -x 
+# Updated: 07/15/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#**************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
-
-export eval_period='TEST'
-
-export interp_pnts=''
-
-export init_end=$VDATE
-export valid_end=$VDATE
+mkdir -p $plots_all_dir
 
 model_list='NAEFS CMCE GEFS'
 models='NAEFS, CMCE, GEFS'
 
 n=0
 while [ $n -le $past_days ] ; do
-    hrs=$((n*24))
-    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
-    n=$((n+1))
+  hrs=$((n*24))
+  first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="0,12"
+export interp_pnts=''
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
-  #hrs=`expr $n \* 24`
   hrs=$((n*24))
   day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
   echo $day
@@ -52,190 +46,177 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done 
 
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="0,12"
-valid_time='valid00z_12z'
-init_time='init00z_12z'
-
-export plot_dir=$DATA/out/sfc_upper/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=$VERIF_CASE
-
-
 #*****************************************
 # Build a POE script to collect sub-tasks
-# ****************************************
+#*****************************************
 > run_all_poe.sh
 
 for stats in acc crps rmse_spread me_mae ; do 
- if [ $stats = acc ] ; then
-  stat_list='acc'
-  line_tp='sal1l2'
-  VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
- elif [ $stats = crps ] ; then
-  stat_list='crps'
-  line_tp='ecnt'
-  VARs='TMP2m  UGRD10m VGRD10m UGRD VGRD TMP'
- elif [ $stats = rmse_spread  ] ; then
-  stat_list='rmse, spread'
-  line_tp='ecnt'
-  VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
- elif [ $stats = me_mae ] ; then
-  stat_list='me, mae'
-  line_tp='ecnt'
-  VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
- else
-  err_exit "$stats is not a valid metric"
- fi   
+  if [ $stats = acc ] ; then
+    stat_list='acc'
+    line_tp='sal1l2'
+    VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
+  elif [ $stats = crps ] ; then
+    stat_list='crps'
+    line_tp='ecnt'
+    VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
+  elif [ $stats = rmse_spread ] ; then
+    stat_list='rmse, spread'
+    line_tp='ecnt'
+    VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
+  elif [ $stats = me_mae ] ; then
+    stat_list='me, mae'
+    line_tp='ecnt'
+    VARs='TMP2m UGRD10m VGRD10m UGRD VGRD TMP'
+  else
+    err_exit "$stats is not a valid metric"
+  fi   
 
- for score_type in lead_average ; do
-
-  export fcst_leads="vs_lead" 
+  for score_type in lead_average ; do
+    export fcst_leads="vs_lead" 
  
-  for lead in $fcst_leads ; do 
+    for lead in $fcst_leads ; do 
+      export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
 
-    export fcst_lead="0, 12, 24, 36, 48, 60, 72, 84, 96,108, 120, 132, 144, 156, 168, 180, 192,204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
-
-    for VAR in $VARs ; do 
-
-       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+      for VAR in $VARs ; do 
+        var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
 	    
-       if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
+        if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
           FCST_LEVEL_values="Z2"
 	  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
-       elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] ; then
+        elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] ; then
           FCST_LEVEL_values="Z10"
 	  VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska"
-       elif [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
+        elif [ $VAR = UGRD ] || [ $VAR = VGRD ] ; then
           FCST_LEVEL_values="P850 P250"
 	  VX_MASK_LIST="NHEM, SHEM, TROPICS"
-       elif [ $VAR = TMP ]  ; then
+        elif [ $VAR = TMP ] ; then
 	  FCST_LEVEL_values="P850"
           VX_MASK_LIST="NHEM, SHEM, TROPICS"
-       fi
-
-     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
-
-	OBS_LEVEL_value=$FCST_LEVEL_value
-
-        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
-
-      for line_type in $line_tp ; do 
-
-         #***************************
-         # Build sub-task scripts
-         #***************************
-         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
-
-	if [ $VAR = UGRD ] || [ $VAR = VGRD ] || [ $VAR = TMP ] ; then
-              if [ $line_type = sal1l2 ] ; then
-	         verif_case=grid2grid
-	         verif_type=anom
-	      else
-	         verif_case=$VERIF_CASE
-	         verif_type=upper_air
-	      fi
-         else
-             verif_case=$VERIF_CASE
-             verif_type=conus_sfc
-	 fi	
-
-        echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-        echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-
-
-        if [ $score_type = valid_hour_average ] ; then
-          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-        else
-          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
         fi
 
+        for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+	  OBS_LEVEL_value=$FCST_LEVEL_value
+          level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
-         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+          for line_type in $line_tp ; do 
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}
+	    export prune_dir=$WORKtask/data
+            export save_dir=$WORKtask/out
+	    export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/sfc_upper/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
-         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh  
 
-         thresh_fcst=' '
-	 thresh_obs=' '
+	    if [ $VAR = UGRD ] || [ $VAR = VGRD ] || [ $VAR = TMP ] ; then
+              if [ $line_type = sal1l2 ] ; then
+	        verif_case=grid2grid
+	        verif_type=anom
+	      else
+	        verif_case=$VERIF_CASE
+	        verif_type=upper_air
+	      fi
+            else
+              verif_case=$VERIF_CASE
+              verif_type=conus_sfc
+	    fi	
 
-         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            thresh_fcst=''
+	    thresh_obs=''
 
-         echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
-         echo " ${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
+            # Copy png files to plots_all_dir
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-      done #end of line_type
+            # Cat the plotting log file
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh
 
-     done #end of FCST_LEVEL_value
+            chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.sh" >> run_all_poe.sh
 
-    done #end of VAR
-
-  done #end of fcst_lead
-
- done #end of score_type
-
-done #end of stats 
+          done # end of line_type
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-
-#***************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
-   mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
+  mpiexec -np 32 -ppn 32 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
   ${DATA}/run_all_poe.sh
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-    echo "Start: $log_file"
-    cat $log_file
-    echo "End: $log_file"
-fi
+#*************************************************
+# Change plot file names to meet the EVS standard
+#*************************************************
+cd $plots_all_dir
 
-cd $plot_dir
-
-for stats in  acc crps rmse_spread me_mae ; do
+for stats in acc crps rmse_spread me_mae ; do
     if [ $stats = rmse_spread ]; then
         evs_graphic_stats="rmse_sprd"
     else
         evs_graphic_stats=$stats
     fi
+
     for var in tmp ugrd vgrd ; do
         if [ $var = tmp ] || [ $var = dpt ] ; then
 	    levels='2m 850mb'
         elif [ $var = ugrd ] || [ $var = vgrd ] ; then
 	    levels='10m 850mb 250mb'
         fi
+
         for level in $levels ; do     
             if [ $level = 850mb ] || [ $level = 250mb ] ; then
                 domains='nhem shem tropics'
             else
 	        domains='conus conus_east conus_west conus_south conus_central alaska'
             fi
+
             if [ $level = 850mb ] ; then
                 level_new=p850
             elif [ $level = 250mb ] ; then
@@ -247,6 +228,7 @@ for stats in  acc crps rmse_spread me_mae ; do
             else
 	        level_new=$level
             fi
+
             for domain in $domains ; do	
                 if [ $domain = conus ]; then
                     evs_graphic_domain="buk_conus"
@@ -261,25 +243,26 @@ for stats in  acc crps rmse_spread me_mae ; do
                 else
                     evs_graphic_domain=$domain
                 fi
+
                 if [ $domain = nhem ] || [ $domain = shem ] || [ $domain = tropics ] || [ $domain = alaska ]; then
                     if [ -f "lead_average_regional_${domain}_valid_00z_12z_${level}_${var}_${stats}.png" ]; then
-                        mv lead_average_regional_${domain}_valid_00z_12z_${level}_${var}_${stats}.png  evs.naefs.${evs_graphic_stats}.${var}_${level_new}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${evs_graphic_domain}.png
+                        mv lead_average_regional_${domain}_valid_00z_12z_${level}_${var}_${stats}.png evs.naefs.${evs_graphic_stats}.${var}_${level_new}.last${past_days}days.fhrmean_valid00z_12z_f384.g003_${evs_graphic_domain}.png
                     fi
                 else
                     if [ -f "lead_average_regional_${domain}_valid_00z_12z_${level}_${var}_${stats}.png" ]; then
-                        mv lead_average_regional_${domain}_valid_00z_12z_${level}_${var}_${stats}.png  evs.naefs.${evs_graphic_stats}.${var}_${level_new}.last${past_days}days.fhrmean_valid00z_12z_f384.g212_${evs_graphic_domain}.png
+                        mv lead_average_regional_${domain}_valid_00z_12z_${level}_${var}_${stats}.png evs.naefs.${evs_graphic_stats}.${var}_${level_new}.last${past_days}days.fhrmean_valid00z_12z_f384.g212_${evs_graphic_domain}.png
                     fi
                 fi
-            done #domain
-        done #level
-    done   #var
-done     #stats
+            done # domain
+        done # level
+    done # var
+done # stats
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_precip_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_atmos_naefs_precip_plots.sh
@@ -1,30 +1,28 @@
 #!/bin/ksh
-#******************************************************************************
-# Purpose: set up environment, paths, and run the NAEFS precip verification 
-#          score plotting python script
+#**************************************************************************
+# Purpose: set up environment, paths, and run the NAEFS precip 
+#          plotting python scripts
 #
-# Last updated: 03/18/2025 L. Gwen Chen (lichuan.chen@noaa.gov)
-#               11/17/2023, Binbin Zhou Lynker@EMC/NCEP 
-#******************************************************************************
-set -x 
+# Updated: 07/23/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          03/18/2025 by L. Gwen Chen (lichuan.chen@noaa.gov)
+#          11/17/2023 by Binbin Zhou, Lynker@EMC/NCEP 
+#**************************************************************************
+set -x
 
 cd $DATA
 
-export prune_dir=$DATA/data
-export save_dir=$DATA/out
 export output_base_dir=$DATA/stat_archive
-export log_metplus=$DATA/logs/GENS_verif_plotting_job.out
-mkdir -p $prune_dir
-mkdir -p $save_dir
+export plots_all_dir=$DATA/plots_all
 mkdir -p $output_base_dir
-mkdir -p $DATA/logs
+mkdir -p $plots_all_dir
 
-export eval_period='TEST'
-export init_end=$VDATE
-export valid_end=$VDATE
-
+verif_case=$VERIF_CASE
+verif_type=ccpa
 model_list='NAEFS CMCE GEFS'
 models='NAEFS, CMCE, GEFS'
+VX_MASK_LIST="CONUS, CONUS_East, CONUS_South, CONUS_Central, CONUS_West"
+valid_time='valid_12z'
+init_time='init00z_12z'
 
 n=0
 while [ $n -le $past_days ] ; do
@@ -33,12 +31,16 @@ while [ $n -le $past_days ] ; do
   n=$((n+1))
 done
 
-export init_beg=$first_day
 export valid_beg=$first_day
+export valid_end=$VDATE
+export init_beg=$first_day
+export init_end=$VDATE
+export fcst_init_hour="0,12"
+export fcst_valid_hour="12"
 
-#*************************************************************
-# Virtual link required stat data files of past 31/90 days
-#*************************************************************
+#*************************************************
+# Create links of stat files from past 31/90 days
+#*************************************************
 n=0
 while [ $n -le $past_days ] ; do
   hrs=$((n*24))
@@ -48,17 +50,6 @@ while [ $n -le $past_days ] ; do
   export err=$?; err_chk
   n=$((n+1))
 done 
-
-VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central"
-
-export fcst_init_hour="0,12"
-export fcst_valid_hour="12"
-
-export plot_dir=$DATA/out/precip/${valid_beg}-${valid_end}
-mkdir -p $plot_dir
-
-verif_case=$VERIF_CASE
-verif_type=ccpa
 
 #*****************************************
 # Build a POE script to collect sub-tasks
@@ -111,21 +102,15 @@ for stats in crps me rmse ets fbias fss bs bss ; do
   fi   
 
   if [ $stats = fss ] ; then
-   interp_pnts='1 9 25 49 81 121'
+    interp_pnts='1 9 25 49 81 121'
   else
-   interp_pnts='1'
+    interp_pnts='1'
   fi 
 
   for score_type in lead_average ; do
-
-    export fcst_init_hour="0,12"
-    export fcst_valid_hour="12"
-    valid_time='valid_12z'
-    init_time='init00z_12z'
     export fcst_leads="vs_lead" 
  
     for lead in $fcst_leads ; do 
-
       export fcst_lead="12, 24, 36, 48, 60, 72, 84, 96, 108, 120, 132, 144, 156, 168, 180, 192, 204, 216, 228, 240, 252, 264, 276, 288, 300, 312, 324, 336, 348, 360, 372, 384"
 
       for VAR in $VARs; do 
@@ -149,69 +134,89 @@ for stats in crps me rmse ets fbias fss bs bss ; do
           level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
 
           for interp_pnt in $interp_pnts ; do
+            export WORKtask=$DATA/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}
+	    export prune_dir=$WORKtask/data
+	    export save_dir=$WORKtask/out
+            export log_metplus=$WORKtask/logs/GENS_verif_plotting_job.log
+	    export plot_dir=$WORKtask/out/precip/${valid_beg}-${valid_end}
+	    mkdir -p $WORKtask
+	    mkdir -p $prune_dir
+	    mkdir -p $save_dir
+	    mkdir -p $WORKtask/logs
+	    mkdir -p $plot_dir
 
-          #***************************
-          # Build sub-task scripts
-          #***************************
-          > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh  
+            #************************
+            # Build sub-task scripts
+            #************************
+            > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh  
 
-          echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export ush_dir=$ush_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export prune_dir=$prune_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export plot_dir=$plot_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export output_base_dir=$output_base_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export log_metplus=$log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export eval_period=TEST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export valid_beg=$valid_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export valid_end=$valid_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export init_beg=$init_beg" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export init_end=$init_end" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "export fcst_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "export line_type=$line_tp" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+            echo "export confidence_intervals=False" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+	    echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          if [ $score_type = valid_hour_average ] ; then
-            echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          else
-            echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          fi
+            if [ $stats = fss ] ; then
+              echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+              interp_pnt_config=$interp_pnt
+            else	   
+	      echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+              interp_pnt_config=''
+	    fi
 
-          echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "export line_type=$line_tp" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            if [ $line_tp = pstd ] ; then
+              thresh_fcst='==0.10000'
+              thresh_obs=$threshes
+            else
+              thresh_fcst=$threshes
+              thresh_obs=$threshes
+            fi
 
-          if [ $stats = fss ] ; then
-            echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-            interp_pnt_config=$interp_pnt
-          else	   
-	    echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-            interp_pnt_config=''
-	  fi
+            sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnt_config!g" $USHevs/global_ens/evs_gens_atmos_plots_config.sh > $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-     
-          if [ $line_tp = pstd ] ; then
-            thresh_fcst='==0.10000'
-            thresh_obs=$threshes
-          else
-            thresh_fcst=$threshes
-            thresh_obs=$threshes
-          fi
+            chmod +x $WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            echo "$WORKtask/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g" -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g" -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnt_config!g"  $USHevs/global_ens/evs_gens_atmos_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            # Copy png files to plots_all_dir            
+	    echo "cp $plot_dir/*.png $plots_all_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          chmod +x run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
-          echo "${DATA}/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
+            # Cat the plotting log file            
+	    echo "if [ -s $log_metplus ]; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "  cat $log_metplus" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh            
+	    echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh
 
-          chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh 
-          echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_all_poe.sh
+  	    chmod +x run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh 
+            echo "${DATA}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_tp}_${interp_pnt}.sh" >> run_all_poe.sh
 
-          done #end of interp_pnts
-        done #end of FCST_LEVEL_value
-      done #end of VAR
-    done #end of fcst_lead
-  done #end of score_type
-done #end of stats 
+          done # end of interp_pnt
+        done # end of FCST_LEVEL_value
+      done # end of VAR
+    done # end of lead
+  done # end of score_type
+done # end of stats 
 
 chmod +x run_all_poe.sh
 
-#**************************************************************************
-# Run the POE script in parallel or in sequence order to generate png files
-#**************************************************************************
+#*********************************************************************
+# Run the POE script in parallel or in sequence to generate png files
+#*********************************************************************
 if [ $run_mpi = yes ] ; then
   mpiexec -np 8 -ppn 8 --cpu-bind verbose,depth cfp ${DATA}/run_all_poe.sh
 else
@@ -219,18 +224,10 @@ else
   export err=$?; err_chk
 fi
 
-# Cat the plotting log file
-log_file=$DATA/logs/GENS_verif_plotting_job.out
-if [ -s $log_file ]; then
-  echo "Start: $log_file"
-  cat $log_file
-  echo "End: $log_file"
-fi
-
-#**************************************************
+#*************************************************
 # Change plot file names to meet the EVS standard
-#**************************************************
-cd $plot_dir
+#*************************************************
+cd $plots_all_dir
 
 for domain in conus conus_east conus_west conus_south conus_central ; do
     if [ $domain = conus ]; then
@@ -289,16 +286,16 @@ for domain in conus conus_east conus_west conus_south conus_central ; do
                         mv lead_average_regional_${domain}_valid_12z_24h_apcp_24_${stat}${nbhrd_graphic}${thresh_graphic}.png evs.naefs.${stat}${nbhrd_graphic}${thresh_graphic}.apcp_a24.last${past_days}days.fhrmean_valid12z_f384.g212_${evs_graphic_domain}.png
                     fi
                 fi
-            done
-        done
-    done
-done
+            done # nbrhd
+        done # thresh
+    done # stat
+done # domain
 
 tar -cvf evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar *.png
 
 if [ $SENDCOM = YES ]; then
     if [ -s evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar ]; then
-        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar  $COMOUT/.
+        cp -v evs.plots.${COMPONENT}.${RUN}.${MODELNAME}.${VERIF_CASE}.past${past_days}days.v${VDATE}.tar $COMOUT/.
     fi
 fi
 

--- a/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
@@ -14,6 +14,10 @@
 # 6- Updated all image names to be lastXXdays instead of pastXXdays. tar files have lastXXdays for waves plots.
 # 7- added obs name to image title.
 # 8- Updated walltime for global_ens wave prep.
+# 
+# Updates on 202507:
+# Separated last31days and last90days plots.
+#
 #
 # Purpose of Script: Run the grid2obs plots for any global wave model           
 #                    (deterministic and ensemble: GEFS-Wave, GFS-Wave, NWPS)    
@@ -136,7 +140,8 @@ fi
 #######################
 # Gather all the files 
 #######################
-periods='LAST31DAYS LAST90DAYS'
+periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
+
 if [ $gather = yes ] ; then
   echo "copying all images into one directory"
   for FILE in ${DATA}/wave/*png ; do

--- a/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
+++ b/scripts/plots/global_ens/exevs_global_ens_wave_grid2obs_plots.sh
@@ -14,10 +14,6 @@
 # 6- Updated all image names to be lastXXdays instead of pastXXdays. tar files have lastXXdays for waves plots.
 # 7- added obs name to image title.
 # 8- Updated walltime for global_ens wave prep.
-# 
-# Updates on 202507:
-# Separated last31days and last90days plots.
-#
 #
 # Purpose of Script: Run the grid2obs plots for any global wave model           
 #                    (deterministic and ensemble: GEFS-Wave, GFS-Wave, NWPS)    
@@ -140,8 +136,7 @@ fi
 #######################
 # Gather all the files 
 #######################
-periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
-
+periods='LAST31DAYS LAST90DAYS'
 if [ $gather = yes ] ; then
   echo "copying all images into one directory"
   for FILE in ${DATA}/wave/*png ; do

--- a/ush/global_ens/evs_gens_atmos_plots_config.sh
+++ b/ush/global_ens/evs_gens_atmos_plots_config.sh
@@ -1,9 +1,10 @@
 #!/bin/ksh
 
 # ================================================================================================
-# NCEP EMC PYTHON PLOTTING OF CAM VERIFICATION
+# NCEP EMC PYTHON PLOTTING CONFIGURATION FILE
 # 
-# CONTRIBUTORS:     Marcel Caron, marcel.caron@noaa.gov, NOAA/NWS/NCEP/EMC-VPPPGB
+# CONTRIBUTORS:     Marcel Caron, marcel.caron@noaa.gov, NOAA/NWS/NCEP/EMC/VPPPGB
+#                   L. Gwen Chen, lichuan.chen@noaa.gov, NOAA/NWS/NCEP/EMC/VPPPGB
 #
 # PURPOSE:          Set up configurations to plot METPLUS output statistics
 #
@@ -11,17 +12,7 @@
 #                   edited by the user and that are called by python scripts at runtime to define 
 #                   the plotting task, resulting in one or more graphics output files. 
 #
-# BEFORE YOU BEGIN: Make sure to set up verif_plotting if you haven't already.  To set up, 
-#                   clone the Github repository:
-#
-#                   or, if on the NOAA WCOSS supercomputer, choose any directory that will house 
-#                   verif_plotting.  As an example, we'll call that directory PY_PLOT_DIR.  Then on 
-#                   the command line:
-#
-#                   $ PY_PLOT_DIR="/path/to/my/verif/plotting/home/directory"
-#                   $ mkdir -p ${PY_PLOT_DIR}/out/logs ${PY_PLOT_DIR}/data ${PY_PLOT_DIR}/ush
-#                   $ cp -r ${BASE_DIR}/ush/* ${PY_PLOT_DIR}/ush/.
-#                   $ cp ${BASE_DIR}/py_plotting.config ${PY_PLOT_DIR}/.
+# BEFORE YOU BEGIN: Make sure to set up verif_plotting software package if you haven't already.
 #
 # CONFIGURATION:    After setting up verif_plotting, edit the exported variables below.  Each 
 #                   variable is a string that will be ingested by the python code.  You'll need to 
@@ -67,8 +58,7 @@
 #
 # DEBUGGING:        Part of the configuration for this script involves setting a logfile path. 
 #                   Running the script will print the logfile path for your specific task, which you 
-#                   can check for debugging.  The lowest log level that is currently functional is 
-#                   "INFO". "DEBUG" statements may be included in a later implementation.
+#                   can check for debugging.
 #                
 # ================================================================================================
 set -x
@@ -83,10 +73,8 @@ export URL_HEADER=""
 
 # Directory Settings.  Make sure USH_DIR, PRUNE_DIR, and SAVE_DIR point to desired .../ush, 
 # .../data, and .../out directories.  OUTPUT_BASE_DIR is the location of the metplus stat archive.  
-# The default format that plotting scripts use to look for .stat files in the archive is 
-# ${OUTPUT_BASE_DIR}/${VERIF_CASE}/${MODEL_NAME}/${Ym}/${MODEL_NAME}*.stat
-# This format can be changed by editing the output_base_template variable in the Templates class in
-# ${USH_DIR}/settings.py  
+# The format that plotting scripts used to look for .stat files in the archive is set by the 
+# output_base_template variable in the Templates class in ${USH_DIR}/settings.py
 export USH_DIR=$ush_dir
 export PRUNE_DIR=$prune_dir
 export SAVE_DIR=$save_dir
@@ -124,7 +112,7 @@ export FCST_INIT_HOUR="fcst_init_hour"
 export FCST_VALID_HOUR="fcst_valid_hour"
 
 # Settings below are used to select desired variable and domain. **
-export FCST_LEVEL=$fcts_level
+export FCST_LEVEL=$fcst_level
 export OBS_LEVEL=$obs_level
 export var_name=$var_name
 export VX_MASK_LIST="$vx_mask_list"
@@ -143,18 +131,18 @@ export INTERP=$interp
 export FCST_THRESH="thresh_fcst"
 export OBS_THRESH="thresh_obs"
 
-# Will plot all comma-separated metrics.  For performance diagram, metrics must be "sratio,pod,csi". 
+# Will plot all comma-separated metrics. For performance diagram, metrics must be "sratio,pod,csi". 
 # Depending on the VERIF_CASE, VERIF_TYPE, and LINE_TYPE, only some settings are allowed. **
 export STATS="stat_list"
 
 # String of True or False. If "True", will plot bootstrap confidence intervals. Other confidence 
 # interval settings can be configured in ${USH_DIR}/settings.py
-export CONFIDENCE_INTERVALS="False"
+export CONFIDENCE_INTERVALS=$confidence_intervals
 
 # Will use statistics for all comma-separated interpolation points
-export INTERP_PNTS=interp_pnts
+export INTERP_PNTS="interp_pnts"
 
-# Executes the desired python script.  No need to edit this. 
+# Executes the desired python script. No need to edit this. 
 python $USH_DIR/${PLOT_TYPE}.py
 export err=$?; err_chk
 


### PR DESCRIPTION
## Description of Changes
This PR addresses Issue https://github.com/NOAA-EMC/EVS/issues/555 and modifies atmos plots jobs to meet the MPMD requirements.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? Yes, on Aug 8.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d
COMOUT - set to your test output directory
KEEPDATA - set to YES

(2) Run the atmos plots jobs
Run the following jobs in dev/drivers/scripts/plots/global_ens for any VDATE:

qsub jevs_global_ens_atmos_gefs_grid2grid_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_grid2obs_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_grid2obs_past90days_separate_plots.sh
qsub jevs_global_ens_atmos_gefs_precip_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_profile1_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_profile2_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_profile3_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_profile4_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_sea_ice_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_snowfall_past90days_plots.sh
qsub jevs_global_ens_atmos_gefs_sst_past90days_plots.sh
qsub jevs_global_ens_atmos_naefs_grid2grid_past90days_plots.sh
qsub jevs_global_ens_atmos_naefs_grid2obs_past90days_plots.sh
qsub jevs_global_ens_atmos_naefs_precip_past90days_plots.sh

After the jobs completed, log files should be free of errors or warnings. The tar balls under $COMOUT directory (evs/v2.0/plots/global_ens/atmos.$VDATE) should contain the same image files as those in emc.vpppg parallel. The $DATA directory should contain many individual working directories, one for each subtask, and a new plots_all directory with all plots copied from the subtasks.