### PR TITLE
Move ${STEP} in rtofs filenames

### DIFF
--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_rtofs_aviso_grid2grid_last60days_plots
+#PBS -N jevs_plots_rtofs_argo_grid2obs_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=5GB
+#PBS -l walltime=00:50:00
+#PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 
 ############################################################
@@ -27,8 +27,8 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=aviso
-export VERIF_CASE=grid2grid
+export OBTYPE=argo
+export VERIF_CASE=grid2obs
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
 
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_aviso_grid2grid_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_argo_grid2obs_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:50:00
+#PBS -l walltime=00:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_aviso_grid2grid_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_aviso_grid2grid_last60days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_rtofs_ghrsst_grid2grid_last60days_plots
+#PBS -N jevs_plots_rtofs_aviso_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -27,7 +27,7 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=ghrsst
+export OBTYPE=aviso
 export VERIF_CASE=grid2grid
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_ghrsst_grid2grid_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_aviso_grid2grid_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_ghrsst_grid2grid_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_ghrsst_grid2grid_last60days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_rtofs_smos_grid2grid_last60days_plots
+#PBS -N jevs_plots_rtofs_ghrsst_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=50GB
+#PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 ############################################################
@@ -27,7 +27,7 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=smos
+export OBTYPE=ghrsst
 export VERIF_CASE=grid2grid
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_smos_grid2grid_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_ghrsst_grid2grid_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_headline_grid2grid_last90days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_headline_grid2grid_last90days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_rtofs_headline_grid2grid_last90days_plots
+#PBS -N jevs_plots_rtofs_headline_grid2grid_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -38,11 +38,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_headline_grid2grid_last90days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_headline_grid2grid_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_rtofs_argo_grid2obs_last60days_plots
+#PBS -N jevs_plots_rtofs_ndbc_grid2obs_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:50:00
-#PBS -l place=shared,select=1:ncpus=1:mem=10GB
+#PBS -l walltime=00:15:00
+#PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 ############################################################
@@ -27,7 +27,7 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=argo
+export OBTYPE=ndbc
 export VERIF_CASE=grid2obs
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_argo_grid2obs_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_ndbc_grid2obs_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_osisaf_grid2grid_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_osisaf_grid2grid_last60days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_rtofs_ndbc_grid2obs_last60days_plots
+#PBS -N jevs_plots_rtofs_osisaf_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -27,8 +27,8 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=ndbc
-export VERIF_CASE=grid2obs
+export OBTYPE=osisaf
+export VERIF_CASE=grid2grid
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
 
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_ndbc_grid2obs_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_osisaf_grid2grid_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_smap_grid2grid_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_smap_grid2grid_last60days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_rtofs_osisaf_grid2grid_last60days_plots
+#PBS -N jevs_plots_rtofs_smap_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -27,7 +27,7 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=osisaf
+export OBTYPE=smap
 export VERIF_CASE=grid2grid
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_osisaf_grid2grid_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_smap_grid2grid_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_smos_grid2grid_last60days.sh
+++ b/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_smos_grid2grid_last60days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_rtofs_smap_grid2grid_last60days_plots
+#PBS -N jevs_plots_rtofs_smos_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=5GB
+#PBS -l place=shared,select=1:ncpus=1:mem=50GB
 #PBS -l debug=true
 
 ############################################################
@@ -27,7 +27,7 @@ export NET=evs
 export STEP=plots
 export COMPONENT=rtofs
 export RUN=ocean
