### PR TITLE
feature/EVSv2-RTOFS_plots_axis_R1

### DIFF
--- a/dev/drivers/scripts/plots/rtofs/jevs_rtofs_smos_grid2grid_last60days_plots.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_rtofs_smos_grid2grid_last60days_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=01:35:00
+#PBS -l walltime=00:15:00
 #PBS -l place=shared,select=1:ncpus=1:mem=50GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/rtofs/jevs_rtofs_smos_grid2grid_last60days_plots.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_rtofs_smos_grid2grid_last60days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:35:00
+#PBS -l walltime=00:15:00
 #PBS -l place=shared,select=1:ncpus=1:mem=50GB
 #PBS -l debug=true
 

--- a/ush/rtofs/time_series.py
+++ b/ush/rtofs/time_series.py
@@ -755,11 +755,12 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
         [np.power(10.,y), 2.*np.power(10.,y)] 
         for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
     ]).flatten()
-    round_to_nearest_categories = y_range_categories/2.
     y_range = y_max-y_min
-    round_to_nearest =  round_to_nearest_categories[
-        np.digitize(y_range, y_range_categories[:-1])
-    ]
+    if y_range < 1.0:
+        round_to_nearest = 0.5
+    else:
+        index = np.floor(y_range)
+        round_to_nearest = index / 2.0
     margin = np.ceil(y_max) -np.floor(y_min)
     ylim_min = (np.floor(y_min/round_to_nearest)*round_to_nearest) - 0.1 *margin
     ylim_max = (np.ceil(y_max/round_to_nearest)*round_to_nearest) + 0.1 * margin


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR refactors the Y-axis setup for time series plots in EVS-RTOFS. This resolves the slowness issue in SMOS plot jobs and implements the requested Y-axis range from developers across all run cases.  In addition, the walltime for one of the plots job `smos`, which was affected with the older version of Y-axis setup has been reverted to its original 00:15:00 by these new setup.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- To test this PR, you need to run the driver scripts for EVS-RTOFS plots step.
2- Clone my fork in your local and checkout branch `feature/EVSv2-RTOFS_plots_axis_R1`.
3- In `COMIN`, replace the `${USER}` with `emc.vpppg`.
4- Find the driver scripts for plots step at:  `$EVS/dev/drivers/scripts/plots/rtofs/*` and run them.