### PR TITLE
Cleanup of analyses and mesoscale

### DIFF
--- a/dev/drivers/scripts/plots/analyses/jevs_analyses_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_analyses_grid2obs_plots_last31days.sh
@@ -56,7 +56,7 @@ export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}
 export vhr=00
 echo $vhr
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_PLOTS

--- a/dev/drivers/scripts/prep/mesoscale/jevs_mesoscale_grid2obs_prep.sh
+++ b/dev/drivers/scripts/prep/mesoscale/jevs_mesoscale_grid2obs_prep.sh
@@ -54,7 +54,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'perry.shafran@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_ccpa_precip_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${ccpa_ver}
 export modsys=ccpa
 export MODELNAME=ccpa
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_grid2obs_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_precip_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats.sh
@@ -55,7 +55,7 @@ export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma_ru
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_grid2obs_stats.sh
@@ -56,7 +56,7 @@ export MODELNAME=urma
 export modsys=urma
 export mod_ver=${urma_ver}
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_precip_stats.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_analyses_urma_precip_stats.sh
@@ -57,7 +57,7 @@ export mod_ver=${urma_ver}
 export modsys=urma
 export MODELNAME=urma
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_ANALYSES_STATS

--- a/dev/drivers/scripts/stats/cam/jevs_cam_nam_firewxnest_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_cam_nam_firewxnest_grid2obs_stats.sh
@@ -47,7 +47,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
-export MAILTO=${MAILTO:-'perry.shafran@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_CAM_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_grid2obs_stats.sh
@@ -59,7 +59,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}
-  export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+  export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_MESOSCALE_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_precip_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_grid2obs_stats.sh
@@ -59,7 +59,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}
-  export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+  export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_MESOSCALE_STATS

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_precip_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
+++ b/dev/drivers/scripts/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats.sh
@@ -38,7 +38,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="perry.shafran@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/mesoscale/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -30,11 +30,6 @@ suite evs_nco
             task jevs_global_ens_headline_prep
               trigger :TIME >= 0400 and ./jevs_global_ens_atmos_prep == complete and ./jevs_global_ens_naefs_atmos_prep == complete
           endfamily
-          family analyses
-            task jevs_analyses_precip_prep_vhr_00
-              time 00:00
-              edit VHR '00'
-          endfamily
           family cam
             task jevs_cam_radar_prep_vhr_00
               time 00:05
@@ -393,60 +388,6 @@ suite evs_nco
             task jevs_analyses_rtma_ru_grid2obs_stats_vhr_05
               time 05:00
               edit VHR '05'
-            task jevs_analyses_urma_precip_stats_vhr_00
-              time 00:00
-              edit VHR '00'
-            task jevs_analyses_urma_precip_stats_vhr_01
-              time 01:00
-              edit VHR '01'
-            task jevs_analyses_urma_precip_stats_vhr_02
-              time 02:00
-              edit VHR '02'
-            task jevs_analyses_urma_precip_stats_vhr_03
-              time 03:00
-              edit VHR '03'
-            task jevs_analyses_urma_precip_stats_vhr_04
-              time 04:00
-              edit VHR '04'
-            task jevs_analyses_urma_precip_stats_vhr_05
-              time 05:00
-              edit VHR '05'
-            task jevs_analyses_rtma_precip_stats_vhr_00
-              time 00:00
-              edit VHR '00'
-            task jevs_analyses_rtma_precip_stats_vhr_01
-              time 01:00
-              edit VHR '01'
-            task jevs_analyses_rtma_precip_stats_vhr_02
-              time 02:00
-              edit VHR '02'
-            task jevs_analyses_rtma_precip_stats_vhr_03
-              time 03:00
-              edit VHR '03'
-            task jevs_analyses_rtma_precip_stats_vhr_04
-              time 04:00
-              edit VHR '04'
-            task jevs_analyses_rtma_precip_stats_vhr_05
-              time 05:00
-              edit VHR '05'
-            task jevs_analyses_ccpa_precip_stats_vhr_00
-              trigger :TIME >= 0015 ../../prep/analyses/jevs_analyses_precip_prep_vhr_00 == complete
-              edit VHR '00'
-            task jevs_analyses_ccpa_precip_stats_vhr_01
-              trigger :TIME >= 0115 ../../prep/analyses/jevs_analyses_precip_prep_vhr_00 == complete
-              edit VHR '01'
-            task jevs_analyses_ccpa_precip_stats_vhr_02
-              trigger :TIME >= 0215 ../../prep/analyses/jevs_analyses_precip_prep_vhr_00 == complete
-              edit VHR '02'
-            task jevs_analyses_ccpa_precip_stats_vhr_03
-              trigger :TIME >= 0315 ../../prep/analyses/jevs_analyses_precip_prep_vhr_00 == complete
-              edit VHR '03'
-            task jevs_analyses_ccpa_precip_stats_vhr_04
-              trigger :TIME >= 0415 ../../prep/analyses/jevs_analyses_precip_prep_vhr_00 == complete
-              edit VHR '04'
-            task jevs_analyses_ccpa_precip_stats_vhr_05
-              trigger :TIME >= 0515 ../../prep/analyses/jevs_analyses_precip_prep_vhr_00 == complete
-              edit VHR '05'
           endfamily
           family global_chem
             task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_00