-export OBTYPE=smap
+export OBTYPE=smos
 export VERIF_CASE=grid2grid
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,11 +39,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_rtofs_smap_grid2grid_last60days_plots}
+export job=${PBS_JOBNAME:-jevs_plots_rtofs_smos_grid2grid_last60days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create plots

--- a/dev/drivers/scripts/prep/rtofs/jevs_prep_rtofs.sh
+++ b/dev/drivers/scripts/prep/rtofs/jevs_prep_rtofs.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_rtofs_prep
+#PBS -N jevs_prep_rtofs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -36,13 +36,13 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_PREP
+$HOMEevs/jobs/JEVS_PREP_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to pre-process RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_rtofs_ndbc_grid2obs_stats
+#PBS -N jevs_stats_rtofs_argo_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=05:30:00
+#PBS -l walltime=02:25:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -26,7 +26,7 @@ export envir=prod
 export NET=evs
 export STEP=stats
 export RUN=ocean
-export OBTYPE=ndbc
+export OBTYPE=argo
 export VERIF_CASE=grid2obs
 export COMPONENT=rtofs
 
@@ -39,17 +39,16 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat
-#          files for RTOFS forecasts verified with NDBC data using
-#          MET/METplus.
+#          files for RTOFS forecast verification using MET/METplus.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)
 ######################################################################

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_rtofs_ghrsst_grid2grid_stats
+#PBS -N jevs_stats_rtofs_aviso_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:15:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -26,7 +26,7 @@ export envir=prod
 export NET=evs
 export STEP=stats
 export RUN=ocean
-export OBTYPE=ghrsst
+export OBTYPE=aviso
 export VERIF_CASE=grid2grid
 export COMPONENT=rtofs
 
@@ -39,13 +39,13 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_rtofs_smos_grid2grid_stats
+#PBS -N jevs_stats_rtofs_ghrsst_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:10:00
+#PBS -l walltime=00:30:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -26,7 +26,7 @@ export envir=prod
 export NET=evs
 export STEP=stats
 export RUN=ocean
-export OBTYPE=smos
+export OBTYPE=ghrsst
 export VERIF_CASE=grid2grid
 export COMPONENT=rtofs
 
@@ -39,13 +39,13 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_rtofs_osisaf_grid2grid_stats
+#PBS -N jevs_stats_rtofs_ndbc_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:10:00
+#PBS -l walltime=05:30:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -26,8 +26,8 @@ export envir=prod
 export NET=evs
 export STEP=stats
 export RUN=ocean
-export OBTYPE=osisaf
-export VERIF_CASE=grid2grid
+export OBTYPE=ndbc
+export VERIF_CASE=grid2obs
 export COMPONENT=rtofs
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,16 +39,17 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat
-#          files for RTOFS forecast verification using MET/METplus.
+#          files for RTOFS forecasts verified with NDBC data using
+#          MET/METplus.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)
 ######################################################################

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
@@ -39,7 +39,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_rtofs_aviso_grid2grid_stats
+#PBS -N jevs_stats_rtofs_osisaf_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -26,7 +26,7 @@ export envir=prod
 export NET=evs
 export STEP=stats
 export RUN=ocean
-export OBTYPE=aviso
+export OBTYPE=osisaf
 export VERIF_CASE=grid2grid
 export COMPONENT=rtofs
 
@@ -39,13 +39,13 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_rtofs_smap_grid2grid_stats
+#PBS -N jevs_stats_rtofs_smap_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -39,13 +39,13 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STATS}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_rtofs_argo_grid2obs_stats
+#PBS -N jevs_stats_rtofs_smos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=02:25:00
+#PBS -l walltime=00:10:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -26,8 +26,8 @@ export envir=prod
 export NET=evs
 export STEP=stats
 export RUN=ocean
-export OBTYPE=argo
-export VERIF_CASE=grid2obs
+export OBTYPE=smos
+export VERIF_CASE=grid2grid
 export COMPONENT=rtofs
 
 source $HOMEevs/dev/modulefiles/${COMPONENT}/${COMPONENT}_${STEP}.sh
@@ -39,13 +39,13 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
 
 # call j-job
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 
 ######################################################################
 # Purpose: The job and task scripts work together to create stat

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -473,7 +473,7 @@ suite evs_nco
             task jevs_rtofs_argo_grid2obs_last60days_plots
               trigger :TIME >= 0300 and :TIME < 0700
             task jevs_rtofs_ndbc_grid2obs_last60days_plots
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_rtofs_ndbc_grid2obs_stats == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete
             task jevs_rtofs_headline_grid2grid_last90days_plots
               trigger :TIME >= 0300 and :TIME < 0700
           endfamily
@@ -1832,19 +1832,19 @@ suite evs_nco
         family stats
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family rtofs
-            task jevs_rtofs_ndbc_grid2obs_stats
+            task jevs_stats_rtofs_ndbc_grid2obs
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
-            task jevs_rtofs_argo_grid2obs_stats
+            task jevs_stats_rtofs_argo_grid2obs
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
-            task jevs_rtofs_aviso_grid2grid_stats
+            task jevs_stats_rtofs_aviso_grid2grid
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
-            task jevs_rtofs_ghrsst_grid2grid_stats
+            task jevs_stats_rtofs_ghrsst_grid2grid
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
-            task jevs_rtofs_osisaf_grid2grid_stats
+            task jevs_stats_rtofs_osisaf_grid2grid
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
-            task jevs_rtofs_smap_grid2grid_stats
+            task jevs_stats_rtofs_smap_grid2grid
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
-            task jevs_rtofs_smos_grid2grid_stats
+            task jevs_stats_rtofs_smos_grid2grid
               trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
           endfamily
           family mesoscale

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -460,21 +460,21 @@ suite evs_nco
         family plots
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family rtofs
-            task jevs_rtofs_aviso_grid2grid_last60days_plots
+            task jevs_plots_rtofs_aviso_grid2grid_last60days
               trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_rtofs_ghrsst_grid2grid_last60days_plots
+            task jevs_plots_rtofs_ghrsst_grid2grid_last60days
               trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_rtofs_osisaf_grid2grid_last60days_plots
+            task jevs_plots_rtofs_osisaf_grid2grid_last60days
               trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_rtofs_smap_grid2grid_last60days_plots
+            task jevs_plots_rtofs_smap_grid2grid_last60days
               trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_rtofs_smos_grid2grid_last60days_plots
+            task jevs_plots_rtofs_smos_grid2grid_last60days
               trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_rtofs_argo_grid2obs_last60days_plots
+            task jevs_plots_rtofs_argo_grid2obs_last60days
               trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_rtofs_ndbc_grid2obs_last60days_plots
+            task jevs_plots_rtofs_ndbc_grid2obs_last60days
               trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete
-            task jevs_rtofs_headline_grid2grid_last90days_plots
+            task jevs_plots_rtofs_headline_grid2grid_last90days
               trigger :TIME >= 0300 and :TIME < 0700
           endfamily
           family cam

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1,6 +1,6 @@
 suite evs_nco
   family primary
-    edit evs_ver 'v1.0'
+    edit evs_ver 'v2.0'
     edit PACKAGEHOME '/lfs/h2/emc/global/noscrub/%EMC_USER%/para/packages/evs.%evs_ver%'
     edit NET 'evs'
     edit RUN 'evs'
@@ -527,7 +527,7 @@ suite evs_nco
         family prep
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family rtofs
-            task jevs_rtofs_prep
+            task jevs_prep_rtofs
               time 07:00
           endfamily
           family global_ens

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_rtofs_smap_grid2grid_last60days_plots
+#PBS -N evs_plots_rtofs_argo_grid2obs_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=5GB
+#PBS -l walltime=00:50:00
+#PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 
 export model=evs
@@ -37,13 +37,13 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=smap
-export VERIF_CASE=grid2grid
+export OBTYPE=argo
+export VERIF_CASE=grid2obs
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_argo_grid2obs_last60days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:50:00
+#PBS -l walltime=00:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_aviso_grid2grid_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_aviso_grid2grid_last60days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_ndbc_grid2obs_last60days_plots
+#PBS -N evs_plots_rtofs_aviso_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -37,13 +37,13 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=ndbc
-export VERIF_CASE=grid2obs
+export OBTYPE=aviso
+export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_ghrsst_grid2grid_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_ghrsst_grid2grid_last60days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_ghrsst_grid2grid_last60days_plots
+#PBS -N evs_plots_rtofs_ghrsst_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -43,7 +43,7 @@ export VERIF_CASE=grid2grid
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_headline_grid2grid_last90days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_headline_grid2grid_last90days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_rtofs_argo_grid2obs_last60days_plots
+#PBS -N evs_plots_rtofs_headline_grid2grid_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:50:00
-#PBS -l place=shared,select=1:ncpus=1:mem=10GB
+#PBS -l walltime=00:15:00
+#PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 export model=evs
@@ -36,14 +36,13 @@ else
   export vhr=00
 fi
 export NET=evs
-export RUN=ocean
-export OBTYPE=argo
-export VERIF_CASE=grid2obs
+export RUN=headline
+export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_ndbc_grid2obs_last60days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_headline_grid2grid_last90days_plots
+#PBS -N evs_plots_rtofs_ndbc_grid2obs_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -36,13 +36,14 @@ else
   export vhr=00
 fi
 export NET=evs
-export RUN=headline
-export VERIF_CASE=grid2grid
+export RUN=ocean
+export OBTYPE=ndbc
+export VERIF_CASE=grid2obs
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_osisaf_grid2grid_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_osisaf_grid2grid_last60days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_aviso_grid2grid_last60days_plots
+#PBS -N evs_plots_rtofs_osisaf_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -37,13 +37,13 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=aviso
+export OBTYPE=osisaf
 export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_smap_grid2grid_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_smap_grid2grid_last60days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_rtofs_smos_grid2grid_last60days_plots
+#PBS -N evs_plots_rtofs_smap_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=50GB
+#PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 export model=evs
@@ -37,13 +37,13 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=smos
+export OBTYPE=smap
 export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/rtofs/jevs_plots_rtofs_smos_grid2grid_last60days.ecf
+++ b/ecf/scripts/plots/rtofs/jevs_plots_rtofs_smos_grid2grid_last60days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_rtofs_osisaf_grid2grid_last60days_plots
+#PBS -N evs_plots_rtofs_smos_grid2grid_last60days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=5GB
+#PBS -l place=shared,select=1:ncpus=1:mem=50GB
 #PBS -l debug=true
 
 export model=evs
@@ -37,13 +37,13 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=osisaf
+export OBTYPE=smos
 export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/prep/rtofs/jevs_prep_rtofs.ecf
+++ b/ecf/scripts/prep/rtofs/jevs_prep_rtofs.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_prep
+#PBS -N evs_prep_rtofs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -42,7 +42,7 @@ export RUN=ocean
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_PREP
+$HOMEevs/jobs/JEVS_PREP_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_argo_grid2obs_stats
+#PBS -N evs_stats_rtofs_argo_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -45,7 +45,7 @@ export VARS="temp psal"
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.ecf
@@ -1,9 +1,9 @@
-#PBS -N evs_rtofs_ndbc_grid2obs_stats
+#PBS -N evs_stats_rtofs_aviso_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=05:30:00
+#PBS -l walltime=00:15:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -37,20 +37,19 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=ndbc
-export OBTYPEupper=NDBC_STANDARD
-export VERIF_CASE=grid2obs
-export VAR=sst
-export VDATE=$($NDATE -48 ${PDY}00| cut -c 1-8)
+export OBTYPE=aviso
+export OBTYPEupper=AVISO
+export VERIF_CASE=grid2grid
+export VAR=ssh
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort
-   exit
+   exit 
 fi
 
 %include <tail.h>

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.ecf
@@ -1,9 +1,9 @@
-#PBS -N evs_rtofs_osisaf_grid2grid_stats
+#PBS -N evs_stats_rtofs_ghrsst_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:10:00
+#PBS -l walltime=00:30:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -37,19 +37,19 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=osisaf
-export OBTYPEupper=OSISAF
-export VAR=sic
+export OBTYPE=ghrsst
+export OBTYPEupper=GHRSST
+export VAR=sst
 export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort
-   exit
+   exit 
 fi
 
 %include <tail.h>

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.ecf
@@ -1,9 +1,9 @@
-#PBS -N evs_rtofs_aviso_grid2grid_stats
+#PBS -N evs_stats_rtofs_ndbc_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=05:30:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -37,19 +37,20 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=aviso
-export OBTYPEupper=AVISO
-export VERIF_CASE=grid2grid
-export VAR=ssh
+export OBTYPE=ndbc
+export OBTYPEupper=NDBC_STANDARD
+export VERIF_CASE=grid2obs
+export VAR=sst
+export VDATE=$($NDATE -48 ${PDY}00| cut -c 1-8)
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort
-   exit 
+   exit
 fi
 
 %include <tail.h>

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.ecf
@@ -1,9 +1,9 @@
-#PBS -N evs_rtofs_ghrsst_grid2grid_stats
+#PBS -N evs_stats_rtofs_osisaf_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:30:00
+#PBS -l walltime=00:10:00
 #PBS -l place=exclhost,select=1:ncpus=1:mem=500GB
 #PBS -l debug=true
 
@@ -37,19 +37,19 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=ghrsst
-export OBTYPEupper=GHRSST
-export VAR=sst
+export OBTYPE=osisaf
+export OBTYPEupper=OSISAF
+export VAR=sic
 export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort
-   exit 
+   exit
 fi
 
 %include <tail.h>

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_smos_grid2grid_stats
+#PBS -N evs_stats_rtofs_smap_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -37,15 +37,15 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=smos
-export OBTYPEupper=SMOS
-export VAR=sss
+export OBTYPE=smap
+export OBTYPEupper=SMAP
 export VERIF_CASE=grid2grid
+export VAR=sss
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.ecf
+++ b/ecf/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_rtofs_smap_grid2grid_stats
+#PBS -N evs_stats_rtofs_smos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -37,15 +37,15 @@ else
 fi
 export NET=evs
 export RUN=ocean
-export OBTYPE=smap
-export OBTYPEupper=SMAP
-export VERIF_CASE=grid2grid
+export OBTYPE=smos
+export OBTYPEupper=SMOS
 export VAR=sss
+export VERIF_CASE=grid2grid
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_RTOFS_STATS
+$HOMEevs/jobs/JEVS_STATS_RTOFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/jobs/JEVS_PLOTS_RTOFS
+++ b/jobs/JEVS_PLOTS_RTOFS
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Job Name: JEVS_RTOFS_PLOTS
+# Job Name: JEVS_PLOTS_RTOFS
 # Purpose: To create plots for RTOFS forecast verification using MET/METplus.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)
 ###############################################################################
@@ -82,10 +82,10 @@ fi
 #######################################################################
 env
 if [ $RUN = ocean ]; then
-	$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${OBTYPE}_${VERIF_CASE}_${STEP}.sh
+	$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}.sh
 	export err=$?; err_chk
 elif [ $RUN = headline ]; then
