### PR TITLE
Refactor/change driver name

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots_last31days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_cam_nam_firewxnest_grid2obs_plots
+#PBS -N jevs_cam_nam_firewxnest_grid2obs_plots_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"

--- a/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots_last31days.sh
@@ -13,8 +13,6 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
 source $HOMEevs/versions/run.ver
 
-###%include <head.h>
-###%include <envir-p1.h>
 
 ############################################################
 # Load modules

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -478,7 +478,7 @@ suite evs_nco
               trigger :TIME >= 0300 and :TIME < 0700
           endfamily
           family cam
-            task jevs_cam_nam_firewxnest_grid2obs_plots
+            task jevs_cam_nam_firewxnest_grid2obs_plots_last31days
               time 00:30
           endfamily
           family global_chem

--- a/ecf/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_nam_firewxnest_grid2obs_plots_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_cam_nam_firewxnest_grid2obs_plots
+#PBS -N evs_cam_nam_firewxnest_grid2obs_plots_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR includes the following bugfixes:
- _Cleanup:_ The EVS-cam nam firewxnest plots job generates graphics valid across a 31-day period.  For clarity, this PR adds this time period explicitly in the job driver names.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No, however a driver name changed:
jevs_cam_nam_firewxnest_grid2obs_plots -> jevs_cam_nam_firewxnest_grid2obs_plots_last31days
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

A test job might be overkill but it will allow us to make sure before we merge that all needed name changes have been made.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### Running jobs

I recommend testing the following job:
```
jevs_cam_nam_firewxnest_grid2obs_plots_last31days
```

[Total: 1 plots job]

#### Testing jobs

- submit the driver using `qsub -v vhr=00 $driver`

#### Checking jobs
- The log file should be checked by the developer for "nam_firewxnest_grid2obs_plots" to make sure all matches continue with "_last31days", if needed
- Also, as usual, the develop should check the log for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```