@@ -538,11 +479,6 @@ suite evs_nco
             task jevs_mesoscale_grid2obs_prep
               time 07:30
               edit VHR '07'
-          endfamily
-          family analyses
-            task jevs_analyses_precip_prep_vhr_06
-              time 6:00
-              edit VHR '06'
           endfamily
           family cam
             task jevs_cam_radar_prep_vhr_06
@@ -1032,60 +968,6 @@ suite evs_nco
             task jevs_analyses_rtma_ru_grid2obs_stats_vhr_11
               time 11:00
               edit VHR '11'
-            task jevs_analyses_rtma_precip_stats_vhr_06
-              time 06:00
-              edit VHR '06'
-            task jevs_analyses_rtma_precip_stats_vhr_07
-              time 07:00
-              edit VHR '07'
-            task jevs_analyses_rtma_precip_stats_vhr_08
-              time 08:00
-              edit VHR '08'
-            task jevs_analyses_rtma_precip_stats_vhr_09
-              time 09:00
-              edit VHR '09'
-            task jevs_analyses_rtma_precip_stats_vhr_10
-              time 10:00
-              edit VHR '10'
-            task jevs_analyses_rtma_precip_stats_vhr_11
-              time 11:00
-              edit VHR '11'
-            task jevs_analyses_urma_precip_stats_vhr_06
-              time 06:00
-              edit VHR '06'
-            task jevs_analyses_urma_precip_stats_vhr_07
-              time 07:00
-              edit VHR '07'
-            task jevs_analyses_urma_precip_stats_vhr_08
-              time 08:00
-              edit VHR '08'
-            task jevs_analyses_urma_precip_stats_vhr_09
-              time 09:00
-              edit VHR '09'
-            task jevs_analyses_urma_precip_stats_vhr_10
-              time 10:00
-              edit VHR '10'
-            task jevs_analyses_urma_precip_stats_vhr_11
-              time 11:00
-              edit VHR '11'
-            task jevs_analyses_ccpa_precip_stats_vhr_06
-              trigger :TIME >= 0615 ../../prep/analyses/jevs_analyses_precip_prep_vhr_06 == complete
-              edit VHR '06'
-            task jevs_analyses_ccpa_precip_stats_vhr_07
-              trigger :TIME >= 0715 ../../prep/analyses/jevs_analyses_precip_prep_vhr_06 == complete
-              edit VHR '07'
-            task jevs_analyses_ccpa_precip_stats_vhr_08
-              trigger :TIME >= 0815 ../../prep/analyses/jevs_analyses_precip_prep_vhr_06 == complete
-              edit VHR '08'
-            task jevs_analyses_ccpa_precip_stats_vhr_09
-              trigger :TIME >= 0915 ../../prep/analyses/jevs_analyses_precip_prep_vhr_06 == complete
-              edit VHR '09'
-            task jevs_analyses_ccpa_precip_stats_vhr_10
-              trigger :TIME >= 1015 ../../prep/analyses/jevs_analyses_precip_prep_vhr_06 == complete
-              edit VHR '10'
-            task jevs_analyses_ccpa_precip_stats_vhr_11
-              trigger :TIME >= 1115 ../../prep/analyses/jevs_analyses_precip_prep_vhr_06 == complete
-              edit VHR '11'
           endfamily
           family global_chem
             task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_03