-        $HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${RUN}_${VERIF_CASE}_${STEP}.sh
+        $HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}_headline_${VERIF_CASE}.sh
         export err=$?; err_chk
 fi	
 

--- a/jobs/JEVS_PREP_RTOFS
+++ b/jobs/JEVS_PREP_RTOFS
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Job Name: JEVS_RTOFS_PREP
+# Job Name: JEVS_PREP_RTOFS
 # Purpose: To pre-process RTOFS forecast data into the same spatial and
 #          temporal scales as validation data.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)
@@ -75,7 +75,7 @@ mkdir -p $COMOUT $COMOUTprep
 # Execute the script
 #######################################################################
 env
-$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${STEP}.sh
+$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}.sh
 export err=$?; err_chk
 
 if [ "$KEEPDATA" != "YES" ] ; then

--- a/jobs/JEVS_STATS_RTOFS
+++ b/jobs/JEVS_STATS_RTOFS
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Job Name: JEVS_RTOFS_STATS
+# Job Name: JEVS_STATS_RTOFS
 # Purpose: To create stat files for RTOFS forecast verification using
 #          MET/METplus.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)
@@ -69,7 +69,7 @@ export COMOUTfinal=${COMOUTfinal:-$COMOUT/$STEP/$COMPONENT/$COMPONENT.$VDATE}
 
 mkdir -p $COMOUT $COMOUTsmall $COMOUTfinal
 
