### PR TITLE
global_ens: use split_by_subset to trim prepbufr files

### DIFF
--- a/ecf/scripts/prep/global_ens/jevs_global_ens_atmos_prep.ecf
+++ b/ecf/scripts/prep/global_ens/jevs_global_ens_atmos_prep.ecf
@@ -34,6 +34,7 @@ module load cfp/${cfp_ver}
 module load cdo/${cdo_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
+module load bufr/${bufr_ver}
 module list
 
 ############################################################

--- a/parm/metplus_config/stats/global_ens/atmos_grid2obs/Pb2nc_obsGFS_Prepbufr.conf
+++ b/parm/metplus_config/stats/global_ens/atmos_grid2obs/Pb2nc_obsGFS_Prepbufr.conf
@@ -71,17 +71,15 @@ PB2NC_WINDOW_END = 1800
 # if set, these values are substituted with the times from the current run time and passed to
 # PB2NC on the command line with -valid_beg and -valid_end arguments.
 # Not used if unset or set to an empty string
-
-##PB2NC_VALID_BEGIN = {valid?fmt=%Y%m%d_%H}
-##PB2NC_VALID_END = {valid?fmt=%Y%m%d_%H?shift=1d}
+#PB2NC_VALID_BEGIN = {valid?fmt=%Y%m%d_%H}
+#PB2NC_VALID_END = {valid?fmt=%Y%m%d_%H?shift=1d}
 
 # Values to pass to pb2nc config file using environment variables of the same name.
 # See MET User's Guide for more information
 PB2NC_GRID = G003
 PB2NC_POLY =
 PB2NC_STATION_ID =
-#PB2NC_MESSAGE_TYPE = ADPUPA, ADPSFC, SFCSHP
-PB2NC_MESSAGE_TYPE = 
+PB2NC_MESSAGE_TYPE = ADPUPA, ADPSFC, SFCSHP
 
 #PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
 
@@ -97,16 +95,9 @@ PB2NC_QUALITY_MARK_THRESH = 9
 PB2NC_OBS_BUFR_VAR_LIST = UOB, VOB, TOB, TDO, D_CAPE, D_RH, HOVI, TOCC, CEILING, PMO
 
 #Note, there must be no space between " and ; 
-#George: In MET version 10.1.0 the variable obs_prefbufr_map was renamed to obs_prepbufr_map to fix a typo (pref to prep). Typically obs_bufr_map is set by users and obs_prepbufr_map is not modified, so I would recommend removing obs_prefbufr_map from PB2NC_MET_CONFIG_OVERRIDES and instead set:
-#
-#PB2NC_OBS_BUFR_MAP = { key = "ZOB"; val = "HGT"; }, ..... { key = "PMO"; val = "PRMSL"; } ...
-#
-#That should change the PB2NC output field to PRMSL so you can change the OBS_VAR1_NAME back to PRMSL.
-#
-#
-# For defining the time periods for summarization
 PB2NC_OBS_BUFR_MAP = { key = "TOB"; val = "TMP"; }, { key = "UOB"; val = "UGRD"; }, { key = "VOB"; val = "VGRD"; }, { key = "D_RH"; val = "RH"; }, { key = "PMO"; val = "PRMSL"; }, { key = "D_CAPE"; val = "CAPE"; }, { key = "TDO"; val = "DPT"; }, { key = "TOCC"; val = "TCDC"; }, { key = "HOVI"; val = "VIS"; }, { key = "CEILING"; val = "HGT"; }; 
 
+# For defining the time periods for summarization
 #PB2NC_TIME_SUMMARY_FLAG = False
 #PB2NC_TIME_SUMMARY_BEG = 000000
 #PB2NC_TIME_SUMMARY_END = 235959
@@ -126,7 +117,7 @@ PB2NC_OBS_BUFR_MAP = { key = "TOB"; val = "TMP"; }, { key = "UOB"; val = "UGRD";
 CONFIG_DIR = {PARM_BASE}/met_config
 
 # directory containing input to PB2NC
-PB2NC_INPUT_DIR = {ENV[COMINobsproc]}
+PB2NC_INPUT_DIR = {ENV[bufrpath]}
 
 # directory to write output from PB2NC
 PB2NC_OUTPUT_DIR = {OUTPUT_BASE}/prepbufr_nc
@@ -135,7 +126,7 @@ METPLUS_CONF = {OUTPUT_BASE}/final_pb2nc_{ENV[vbeg]}.conf
 # End of [dir] section and start of [filename_templates] section
 [filename_templates]
 # Template to look for forecast input to PB2NC relative to PB2NC_INPUT_DIR
-PB2NC_INPUT_TEMPLATE = gdas.{da_init?fmt=%Y%m%d}/{da_init?fmt=%H}/atmos/gdas.t{da_init?fmt=%H}z.prepbufr
+PB2NC_INPUT_TEMPLATE = prepbufr.{da_init?fmt=%Y%m%d}/gdas.t{da_init?fmt=%H}z.prepbufr
 
 # Template to use to write output from PB2NC
 PB2NC_OUTPUT_TEMPLATE = gfs.t{da_init?fmt=%H}z.prepbufr.f00.nc

--- a/parm/metplus_config/stats/global_ens/atmos_grid2obs/Pb2nc_obsGFS_Prepbufr_Profile.conf
+++ b/parm/metplus_config/stats/global_ens/atmos_grid2obs/Pb2nc_obsGFS_Prepbufr_Profile.conf
@@ -71,16 +71,14 @@ PB2NC_WINDOW_END = 1800
 # if set, these values are substituted with the times from the current run time and passed to
 # PB2NC on the command line with -valid_beg and -valid_end arguments.
 # Not used if unset or set to an empty string
-
-##PB2NC_VALID_BEGIN = {valid?fmt=%Y%m%d_%H}
-##PB2NC_VALID_END = {valid?fmt=%Y%m%d_%H?shift=1d}
+#PB2NC_VALID_BEGIN = {valid?fmt=%Y%m%d_%H}
+#PB2NC_VALID_END = {valid?fmt=%Y%m%d_%H?shift=1d}
 
 # Values to pass to pb2nc config file using environment variables of the same name.
 # See MET User's Guide for more information
 PB2NC_GRID = G003
 PB2NC_POLY =
 PB2NC_STATION_ID =
-#PB2NC_MESSAGE_TYPE = ADPUPA, AIRCFT, AIRCAR, PROFLR
 PB2NC_MESSAGE_TYPE = ADPUPA
 
 #PB2NC_PB_REPORT_TYPE = 120, 220, 221, 122, 222, 223, 224, 131, 133, 233, 153, 156, 157, 180, 280, 181, 182, 281, 282, 183, 284, 187, 287
@@ -98,8 +96,8 @@ PB2NC_OBS_BUFR_VAR_LIST = ZOB, TOB, UOB, VOB, D_RH
 
 #Note, there must be no space between " and ; 
 PB2NC_OBS_BUFR_MAP =   { key = "ZOB"; val = "HGT"; }, { key = "TOB"; val = "TMP"; }, { key = "UOB"; val = "UGRD"; }, { key = "VOB"; val = "VGRD"; }, { key = "D_RH"; val = "RH"; } ;
-# For defining the time periods for summarization
 
+# For defining the time periods for summarization
 #PB2NC_TIME_SUMMARY_FLAG = False
 #PB2NC_TIME_SUMMARY_BEG = 000000
 #PB2NC_TIME_SUMMARY_END = 235959
@@ -119,7 +117,7 @@ PB2NC_OBS_BUFR_MAP =   { key = "ZOB"; val = "HGT"; }, { key = "TOB"; val = "TMP"
 CONFIG_DIR = {PARM_BASE}/met_config
 
 # directory containing input to PB2NC
-PB2NC_INPUT_DIR = {ENV[COMINobsproc]}
+PB2NC_INPUT_DIR = {ENV[bufrpath]}
 
 # directory to write output from PB2NC
 PB2NC_OUTPUT_DIR = {OUTPUT_BASE}/prepbufr_nc
@@ -128,8 +126,7 @@ METPLUS_CONF = {OUTPUT_BASE}/final_pb2nc_{ENV[vbeg]}.conf
 # End of [dir] section and start of [filename_templates] section
 [filename_templates]
 # Template to look for forecast input to PB2NC relative to PB2NC_INPUT_DIR
-#PB2NC_INPUT_TEMPLATE = ndas.t{valid?fmt=%2H}z.prepbufr.tm{offset?fmt=%2H}.{valid?fmt=%Y%m%d}.nr
-PB2NC_INPUT_TEMPLATE = gdas.{da_init?fmt=%Y%m%d}/{da_init?fmt=%H}/atmos/gdas.t{da_init?fmt=%H}z.prepbufr
+PB2NC_INPUT_TEMPLATE = prepbufr.{da_init?fmt=%Y%m%d}/gdas.t{da_init?fmt=%H}z.prepbufr
 
 # Template to use to write output from PB2NC
 PB2NC_OUTPUT_TEMPLATE = gfs.t{da_init?fmt=%H}z.prepbufr_profile.f00.nc

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -397,11 +397,17 @@ if [ $modnam = prepbufr ] ; then
    > run_pb2nc.sh
    for ihour in 00 06 12 18 ; do
       > run_pb2nc.${ihour}.sh
-      echo "export output_base=${WORKtask}/pb2nc" >> run_pb2nc.${ihour}.sh
+      echo "export bufrpath=$WORKtask" >> run_pb2nc.${ihour}.sh
+      echo "export output_base=$WORKtask/pb2nc" >> run_pb2nc.${ihour}.sh
       echo "export vbeg=${ihour}" >> run_pb2nc.${ihour}.sh
       echo "export vend=${ihour}" >> run_pb2nc.${ihour}.sh
       if [ -s $COMINobsproc/gdas.${vday}/${ihour}/atmos/gdas.t${ihour}z.prepbufr ] ; then
-        echo "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/Pb2nc_obsGFS_Prepbufr.conf" >> run_pb2nc.${ihour}.sh  
+        # Split the prepbufr data file by message types to reduce walltime
+	echo "mkdir -p $WORKtask/prepbufr.${vday}" >> run_pb2nc.${ihour}.sh
+        echo ">$WORKtask/prepbufr.${vday}/gdas.t${ihour}z.prepbufr" >> run_pb2nc.${ihour}.sh
+	echo "split_by_subset $COMINobsproc/gdas.${vday}/${ihour}/atmos/gdas.t${ihour}z.prepbufr" >> run_pb2nc.${ihour}.sh
+	echo "cat $WORKtask/ADPUPA $WORKtask/ADPSFC $WORKtask/SFCSHP >> $WORKtask/prepbufr.${vday}/gdas.t${ihour}z.prepbufr" >> run_pb2nc.${ihour}.sh
+      	echo "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/Pb2nc_obsGFS_Prepbufr.conf" >> run_pb2nc.${ihour}.sh  
         echo "${METPLUS_PATH}/ush/run_metplus.py -c ${PARMevs}/metplus_config/machine.conf -c ${GRID2OBS_CONF}/Pb2nc_obsGFS_Prepbufr_Profile.conf" >> run_pb2nc.${ihour}.sh  
       else
         echo "WARNING: $COMINobsproc/gdas.${vday}/${ihour}/atmos/gdas.t${ihour}z.prepbufr is not available"
@@ -414,19 +420,19 @@ if [ $modnam = prepbufr ] ; then
 	fi
       fi 
       chmod +x run_pb2nc.${ihour}.sh
-      echo "${WORKtask}/run_pb2nc.${ihour}.sh" >> run_pb2nc.sh
+      echo "$WORKtask/run_pb2nc.${ihour}.sh" >> run_pb2nc.sh
    done
-   echo "for FILE in ${WORKtask}/pb2nc/prepbufr_nc/*.nc ; do" >> run_pb2nc.sh
+   echo "for FILE in $WORKtask/pb2nc/prepbufr_nc/*.nc ; do" >> run_pb2nc.sh
    echo "  if [ -s \$FILE ]; then" >> run_pb2nc.sh
-   echo "      chmod 640 ${WORKtask}/pb2nc/prepbufr_nc/*prepbufr*.nc" >> run_pb2nc.sh
-   echo "      chgrp rstprod ${WORKtask}/pb2nc/prepbufr_nc/*prepbufr*.nc" >> run_pb2nc.sh
+   echo "      chmod 640 $WORKtask/pb2nc/prepbufr_nc/*prepbufr*.nc" >> run_pb2nc.sh
+   echo "      chgrp rstprod $WORKtask/pb2nc/prepbufr_nc/*prepbufr*.nc" >> run_pb2nc.sh
    echo "      cp -v \$FILE $COMOUTgefs" >> run_pb2nc.sh
    echo "      chmod 640 $COMOUTgefs/*prepbufr*.nc" >> run_pb2nc.sh
    echo "      chgrp rstprod $COMOUTgefs/*prepbufr*.nc" >> run_pb2nc.sh
    echo "  fi" >> run_pb2nc.sh
    echo "done" >> run_pb2nc.sh
    chmod +x run_pb2nc.sh
-   ${WORKtask}/run_pb2nc.sh
+   $WORKtask/run_pb2nc.sh
 fi
 
 ############################################################


### PR DESCRIPTION
## Description of Changes
This PR uses split_by_subset to trim prepbufr files to only include needed obs before running METplus.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? Yes, on Aug 15.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d
COMOUT - set to your test output directory
KEEPDATA - set to YES

(2) Run the prep job
Run the following job in dev/drivers/scripts/prep/global_ens for any VDATE:

qsub jevs_global_ens_atmos_prep.sh

This job runs about 4+ hours. After the job completed, log file should be free of errors or warnings, and a new prepbufr.$VDATE directory will appear under $DATA/get_prepbufr, containing the trimmed prepbufr files. The output gfs.t*z.prepbufr*.f00.nc files under $COMOUT/prep/global_ens/atmos.$VDATE/gefs should be smaller than or equal to those under emc.vpppg parallel.