@@ -1152,11 +1034,6 @@ suite evs_nco
           family global_det
             task jevs_global_det_wave_prep
               time 13:15
-          endfamily
-          family analyses
-            task jevs_analyses_precip_prep_vhr_12
-              time 12:00
-              edit VHR '12'
           endfamily
           family cam
             task jevs_cam_radar_prep_vhr_12
@@ -1568,60 +1445,6 @@ suite evs_nco
             task jevs_analyses_rtma_ru_grid2obs_stats_vhr_17
               time 17:00
               edit VHR '17'
-            task jevs_analyses_rtma_precip_stats_vhr_12
-              time 12:00
-              edit VHR '12'
-            task jevs_analyses_rtma_precip_stats_vhr_13
-              time 13:00
-              edit VHR '13'
-            task jevs_analyses_rtma_precip_stats_vhr_14
-              time 14:00
-              edit VHR '14'
-            task jevs_analyses_rtma_precip_stats_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_analyses_rtma_precip_stats_vhr_16
-              time 16:00
-              edit VHR '16'
-            task jevs_analyses_rtma_precip_stats_vhr_17
-              time 17:00
-              edit VHR '17'
-            task jevs_analyses_urma_precip_stats_vhr_12
-              time 12:00
-              edit VHR '12'
-            task jevs_analyses_urma_precip_stats_vhr_13
-              time 13:00
-              edit VHR '13'
-            task jevs_analyses_urma_precip_stats_vhr_14
-              time 14:00
-              edit VHR '14'
-            task jevs_analyses_urma_precip_stats_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_analyses_urma_precip_stats_vhr_16
-              time 16:00
-              edit VHR '16'
-            task jevs_analyses_urma_precip_stats_vhr_17
-              time 17:00
-              edit VHR '17'
-            task jevs_analyses_ccpa_precip_stats_vhr_12
-              trigger :TIME >= 1215 ../../prep/analyses/jevs_analyses_precip_prep_vhr_12 == complete
-              edit VHR '12'
-            task jevs_analyses_ccpa_precip_stats_vhr_13
-              trigger :TIME >= 1315 ../../prep/analyses/jevs_analyses_precip_prep_vhr_12 == complete
-              edit VHR '13'
-            task jevs_analyses_ccpa_precip_stats_vhr_14
-              trigger :TIME >= 1415 ../../prep/analyses/jevs_analyses_precip_prep_vhr_12 == complete
-              edit VHR '14'
-            task jevs_analyses_ccpa_precip_stats_vhr_15
-              trigger :TIME >= 1515 ../../prep/analyses/jevs_analyses_precip_prep_vhr_12 == complete
-              edit VHR '15'
-            task jevs_analyses_ccpa_precip_stats_vhr_16
-              trigger :TIME >= 1615 ../../prep/analyses/jevs_analyses_precip_prep_vhr_12 == complete
-              edit VHR '16'
-            task jevs_analyses_ccpa_precip_stats_vhr_17
-              trigger :TIME >= 1715 ../../prep/analyses/jevs_analyses_precip_prep_vhr_12 == complete
-              edit VHR '17'
           endfamily
           family global_chem
             task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_12
@@ -1804,11 +1627,6 @@ suite evs_nco
           family global_det
             task jevs_global_det_atmos_prep
               time 18:10
-          endfamily
-          family analyses
-            task jevs_analyses_precip_prep_vhr_18
-              time 18:00
-              edit VHR '18'
           endfamily
           family cam
             task jevs_cam_radar_prep_vhr_18