-$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${VERIF_CASE}_${STEP}.sh
+$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}_${VERIF_CASE}.sh
 
 export err=$?; err_chk
 

--- a/scripts/plots/rtofs/exevs_plots_rtofs_argo_grid2obs.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_argo_grid2obs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ####################################################################################################
-# Name of Script: exevs_rtofs_argo_grid2obs_plots
+# Name of Script: exevs_plots_rtofs_argo_grid2obs
 # Purpose of Script: Create RTOFS ARGO plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 

--- a/scripts/plots/rtofs/exevs_plots_rtofs_aviso_grid2grid.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_aviso_grid2grid.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
-#####################################################################################################
-# Name of Script: exevs_rtofs_ghrsst_grid2grid_plots
-# Purpose of Script: Create RTOFS GHRSST plots for last 60 days
+######################################################################################################
+# Name of Script: exevs_plots_rtofs_aviso_grid2grid
+# Purpose of Script: Create RTOFS AVISO plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 
-# 09/2024: Variable names changed:
-# 1- $RUN=ocean for each step of EVSv2-RTOFS was defined to be consistent with other EVS components. 
-# 2- $RUN was defined in all j-jobs. 
-# 3- $RUNsmall was renamed to $RUN in stats j-job and all stats scripts; and 
-# 4- For all observation types, variable $OBTYPE was used instead of $RUN throughout all scripts.
-#####################################################################################################
+#  09/2024: Variable names changed:
+#  1- $RUN=ocean for each step of EVSv2-RTOFS was defined to be consistent with other EVS components. 
+#  2- $RUN was defined in all j-jobs. 
+#  3- $RUNsmall was renamed to $RUN in stats j-job and all stats scripts; and 
+#  4- For all observation types, variable $OBTYPE was used instead of $RUN throughout all scripts.
+# 
+######################################################################################################
 
 set -x
 
