### PR TITLE
Refactor/move spatial maps

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:45:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_cam_precip_plots_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=02:05:00
+#PBS -l walltime=02:20:00
 #PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_cam_precip_plots_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_precip_plots_last31days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:45:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_cam_precip_plots_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_cam_precip_plots_last90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:05:00
+#PBS -l walltime=02:20:00
 #PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=500GB
 #PBS -l debug=true
 

--- a/ush/cam/cam_plots_precip_last31days_graphx_defs.py
+++ b/ush/cam/cam_plots_precip_last31days_graphx_defs.py
@@ -159,32 +159,6 @@ graphics = {
                             }
                         }
                     },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'CONUS',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['24','30','36','42','48'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
                 },
                 'domain_group1, fhr_group2, init_group1, namnest, hireswfv3':{
                     'threshold_average':{
@@ -293,32 +267,6 @@ graphics = {
                             }
                         }
                     },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'CONUS',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['54','60'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
                 },
                 'domain_group1, fhr_group1, init_group2, namnest, hrrr':{
                     'threshold_average':{
@@ -388,32 +336,6 @@ graphics = {
                             }
                         }
                     },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'CONUS',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['24','30','36','42','48'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
                 },
                 'domain_group1, fhr_group2, init_group2, namnest':{
                     'threshold_average':{
@@ -478,32 +400,6 @@ graphics = {
                                     'OBS_THRESHs':['>=0.254,>=2.54,>=6.35,>=12.7,>=25.4,>=38.1,>=50.8,>=76.2,>=101.6,>=152.4'],
                                     'CONFIDENCE_INTERVALS':'False',
                                     'INTERP':'NEAREST',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'CONUS',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['54','60'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
                                     'INTERP_PNTSs':[''],
                                 },
                             }
@@ -2230,32 +2126,6 @@ graphics = {
                             }
                         }
                     },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Alaska',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['24','36','48'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
                 },
                 'domain_group1, fhr_group2, init_group1, namnest':{
                     'threshold_average':{
@@ -2364,32 +2234,6 @@ graphics = {
                             }
                         }
                     },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Alaska',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['60'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
                 },
                 'domain_group1, fhr_group1, init_group2, namnest, hireswarw, hireswarwmem2, hireswfv3, hrrr':{
                     'threshold_average':{
@@ -2454,32 +2298,6 @@ graphics = {
                                     'OBS_THRESHs':['>=0.254,>=2.54,>=6.35,>=12.7,>=25.4,>=38.1,>=50.8,>=76.2,>=101.6,>=152.4'],
                                     'CONFIDENCE_INTERVALS':'False',
                                     'INTERP':'NEAREST',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Alaska',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['30','42'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
                                     'INTERP_PNTSs':[''],
                                 },
                             }
@@ -2554,257 +2372,7 @@ graphics = {
                             }
                         }
                     },
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Alaska',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['54'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
                 },
-                'domain_group2, fhr_group1, init_group1, namnest':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'PuertoRico',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['24','36','48'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group2, fhr_group2, init_group1, namnest':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'PuertoRico',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['60'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group2, fhr_group1, init_group2, namnest, hireswarw, hireswarwmem2, hireswfv3':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'PuertoRico',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['30','42'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group2, fhr_group2, init_group2, namnest, hireswfv3':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'PuertoRico',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['54'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group3, fhr_group1, init_group1, namnest, hireswarw, hireswarwmem2, hireswfv3':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Hawaii',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['24','36','48'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group3, fhr_group2, init_group1, namnest, hireswfv3':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Hawaii',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['60'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group3, fhr_group1, init_group2, namnest':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Hawaii',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['30','42'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                },
-                'domain_group3, fhr_group2, init_group2, namnest':{
-                    'spatial_map':{
-                        'DATE_TYPE':'VALID',
-                        'VALID_BEG':'',
-                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
-                        'INIT_BEG':'',
-                        'INIT_END':'',
-                        'VX_MASK_LIST':'Hawaii',
-                        'EVAL_PERIODS':['NA'],
-                        'VARIABLES':{
-                            'NA':{
-                                'APCP_24':{
-                                    'FCST_VALID_HOURS':['12'],
-                                    'FCST_INIT_HOURS':[''],
-                                    'STATSs':[''],
-                                    'FCST_LEADS':['54'],
-                                    'FCST_LEVEL':'A24',
-                                    'OBS_LEVEL':'A24',
-                                    'FCST_THRESHs':[''],
-                                    'OBS_THRESHs':[''],
-                                    'CONFIDENCE_INTERVALS':'False',
-                                    'INTERP':'None',
-                                    'INTERP_PNTSs':[''],
-                                },
-                            }
-                        }
-                    },
-                }
             }
         },
     }

