### PR TITLE
feature/subseasonal_fix_evs_nco_def

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1227,13 +1227,13 @@ suite evs_nco
 	      trigger :TIME >= 1515 and ../../prep/nwps == complete
 	  endfamily
           family subseasonal
-            task jevs_cfs_subseasonal_grid2obs_stats
+            task jevs_subseasonal_cfs_grid2obs_stats
               trigger :TIME >= 1530 and ../../prep/subseasonal/jevs_subseasonal_cfs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
-            task jevs_cfs_subseasonal_grid2grid_stats
+            task jevs_subseasonal_cfs_grid2grid_stats
               trigger :TIME >= 1600 and ../../prep/subseasonal/jevs_subseasonal_cfs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
-            task jevs_gefs_subseasonal_grid2obs_stats
+            task jevs_subseasonal_gefs_grid2obs_stats
               trigger :TIME >= 1630 and ../../prep/subseasonal/jevs_subseasonal_gefs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
-            task jevs_gefs_subseasonal_grid2grid_stats    # walltime=02:00:00
+            task jevs_subseasonal_gefs_grid2grid_stats    # walltime=02:00:00
               trigger :TIME >= 1610 and ../../prep/subseasonal/jevs_subseasonal_gefs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
           endfamily
           family mesoscale
@@ -2307,29 +2307,29 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family subseasonal
             task jevs_subseasonal_grid2obs_prepbufr_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2obs_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2obs_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2obs_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2obs_stats == complete
             task jevs_subseasonal_grid2obs_prepbufr_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2obs_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2obs_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2obs_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2obs_stats == complete
             task jevs_subseasonal_grid2grid_sst_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_sst_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_sea_ice_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_sea_ice_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_pres_lvls_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_pres_lvls_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_precip_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_precip_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_temp_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
             task jevs_subseasonal_grid2grid_temp_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_cfs_subseasonal_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_gefs_subseasonal_grid2grid_stats == complete
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
           endfamily
           family mesoscale
             task jevs_mesoscale_snowfall_plots_last31days


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR fixes the incorrect subseasonal stat job naming conventions in evs-nco.def that were noticed in PR #827.
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
This PR only addresses simple naming convention fixes so testing should not be necessary.