@@ -2246,60 +2064,6 @@ suite evs_nco
               edit VHR '22'
             task jevs_analyses_rtma_ru_grid2obs_stats_vhr_23
               trigger :TIME >= 2300 and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_ru_grid2obs_stats_vhr_22 == complete
-              edit VHR '23'
-            task jevs_analyses_rtma_precip_stats_vhr_18
-              time 18:15
-              edit VHR '18'
-            task jevs_analyses_rtma_precip_stats_vhr_19
-              time 19:00
-              edit VHR '19'
-            task jevs_analyses_rtma_precip_stats_vhr_20
-              time 20:00
-              edit VHR '20'
-            task jevs_analyses_rtma_precip_stats_vhr_21
-              time 21:00
-              edit VHR '21'
-            task jevs_analyses_rtma_precip_stats_vhr_22
-              time 22:00
-              edit VHR '22'
-            task jevs_analyses_rtma_precip_stats_vhr_23
-              trigger :TIME >= 2300 and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_rtma_precip_stats_vhr_22 == complete
-              edit VHR '23'
-            task jevs_analyses_urma_precip_stats_vhr_18
-              time 18:15
-              edit VHR '18'
-            task jevs_analyses_urma_precip_stats_vhr_19
-              time 19:00
-              edit VHR '19'
-            task jevs_analyses_urma_precip_stats_vhr_20
-              time 20:00
-              edit VHR '20'
-            task jevs_analyses_urma_precip_stats_vhr_21
-              time 21:00
-              edit VHR '21'
-            task jevs_analyses_urma_precip_stats_vhr_22
-              time 22:00
-              edit VHR '22'
-            task jevs_analyses_urma_precip_stats_vhr_23
-              trigger :TIME >= 2300 and ../../../../06/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_urma_precip_stats_vhr_22 == complete
-              edit VHR '23'
-            task jevs_analyses_ccpa_precip_stats_vhr_18
-              trigger :TIME >= 1815 ../../prep/analyses/jevs_analyses_precip_prep_vhr_18 == complete
-              edit VHR '18'
-            task jevs_analyses_ccpa_precip_stats_vhr_19
-              trigger :TIME >= 1915 ../../prep/analyses/jevs_analyses_precip_prep_vhr_18 == complete
-              edit VHR '19'
-            task jevs_analyses_ccpa_precip_stats_vhr_20
-              trigger :TIME >= 2015 ../../prep/analyses/jevs_analyses_precip_prep_vhr_18 == complete
-              edit VHR '20'
-            task jevs_analyses_ccpa_precip_stats_vhr_21
-              trigger :TIME >= 2115 ../../prep/analyses/jevs_analyses_precip_prep_vhr_18 == complete
-              edit VHR '21'
-            task jevs_analyses_ccpa_precip_stats_vhr_22
-              trigger :TIME >= 2215 ../../prep/analyses/jevs_analyses_precip_prep_vhr_18 == complete
-              edit VHR '22'
-            task jevs_analyses_ccpa_precip_stats_vhr_23
-              trigger :TIME >= 2315 and ../../prep/analyses/jevs_analyses_precip_prep_vhr_18 == complete and  ../../../../00/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_00 == complete and  ../../../../00/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_01 == complete and  ../../../../00/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_02 == complete and  ../../../../00/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_03 == complete and  ../../../../00/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_04 == complete and  ../../../../00/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_05 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_analyses_ccpa_precip_stats_vhr_22 == complete
               edit VHR '23'
           endfamily
         endfamily   # 18 stats


### PR DESCRIPTION
## Description of Changes

We have decided not to add analyses precip prep/stats jobs to EVS v2.0 (plots don't exist yet). We have removed these jobs from the evs-nco.defs file. No testing is needed. This PR also changes Perry's email address to mine or Marcel's email in the dev drivers (Marcel only on cam firewxnest). Again, no testing is needed if your visual assessment looks good.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

I do not think that this PR needs to be tested. Please review and comment on the coding changes themselves. Thanks!