### PR TITLE
increase walltime for jevs_global_det_atmos_grid2obs_sfc_plots_last90days to 01:30

### DIFF
--- a/dev/drivers/scripts/plots/global_det/jevs_global_det_atmos_grid2obs_sfc_plots_last90days.sh
+++ b/dev/drivers/scripts/plots/global_det/jevs_global_det_atmos_grid2obs_sfc_plots_last90days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=01:15:00
+#PBS -l walltime=01:30:00
 #PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=325GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_det/jevs_global_det_atmos_grid2obs_sfc_plots_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_global_det_atmos_grid2obs_sfc_plots_last90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:15:00
+#PBS -l walltime=01:30:00
 #PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=500GB
 #PBS -l debug=true
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Increased walltime of jevs_global_det_atmos_grid2obs_sfc_plots_last90days.sh and corresponding .ecf script
to 01:30.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1. Make a local directory and git clone git@github.com:QiShi-NOAA/EVS.git
     cd EVS
     git checkout feature/g2o_sfc_90day_walltime
2. ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix 
3. In dev/drivers/scripts/plots/global_det/jevs_global_det_atmos_grid2obs_sfc_plots_last90days.sh, change the HOMEevs path and set export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d
4.  qsub jevs_global_det_atmos_grid2obs_sfc_plots_last90days.sh. 
5. The job should take about 1 hour to finish. 