-export OBTYPE=GHRSST
+export OBTYPE=AVISO
 
-export VAR=SST
+export VAR=SSH
 
 mkdir -p $DATA/$STEP/$COMPONENT/$COMPONENT.$VDATE
 mkdir -p $DATA/tmp/rtofs
@@ -97,7 +98,7 @@ cd $DATA/plots/$COMPONENT/rtofs.$VDATE/$obtype
 tar -cvf evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar *.png
 
 if [ $SENDCOM = "YES" ]; then
- if [ -s evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar ] ; then
+ if [ -s evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar ]; then
 	cp -v evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar $COMOUTplots
  fi
 fi

--- a/scripts/plots/rtofs/exevs_plots_rtofs_ghrsst_grid2grid.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_ghrsst_grid2grid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-######################################################################################################
-# Name of Script: exevs_rtofs_ndnc_grid2obs_plots
-# Purpose of Script: Create RTOFS NDBC plots for last 60 days
+#####################################################################################################
+# Name of Script: exevs_plots_rtofs_ghrsst_grid2grid
+# Purpose of Script: Create RTOFS GHRSST plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 
 # 09/2024: Variable names changed:
@@ -13,11 +13,9 @@
 
 set -x
 
-export OBTYPE=NDBC_STANDARD
+export OBTYPE=GHRSST
 
 export VAR=SST
