### PR TITLE
NAM/RAP - fix restart for grid2obs stats

### DIFF
--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -14,7 +14,7 @@ set -x
 # ECF Settings
   export SENDECF=YES
   export SENDCOM=YES
-  export KEEPDATA=YES
+  export KEEPDATA=NO
   export SENDDBN=NO
   export SENDDBN_NTC=
   export SENDMAIL=YES

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:50:00
+#PBS -l walltime=00:25:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 
@@ -14,7 +14,7 @@ set -x
 # ECF Settings
   export SENDECF=YES
   export SENDCOM=YES
-  export KEEPDATA=NO
+  export KEEPDATA=YES
   export SENDDBN=NO
   export SENDDBN_NTC=
   export SENDMAIL=YES

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -14,7 +14,7 @@ set -x
 # ECF Settings
   export SENDECF=YES
   export SENDCOM=YES
-  export KEEPDATA=YES
+  export KEEPDATA=NO
   export SENDDBN=NO
   export SENDDBN_NTC=
   export SENDMAIL=YES

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=01:00:00
+#PBS -l walltime=00:30:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 
@@ -14,7 +14,7 @@ set -x
 # ECF Settings
   export SENDECF=YES
   export SENDCOM=YES
-  export KEEPDATA=NO
+  export KEEPDATA=YES
   export SENDDBN=NO
   export SENDDBN_NTC=
   export SENDMAIL=YES

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:50:00
+#PBS -l walltime=00:25:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:00:00
+#PBS -l walltime=00:30:00
 #PBS -l place=vscatter:exclhost,select=3:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 

--- a/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
+++ b/ush/mesoscale/mesoscale_stats_grid2obs_create_job_script.py
@@ -395,10 +395,10 @@ elif STEP == 'stats':
           )
         completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
         job_cmd_list_iterative.append(
-           "python -c "
+           f"if [ $FHR_GROUP = FULL ]; then python -c "
            + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
            + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-           + f"\"job{njob}\", job_type=\"{job_type}\")'"
+           + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
         )
         completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
         completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
@@ -435,18 +435,18 @@ elif STEP == 'stats':
                + 'var_name=\\\"${VAR_NAME}\\\"'
                + ')\"'
               )
-            completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
-            job_cmd_list_iterative.append(
-               "python -c "
+              completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
+              job_cmd_list_iterative.append(
+               f"if [ $FHR_GROUP == FULL ]; then python -c "
                + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-               + f"\"job{njob}\", job_type=\"{job_type}\")'"
-            )
-            completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
-            completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
-            job_cmd_list_iterative.append(
+               + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
+              )
+              completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
+              completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
+              job_cmd_list_iterative.append(
                f"if [ -f {completed_job_path} ] && [ $SENDCOM == YES ]; then cp -rpfv {completed_job_path} {completed_job_restart_dir}; fi"
-            )
+              )
         else:
             if NEST == 'conusp':
                 if VAR_NAME == 'PTYPE':
@@ -507,7 +507,7 @@ elif STEP == 'stats':
                        + f'obs{VERIF_TYPE.upper()}_{VAR_NAME}.conf'
                    )
                    if SENDCOM == 'YES':
-                      job_cmd_list_iterative.append(
+                     job_cmd_list_iterative.append(
                        f'python -c '
                        + '\"import mesoscale_util as cutil; cutil.copy_data_to_restart('
                        + '\\\"${DATA}\\\", \\\"${RESTART_DIR}\\\", '
@@ -525,18 +525,18 @@ elif STEP == 'stats':
                        + 'var_name=\\\"${VAR_NAME}\\\"'
                        + ')\"'
                       )
-                   completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
-                   job_cmd_list_iterative.append(
+                     completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
+                     job_cmd_list_iterative.append(
                        f"if [ $FHR == $FHR_END ]; then python -c "
                        + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                        + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
                        + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
-                   )
-                   completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
-                   completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
-                   job_cmd_list_iterative.append(
+                     )
+                     completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
+                     completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")
+                     job_cmd_list_iterative.append(
                      f"if [ -f {completed_job_path} ] && [ $SENDCOM == YES ]; then cp -rpfv {completed_job_path} {completed_job_restart_dir}; fi"
-                   )
+                     )
 
             else:
                   completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
@@ -573,10 +573,10 @@ elif STEP == 'stats':
                        )
                      completed_jobs_file_full = COMPLETED_JOBS_FILE + "_" + job_type + "_job" + njob + ".txt"
                      job_cmd_list_iterative.append(
-                       "python -c "
+                       f"if [ $FHR_GROUP = FULL ]; then python -c "
                        + f"'import mesoscale_util; mesoscale_util.mark_job_completed("
                        + f"\"{os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)}\", "
-                       + f"\"job{njob}\", job_type=\"{job_type}\")'"
+                       + f"\"job{njob}\", job_type=\"{job_type}\")'; fi"
                      )
                      completed_job_path = os.path.join(COMPLETED_JOBS_DIR, completed_jobs_file_full)
                      completed_job_restart_dir = os.path.join(RESTART_DIR, "completed_jobs")


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In recent PRs for the mesoscale component, it was noticed that, at least for RAP, the final stats file for restart was slightly smaller than the final stats file for a full uninterrupted job.  It was discovered that, for RAP, there is a loop for hours in "SHORT FULL", where SHORT was for those cycles that went up to 21-hr forecasts, whereas FULL was for those cycles that extended to 51 hr.  The issue is that a completed jobs file was written when the SHORT cycle was completed, thus when the jobs were interrupted in the middle of the FULL cycles, they did not get re-run in the restart because the completed jobs file had already existed, causing some stats (mainly 27 to 51 hr forecasts) to be missing from the final stats file.

This PR ensures that the completed jobs file is written only after the FULL runs are completed.  Only FULL jobs are done for NAM, and NAM stats have been identical for restart jobs and uninterrupted jobs, and they are unchanged with these changes.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No

* Do you have any planned upcoming annual leave/PTO?

No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. git clone https://github.com/PerryShafran-NOAA/EVS.git
2. cd EVS; git checkout bugfix/mesoscale_rap_restart_fix
3. cd dev/drivers/scripts/stats/mesoscale
4. In the jevs_mesoscale_nam_grid2obs_stats.sh and jevs_mesoscale_rap_grid2obs_stats.sh jobs, set HOMEevs to your testing directory and COMIN to point to emc.vpppg.
5. Run the full, uninterrupted jobs, using qsub -v vhr=08 for both scripts.  Save the output to a different directory.
6. Run interrupted jobs.  Set the interrupt time for both for 10 minutes.  Once the interrupt job is done, re-run the scripts for the restart.  

In all cases we'll check for errors (except those related to interrupting the job for restart) and also check that the final stats file for restart matches what we see for the full uninterrupted run.  They should also match what is in emc.vpppg.  

NOTE - since NAM now runs in around 14 minutes, the restart job might not offer you any time savings, but since restart rules are for jobs longer than 15 minutes, this is less of a concern for NAM now.  You will see the restart time savings for RAP.
