### PR TITLE
Updating analyses prep and rtofs stats modulefiles

### DIFF
--- a/dev/modulefiles/analyses/analyses_prep.sh
+++ b/dev/modulefiles/analyses/analyses_prep.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
-# modulefile for EVS analyses prep component
+# modulefile for EVS analyses component, prep step
 
 set -x
 
-module use /apps/ops/para/libs/modulefiles/compiler/intel/${intel_ver}
-export HPC_OPT=/apps/ops/para/libs
-module use /apps/dev/modulefiles
 module load PrgEnv-intel/${PrgEnvintel_ver}
 module load intel/${intel_ver}
 module load ve/evs/${ve_evs_ver}
@@ -21,4 +18,5 @@ module load met/${met_ver}
 module load metplus/${metplus_ver}
 
 module list
+
 set -x

--- a/dev/modulefiles/rtofs/rtofs_stats.sh
+++ b/dev/modulefiles/rtofs/rtofs_stats.sh
@@ -3,9 +3,6 @@
 
 set -x
 
-module use /apps/ops/para/libs/modulefiles/compiler/intel/${intel_ver}
-export HPC_OPT=/apps/ops/para/libs
-module use /apps/dev/modulefiles
 module load PrgEnv-intel/${PrgEnvintel_ver}
 module load intel/${intel_ver}
 module load ve/evs/${ve_evs_ver}


### PR DESCRIPTION
## Description of Changes

Updating two more /dev/modulefiles in the develop branch to use the prod versions of EVS v2.0 VE, MET-12.0.1, METplus-6.0.0. Only the /dev/modulefiles are changed. The EVS .ecf scripts are already set up use the prod versions.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No, there is no major rush to make these changes. They just need to be made and tested before our internal code freeze.

* Do you have any planned upcoming annual leave/PTO?

I will be in the office the rest of this week and the first 4 days of next week.

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No, there are no changes to job kick-off times or run times in this PR.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS/
git checkout feature/use_prod_versions_v2
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh

Please edit and test two jobs:
1) analyses prep dev driver (only one in directory)
2) rtofs stats dev driver (the osisaf stats script runs in 2 minutes)

**Things to change:**
-HOMEevs to the directory that you are currently in (e.g., add /pr###test)
-COMIN from $USER to emc.vpppg in stats job (might not have COMIN in prep job)
-KEEPDATA to YES (keeps working directories in stmp/ during PR testing)
-Check the emc.vpppg parallel to see the latest date that's run and test that date (either adding export INITDATE (prep) or VDATE (stats))
export INITDATE=YYYYMMDD
export VDATE=YYYYMMDD 
(remember not to add spaces around =, as those can cause problems)