-export FLVL=Z0
-export OLVL=Z0
 
 mkdir -p $DATA/$STEP/$COMPONENT/$COMPONENT.$VDATE
 mkdir -p $DATA/tmp/rtofs
@@ -27,7 +25,7 @@ export MET_VERSION_major_minor=$(echo $MET_VERSION | sed "s/\([^.]*\.[^.]*\)\..*
 # set up plot variables
 export PERIOD=last60days
 export THRESH=""
-export MASKS="GLB"
+export MASKS="GLB, NATL, SATL, EQATL, NPAC, SPAC, EQPAC, IND, SOC, Arctic, MEDIT"
 
 # plot time series
 export PTYPE=time_series
@@ -92,20 +90,16 @@ if [[ $log_file_count -ne 0 ]]; then
 	done
 fi
 
-if [ $OBTYPE = 'NDBC_STANDARD' ]; then
-	export obtype_lower=ndbc_standard
-	export obtype=ndbc
-
-fi
+export obtype=`echo $OBTYPE |tr '[A-Z]' '[a-z]'`
 
 # tar all plots together
-cd $DATA/plots/$COMPONENT/rtofs.$VDATE/$obtype_lower
+cd $DATA/plots/$COMPONENT/rtofs.$VDATE/$obtype
 tar -cvf evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar *.png
 
 if [ $SENDCOM = "YES" ]; then
-	if [ -s evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar ]; then
-		cp -v evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar $COMOUTplots
-	fi
+ if [ -s evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar ] ; then
+	cp -v evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar $COMOUTplots
+ fi
 fi
 
 if [ $SENDDBN = YES ] ; then

--- a/scripts/plots/rtofs/exevs_plots_rtofs_headline_grid2grid.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_headline_grid2grid.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ######################################################################################################
-# Name of Script: exevs_rtofs_headline_grid2grid_plots
+# Name of Script: exevs_plots_rtofs_headline_grid2grid
 # Purpose of Script: Create RTOFS headline plots
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 

--- a/scripts/plots/rtofs/exevs_plots_rtofs_ndbc_grid2obs.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_ndbc_grid2obs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-########################################################################################################
-# Name of Script: exevs_rtofs_smap_grid2grid_plots
-# Purpose of Script: Create RTOFS SMAP plots for last 60 days
+######################################################################################################
+# Name of Script: exevs_plots_rtofs_ndnc_grid2obs
+# Purpose of Script: Create RTOFS NDBC plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 
 # 09/2024: Variable names changed:
@@ -9,14 +9,15 @@
 # 2- $RUN was defined in all j-jobs. 
 # 3- $RUNsmall was renamed to $RUN in stats j-job and all stats scripts; and 
 # 4- For all observation types, variable $OBTYPE was used instead of $RUN throughout all scripts.
-
-#########################################################################################################
+#####################################################################################################
 
 set -x
 
-export OBTYPE=SMAP
+export OBTYPE=NDBC_STANDARD
 
-export VAR=SSS
+export VAR=SST
+export FLVL=Z0
+export OLVL=Z0
 
 mkdir -p $DATA/$STEP/$COMPONENT/$COMPONENT.$VDATE
 mkdir -p $DATA/tmp/rtofs
@@ -26,7 +27,7 @@ export MET_VERSION_major_minor=$(echo $MET_VERSION | sed "s/\([^.]*\.[^.]*\)\..*
 # set up plot variables
 export PERIOD=last60days
 export THRESH=""
-export MASKS="GLB, NATL, SATL, EQATL, NPAC, SPAC, EQPAC, IND, SOC, Arctic, MEDIT"
+export MASKS="GLB"
 
 # plot time series
 export PTYPE=time_series
@@ -91,10 +92,14 @@ if [[ $log_file_count -ne 0 ]]; then
 	done
 fi
 
-export obtype=`echo $OBTYPE |tr '[A-Z]' '[a-z]'`
+if [ $OBTYPE = 'NDBC_STANDARD' ]; then
+	export obtype_lower=ndbc_standard
+	export obtype=ndbc
+
+fi
 
 # tar all plots together
-cd $DATA/plots/$COMPONENT/rtofs.$VDATE/$obtype
+cd $DATA/plots/$COMPONENT/rtofs.$VDATE/$obtype_lower
 tar -cvf evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar *.png
 
 if [ $SENDCOM = "YES" ]; then

--- a/scripts/plots/rtofs/exevs_plots_rtofs_osisaf_grid2grid.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_osisaf_grid2grid.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #####################################################################################################
-# Name of Script: exevs_rtofs_osisaf_grid2grid_plots
+# Name of Script: exevs_plots_rtofs_osisaf_grid2grid
 # Purpose of Script: Create RTOFS OSI-SAF plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 

--- a/scripts/plots/rtofs/exevs_plots_rtofs_smap_grid2grid.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_smap_grid2grid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#########################################################################################################
-# Name of Script: exevs_rtofs_smos_grid2grid_plots
-# Purpose of Script: Create RTOFS SMOS plots for last 60 days
+########################################################################################################
+# Name of Script: exevs_plots_rtofs_smap_grid2grid
+# Purpose of Script: Create RTOFS SMAP plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 
 # 09/2024: Variable names changed:
@@ -9,11 +9,12 @@
 # 2- $RUN was defined in all j-jobs. 
 # 3- $RUNsmall was renamed to $RUN in stats j-job and all stats scripts; and 
 # 4- For all observation types, variable $OBTYPE was used instead of $RUN throughout all scripts.
+
 #########################################################################################################
 
 set -x
 
-export OBTYPE=SMOS
+export OBTYPE=SMAP
 
 export VAR=SSS
 

--- a/scripts/plots/rtofs/exevs_plots_rtofs_smos_grid2grid.sh
+++ b/scripts/plots/rtofs/exevs_plots_rtofs_smos_grid2grid.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
-######################################################################################################
-# Name of Script: exevs_rtofs_aviso_grid2grid_plots
-# Purpose of Script: Create RTOFS AVISO plots for last 60 days
+#########################################################################################################
+# Name of Script: exevs_plots_rtofs_smos_grid2grid
+# Purpose of Script: Create RTOFS SMOS plots for last 60 days
 # Author: Mallory Row (mallory.row@noaa.gov)
 # Edited by:  Samira Ardani (samira.ardani@noaa.gov) 
-#  09/2024: Variable names changed:
-#  1- $RUN=ocean for each step of EVSv2-RTOFS was defined to be consistent with other EVS components. 
-#  2- $RUN was defined in all j-jobs. 
-#  3- $RUNsmall was renamed to $RUN in stats j-job and all stats scripts; and 
-#  4- For all observation types, variable $OBTYPE was used instead of $RUN throughout all scripts.
-# 
-######################################################################################################
+# 09/2024: Variable names changed:
+# 1- $RUN=ocean for each step of EVSv2-RTOFS was defined to be consistent with other EVS components. 
+# 2- $RUN was defined in all j-jobs. 
+# 3- $RUNsmall was renamed to $RUN in stats j-job and all stats scripts; and 
+# 4- For all observation types, variable $OBTYPE was used instead of $RUN throughout all scripts.
+#########################################################################################################
 
 set -x
 
-export OBTYPE=AVISO
+export OBTYPE=SMOS
 
-export VAR=SSH
+export VAR=SSS
 
 mkdir -p $DATA/$STEP/$COMPONENT/$COMPONENT.$VDATE
 mkdir -p $DATA/tmp/rtofs
@@ -98,9 +97,9 @@ cd $DATA/plots/$COMPONENT/rtofs.$VDATE/$obtype
 tar -cvf evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar *.png
 
 if [ $SENDCOM = "YES" ]; then
- if [ -s evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar ]; then
-	cp -v evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar $COMOUTplots
- fi
+	if [ -s evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar ]; then
+		cp -v evs.plots.$COMPONENT.$obtype.${VERIF_CASE}.$PERIOD.v$VDATE.tar $COMOUTplots
+	fi
 fi
 
 if [ $SENDDBN = YES ] ; then

--- a/scripts/prep/rtofs/exevs_prep_rtofs.sh
+++ b/scripts/prep/rtofs/exevs_prep_rtofs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #############################################################################################
-# Name of Script: exevs_rtofs_prep.sh
+# Name of Script: exevs_prep_rtofs.sh
 # Purpose of Script: To copy RTOFS production data, convert RTOFS forecasts grids,
 #                    process obs, create masking files
 # Authors: Mallory Row (mallory.row@noaa.gov)

--- a/scripts/stats/rtofs/exevs_stats_rtofs_grid2grid.sh
+++ b/scripts/stats/rtofs/exevs_stats_rtofs_grid2grid.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Name of Script: exevs_rtofs_grid2grid_stats.sh
+# Name of Script: exevs_stats_rtofs_grid2grid.sh
 # Purpose of Script: To create stat files for RTOFS, grid2grid verification cases.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)
 # Modified for EVSv2:

--- a/scripts/stats/rtofs/exevs_stats_rtofs_grid2obs.sh
+++ b/scripts/stats/rtofs/exevs_stats_rtofs_grid2obs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Name of Script: exevs_rtofs_grid2obs_stats.sh
+# Name of Script: exevs_stats_rtofs_grid2obs.sh
 # Purpose of Script: To create stat files for RTOFS ocean temperature and
 #    salinity forecasts verified with Argo and NDBC data using MET/METplus.
 # Author: L. Gwen Chen (lichuan.chen@noaa.gov)


### PR DESCRIPTION
## Description of Changes

NCO has requested that EVS script/job names match the EVS com/ structure: …/com/evs/v1.0/${STEP}/${COMPONENT}/…
This PR updates RTOFS scripts/job names by moving ${STEP} earlier in the name. Tests showed that all updates worked, with no errors or warnings.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS/
git checkout feature/rtofs_step_update
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh

Please edit and test all rtofs dev drivers (prep, stats, and plots) using just qsub drivername.sh. To compare results, the emc.vpppg parallel output can be found here:

**prep:** /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/rtofs/
**stats:** /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/rtofs/
**plots:** /lfs/h2/emc/ptmp/emc.vpppg/evs/v2.0/plots/rtofs/

Things to change in rtofs dev drivers:
-HOMEevs to the directory that you are currently in (e.g., add /pr###test)
-COMIN from $USER to emc.vpppg
-KEEPDATA to YES (keeps working directories in stmp during PR testing)
-SENDMAIL to NO

Drivers to test:
dev/drivers/scripts/prep/rtofs/*
dev/drivers/scripts/stats/rtofs/*
dev/drivers/scripts/plots/rtofs/*