--- a/ush/cam/cam_plots_precip_last90days_graphx_defs.py
+++ b/ush/cam/cam_plots_precip_last90days_graphx_defs.py
@@ -159,6 +159,32 @@ graphics = {
                             }
                         }
                     },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'CONUS',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['24','30','36','42','48'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
                 },
                 'domain_group1, fhr_group2, init_group1, namnest, hireswfv3':{
                     'threshold_average':{
@@ -267,6 +293,32 @@ graphics = {
                             }
                         }
                     },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'CONUS',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['54','60'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
                 },
                 'domain_group1, fhr_group1, init_group2, namnest, hrrr':{
                     'threshold_average':{
@@ -336,6 +388,32 @@ graphics = {
                             }
                         }
                     },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'CONUS',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['24','30','36','42','48'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
                 },
                 'domain_group1, fhr_group2, init_group2, namnest':{
                     'threshold_average':{
@@ -400,6 +478,32 @@ graphics = {
                                     'OBS_THRESHs':['>=0.254,>=2.54,>=6.35,>=12.7,>=25.4,>=38.1,>=50.8,>=76.2,>=101.6,>=152.4'],
                                     'CONFIDENCE_INTERVALS':'False',
                                     'INTERP':'NEAREST',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'CONUS',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['54','60'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
                                     'INTERP_PNTSs':[''],
                                 },
                             }
@@ -2126,6 +2230,32 @@ graphics = {
                             }
                         }
                     },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Alaska',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['24','36','48'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
                 },
                 'domain_group1, fhr_group2, init_group1, namnest':{
                     'threshold_average':{
@@ -2234,6 +2364,32 @@ graphics = {
                             }
                         }
                     },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Alaska',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['60'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
                 },
                 'domain_group1, fhr_group1, init_group2, namnest, hireswarw, hireswarwmem2, hireswfv3, hrrr':{
                     'threshold_average':{
@@ -2298,6 +2454,32 @@ graphics = {
                                     'OBS_THRESHs':['>=0.254,>=2.54,>=6.35,>=12.7,>=25.4,>=38.1,>=50.8,>=76.2,>=101.6,>=152.4'],
                                     'CONFIDENCE_INTERVALS':'False',
                                     'INTERP':'NEAREST',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Alaska',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['30','42'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
                                     'INTERP_PNTSs':[''],
                                 },
                             }
@@ -2372,7 +2554,256 @@ graphics = {
                             }
                         }
                     },
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Alaska',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['54'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
                 },
+                'domain_group2, fhr_group1, init_group1, namnest':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'PuertoRico',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['24','36','48'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group2, fhr_group2, init_group1, namnest':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'PuertoRico',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['60'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group2, fhr_group1, init_group2, namnest, hireswarw, hireswarwmem2, hireswfv3':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'PuertoRico',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['30','42'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group2, fhr_group2, init_group2, namnest, hireswfv3':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'PuertoRico',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['54'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group3, fhr_group1, init_group1, namnest, hireswarw, hireswarwmem2, hireswfv3':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Hawaii',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['24','36','48'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group3, fhr_group2, init_group1, namnest, hireswfv3':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Hawaii',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['60'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group3, fhr_group1, init_group2, namnest':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Hawaii',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['30','42'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                },
+                'domain_group3, fhr_group2, init_group2, namnest':{
+                    'spatial_map':{
+                        'DATE_TYPE':'VALID',
+                        'VALID_BEG':'',
+                        'VALID_END': (datetime.strptime(os.environ['VDATE'], '%Y%m%d')-td(days=1)).strftime('%Y%m%d'),
+                        'INIT_BEG':'',
+                        'INIT_END':'',
+                        'VX_MASK_LIST':'Hawaii',
+                        'EVAL_PERIODS':['NA'],
+                        'VARIABLES':{
+                            'NA':{
+                                'APCP_24':{
+                                    'FCST_VALID_HOURS':['12'],
+                                    'FCST_INIT_HOURS':[''],
+                                    'STATSs':[''],
+                                    'FCST_LEADS':['54'],
+                                    'FCST_LEVEL':'A24',
+                                    'OBS_LEVEL':'A24',
+                                    'FCST_THRESHs':[''],
+                                    'OBS_THRESHs':[''],
+                                    'CONFIDENCE_INTERVALS':'False',
+                                    'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
+                                },
+                            }
+                        }
+                    },
+                }
             }
         },
     }

--- a/ush/cam/cam_plots_precip_last90days_graphx_defs.py
+++ b/ush/cam/cam_plots_precip_last90days_graphx_defs.py
@@ -2631,6 +2631,7 @@ graphics = {
                                     'OBS_THRESHs':[''],
                                     'CONFIDENCE_INTERVALS':'False',
                                     'INTERP':'None',
+                                    'INTERP_PNTSs':[''],
                                 },
                             }
                         }


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR includes the following changes:
- _Cleanup:_ The EVS cam precip plots jobs are split based on evaluation period (31- and 90-day jobs), to allow for the future reduction of plots by simply removing the 31-day job from EVS.  Currently spatial maps are lumped in with the 31-day plots job, and would be removed with that job.  This PR moves the spatial maps to the 90-day job so they remain in EVS.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### Running jobs

I recommend testing the following jobs:
```
jevs_cam_precip_plots_last31days
jevs_cam_precip_plots_last90days
```
[Total: 2 plots jobs]

#### Testing jobs

- submit each driver using `qsub -v vhr=00,VDATE=YYYYMMDD $driver`, where `YYYYMMDD` is three days ago (e.g. use `20250822` when testing on August 25 2025)

#### Checking jobs
- I will check the log for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```