### PR TITLE
Move ${STEP} in subseasonal filenames

### DIFF
--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last31days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_temp_plots_last31days
+#PBS -N jevs_plots_subseasonal_grid2grid_precip_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_temp_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_precip_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,8 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=80
+export nproc=200
+export ncpu=100
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -45,7 +46,7 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=temp
+export VERIF_TYPE=precip
 export NDAYS=31
 export DAYS=32
 
@@ -55,11 +56,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid 2m temp statistical plots
+#          subseasonal grid-to-grid precipitation statistical plots
 #          for the GEFS and CFS models for past 31 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_temp_plots_last90days
+#PBS -N jevs_plots_subseasonal_grid2grid_precip_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_temp_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_precip_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,8 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=80
+export nproc=200
+export ncpu=100
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -45,7 +46,7 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=temp
+export VERIF_TYPE=precip
 export NDAYS=90
 export DAYS=91
 
@@ -55,11 +56,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid 2m temp statistical plots
+#          subseasonal grid-to-grid precipitation statistical plots
 #          for the GEFS and CFS models for past 90 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last31days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_sea_ice_plots_last90days
+#PBS -N jevs_plots_subseasonal_grid2grid_pres_lvls_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=34:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_sea_ice_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_pres_lvls_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=34
+export nproc=120
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -45,9 +45,9 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=sea_ice
-export NDAYS=90
-export DAYS=91
+export VERIF_TYPE=pres_lvls
+export NDAYS=31
+export DAYS=32
 
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid sea ice statistical plots
-#          for the GEFS and CFS models for past 90 days.
+#          subseasonal grid-to-grid 500mb height statistical plots
+#          for the GEFS and CFS models for past 31 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2obs_prepbufr_plots_last31days
+#PBS -N jevs_plots_subseasonal_grid2grid_pres_lvls_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2obs_prepbufr_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_pres_lvls_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=80
+export nproc=120
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -44,10 +44,10 @@ export STEP=plots
 export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
-export VERIF_CASE=grid2obs
-export VERIF_TYPE=prepbufr
-export NDAYS=31
-export DAYS=32
+export VERIF_CASE=grid2grid
+export VERIF_TYPE=pres_lvls
+export NDAYS=90
+export DAYS=91
 
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-obs 2-m temperature statistical plots
-#          for the GEFS and CFS models for past 31 days.
+#          subseasonal grid-to-grid 500mb height statistical plots
+#          for the GEFS and CFS models for past 90 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last31days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_subseasonal_grid2grid_sea_ice_plots_last31days
+#PBS -N jevs_plots_subseasonal_grid2grid_sea_ice_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_sea_ice_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_sea_ice_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -55,7 +55,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_precip_plots_last90days
+#PBS -N jevs_plots_subseasonal_grid2grid_sea_ice_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=34:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_precip_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_sea_ice_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,8 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=200
-export ncpu=100
+export nproc=34
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -46,7 +45,7 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=precip
+export VERIF_TYPE=sea_ice
 export NDAYS=90
 export DAYS=91
 
@@ -56,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid precipitation statistical plots
+#          subseasonal grid-to-grid sea ice statistical plots
 #          for the GEFS and CFS models for past 90 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last31days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2obs_prepbufr_plots_last90days
+#PBS -N jevs_plots_subseasonal_grid2grid_sst_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2obs_prepbufr_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_sst_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=80
+export nproc=30
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -44,10 +44,10 @@ export STEP=plots
 export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
-export VERIF_CASE=grid2obs
-export VERIF_TYPE=prepbufr
-export NDAYS=90
-export DAYS=91
+export VERIF_CASE=grid2grid
+export VERIF_TYPE=sst
+export NDAYS=31
+export DAYS=32
 
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-obs 2-m temperature statistical plots
-#          for the GEFS and CFS models for past 90 days.
+#          subseasonal grid-to-grid SST statistical plots
+#          for the GEFS and CFS models for past 31 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_pres_lvls_plots_last31days
+#PBS -N jevs_plots_subseasonal_grid2grid_sst_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_pres_lvls_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_sst_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=120
+export nproc=30
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -45,9 +45,9 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=pres_lvls
-export NDAYS=31
-export DAYS=32
+export VERIF_TYPE=sst
+export NDAYS=90
+export DAYS=91
 
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid 500mb height statistical plots
-#          for the GEFS and CFS models for past 31 days.
+#          subseasonal grid-to-grid SST statistical plots
+#          for the GEFS and CFS models for past 90 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last31days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_precip_plots_last31days
+#PBS -N jevs_plots_subseasonal_grid2grid_temp_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_precip_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_temp_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,8 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=200
-export ncpu=100
+export nproc=80
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -46,7 +45,7 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=precip
+export VERIF_TYPE=temp
 export NDAYS=31
 export DAYS=32
 
@@ -56,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid precipitation statistical plots
+#          subseasonal grid-to-grid 2m temp statistical plots
 #          for the GEFS and CFS models for past 31 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_sst_plots_last31days
+#PBS -N jevs_plots_subseasonal_grid2grid_temp_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_sst_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2grid_temp_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=30
+export nproc=80
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -45,9 +45,9 @@ export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=sst
-export NDAYS=31
-export DAYS=32
+export VERIF_TYPE=temp
+export NDAYS=90
+export DAYS=91
 
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid SST statistical plots
-#          for the GEFS and CFS models for past 31 days.
+#          subseasonal grid-to-grid 2m temp statistical plots
+#          for the GEFS and CFS models for past 90 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last31days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last31days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_sst_plots_last90days
+#PBS -N jevs_plots_subseasonal_grid2obs_prepbufr_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_sst_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2obs_prepbufr_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=30
+export nproc=80
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -44,10 +44,10 @@ export STEP=plots
 export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
-export VERIF_CASE=grid2grid
-export VERIF_TYPE=sst
-export NDAYS=90
-export DAYS=91
+export VERIF_CASE=grid2obs
+export VERIF_TYPE=prepbufr
+export NDAYS=31
+export DAYS=32
 
 export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid SST statistical plots
-#          for the GEFS and CFS models for past 90 days.
+#          subseasonal grid-to-obs 2-m temperature statistical plots
+#          for the GEFS and CFS models for past 31 days.
 ######################################################################

--- a/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last90days.sh
+++ b/dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_grid2grid_pres_lvls_plots_last90days
+#PBS -N jevs_plots_subseasonal_grid2obs_prepbufr_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_grid2grid_pres_lvls_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_subseasonal_grid2obs_prepbufr_last90days}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -36,7 +36,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=120
+export nproc=80
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -44,8 +44,8 @@ export STEP=plots
 export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME="gefs cfs"
-export VERIF_CASE=grid2grid
-export VERIF_TYPE=pres_lvls
+export VERIF_CASE=grid2obs
+export VERIF_TYPE=prepbufr
 export NDAYS=90
 export DAYS=91
 
@@ -55,11 +55,11 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal grid-to-grid 500mb height statistical plots
+#          subseasonal grid-to-obs 2-m temperature statistical plots
 #          for the GEFS and CFS models for past 90 days.
 ######################################################################

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_obs_prep
+#PBS -N jevs_prep_subseasonal_cfs
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:10:00
-#PBS -l place=shared,select=1:ncpus=1:mem=5GB
+#PBS -l walltime=00:15:00
+#PBS -l place=shared,select=1:ncpus=1:mem=18GB
 #PBS -l debug=true
 
 set -x
@@ -24,7 +24,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
-export job=${PBS_JOBNAME:-jevs_subseasonal_obs_prep}
+export job=${PBS_JOBNAME:-jevs_prep_subseasonal_cfs}
 export jobid=$job.${PBS_JOBID:-$$}
 export TMPDIR=$DATAROOT
 export SITE=$(cat /etc/cluster_name)
@@ -46,19 +46,19 @@ export NET=evs
 export STEP=prep
 export COMPONENT=subseasonal
 export RUN=atmos
-export OBSNAME="gfs ecmwf osi ghrsst umd nam ccpa"
-export PREP_TYPE=obs
+export MODELNAME=cfs
+export PREP_TYPE=cfs
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN
 
-export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.obs.prep
+export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.prep
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PREP
+$HOMEevs/jobs/JEVS_PREP_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to retrieve the
-#          subseasonal data files for obs 
+#          subseasonal data files for the CFS model 
 #          and copy into the prep directory.
 ######################################################################

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=01:50:00
+#PBS -l walltime=02:30:00
 #PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=300GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_cfs_prep
+#PBS -N jevs_prep_subseasonal_gefs
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=18GB
+#PBS -l walltime=01:50:00
+#PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=300GB
 #PBS -l debug=true
 
 set -x
@@ -24,7 +24,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
-export job=${PBS_JOBNAME:-jevs_subseasonal_cfs_prep}
+export job=${PBS_JOBNAME:-jevs_prep_subseasonal_gefs}
 export jobid=$job.${PBS_JOBID:-$$}
 export TMPDIR=$DATAROOT
 export SITE=$(cat /etc/cluster_name)
@@ -40,25 +40,26 @@ export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
 export nproc=1
+export USE_CFP=YES
 export WGRIB2=`which wgrib2`
 export vhr=00
 export NET=evs
 export STEP=prep
 export COMPONENT=subseasonal
 export RUN=atmos
-export MODELNAME=cfs
-export PREP_TYPE=cfs
+export MODELNAME=gefs
+export PREP_TYPE=gefs
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN
 
-export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.prep
+export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.gefs.prep
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PREP
+$HOMEevs/jobs/JEVS_PREP_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to retrieve the
-#          subseasonal data files for the CFS model 
+#          subseasonal data files for the GEFS model 
 #          and copy into the prep directory.
 ######################################################################

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_gefs_prep
+#PBS -N jevs_prep_subseasonal_obs
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=01:50:00
-#PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=300GB
+#PBS -l walltime=00:10:00
+#PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 set -x
@@ -24,7 +24,7 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
 export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
-export job=${PBS_JOBNAME:-jevs_subseasonal_gefs_prep}
+export job=${PBS_JOBNAME:-jevs_prep_subseasonal_obs}
 export jobid=$job.${PBS_JOBID:-$$}
 export TMPDIR=$DATAROOT
 export SITE=$(cat /etc/cluster_name)
@@ -40,26 +40,25 @@ export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
 export nproc=1
-export USE_CFP=YES
 export WGRIB2=`which wgrib2`
 export vhr=00
 export NET=evs
 export STEP=prep
 export COMPONENT=subseasonal
 export RUN=atmos
-export MODELNAME=gefs
-export PREP_TYPE=gefs
+export OBSNAME="gfs ecmwf osi ghrsst umd nam ccpa"
+export PREP_TYPE=obs
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN
 
-export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.gefs.prep
+export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.obs.prep
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PREP
+$HOMEevs/jobs/JEVS_PREP_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to retrieve the
-#          subseasonal data files for the GEFS model 
+#          subseasonal data files for obs 
 #          and copy into the prep directory.
 ######################################################################

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_cfs_grid2obs_stats
+#PBS -N jevs_stats_subseasonal_cfs_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=8:ompthreads=1:mem=60GB
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=66:ompthreads=1:mem=70GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_cfs_grid2obs_stats}
+export job=${PBS_JOBNAME:-jevs_stats_subseasonal_cfs_grid2grid}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -35,7 +35,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=8
+export nproc=66
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -43,19 +43,19 @@ export STEP=stats
 export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME=cfs
-export VERIF_CASE=grid2obs
+export VERIF_CASE=grid2grid
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/prep/$COMPONENT/$RUN
 
-export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.grid2obs.stats
+export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.grid2grid.stats
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal verification grid-to-obs statistics for the CFS model 
+#          subseasonal verification grid-to-grid statistics for the CFS model 
 #          and create the stat files in the databases.
 ######################################################################

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_subseasonal_cfs_grid2grid_stats
+#PBS -N jevs_stats_subseasonal_cfs_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=66:ompthreads=1:mem=70GB
+#PBS -l walltime=00:25:00
+#PBS -l place=vscatter,select=1:ncpus=8:ompthreads=1:mem=60GB
 #PBS -l debug=true
 
 set -x
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_cfs_grid2grid_stats}
+export job=${PBS_JOBNAME:-jevs_stats_subseasonal_cfs_grid2obs}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -35,7 +35,7 @@ export QUEUE=dev
 export QUEUESHARED=dev_shared
 export QUEUESERV=dev_transfer
 export PARTITION_BATCH=
-export nproc=66
+export nproc=8
 export USE_CFP=YES
 export vhr=00
 export NET=evs
@@ -43,19 +43,19 @@ export STEP=stats
 export COMPONENT=subseasonal
 export RUN=atmos
 export MODELNAME=cfs
-export VERIF_CASE=grid2grid
+export VERIF_CASE=grid2obs
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/prep/$COMPONENT/$RUN
 
-export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.grid2grid.stats
+export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.grid2obs.stats
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 
 
 ######################################################################
 # Purpose: The job and task scripts work together to generate the
-#          subseasonal verification grid-to-grid statistics for the CFS model 
+#          subseasonal verification grid-to-obs statistics for the CFS model 
 #          and create the stat files in the databases.
 ######################################################################

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_subseasonal_gefs_grid2grid_stats
+#PBS -N jevs_stats_subseasonal_gefs_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_gefs_grid2grid_stats}
+export job=${PBS_JOBNAME:-jevs_stats_subseasonal_gefs_grid2grid}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -51,7 +51,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/prep/$COMPONENT/
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.gefs.grid2grid.stats
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 
 
 ######################################################################

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_subseasonal_gefs_grid2obs_stats
+#PBS -N jevs_stats_subseasonal_gefs_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q "dev"
@@ -15,7 +15,7 @@ cd $PBS_O_WORKDIR
 
 export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
 
-export job=${PBS_JOBNAME:-jevs_subseasonal_gefs_grid2obs_stats}
+export job=${PBS_JOBNAME:-jevs_stats_subseasonal_gefs_grid2obs}
 export jobid=$job.${PBS_JOBID:-$$}
 
 source $HOMEevs/versions/run.ver
@@ -51,7 +51,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/prep/$COMPONENT/
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.gefs.grid2obs.stats
 
 # Call executable job script
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 
 
 ######################################################################

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1012,11 +1012,11 @@ suite evs_nco
         family prep
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family subseasonal
-            task jevs_subseasonal_obs_prep
+            task jevs_prep_subseasonal_obs
               time 14:00
-            task jevs_subseasonal_gefs_prep
+            task jevs_prep_subseasonal_gefs
               time 14:00
-            task jevs_subseasonal_cfs_prep
+            task jevs_prep_subseasonal_cfs
               time 14:00
           endfamily
           family nfcens
@@ -1104,14 +1104,14 @@ suite evs_nco
 	      trigger :TIME >= 1515 and ../../prep/nwps == complete
 	  endfamily
           family subseasonal
-            task jevs_subseasonal_cfs_grid2obs_stats
-              trigger :TIME >= 1530 and ../../prep/subseasonal/jevs_subseasonal_cfs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
-            task jevs_subseasonal_cfs_grid2grid_stats
-              trigger :TIME >= 1600 and ../../prep/subseasonal/jevs_subseasonal_cfs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
-            task jevs_subseasonal_gefs_grid2obs_stats
-              trigger :TIME >= 1630 and ../../prep/subseasonal/jevs_subseasonal_gefs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
-            task jevs_subseasonal_gefs_grid2grid_stats    # walltime=02:00:00
-              trigger :TIME >= 1610 and ../../prep/subseasonal/jevs_subseasonal_gefs_prep == complete and ../../prep/subseasonal/jevs_subseasonal_obs_prep == complete
+            task jevs_stats_subseasonal_cfs_grid2obs
+              trigger :TIME >= 1530 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+            task jevs_stats_subseasonal_cfs_grid2grid
+              trigger :TIME >= 1600 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+            task jevs_stats_subseasonal_gefs_grid2obs
+              trigger :TIME >= 1630 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+            task jevs_stats_subseasonal_gefs_grid2grid    # walltime=02:00:00
+              trigger :TIME >= 1610 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
           endfamily
           family mesoscale
             task jevs_mesoscale_nam_precip_stats_vhr_12
@@ -2070,30 +2070,18 @@ suite evs_nco
         family plots
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family subseasonal
-            task jevs_subseasonal_grid2obs_prepbufr_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2obs_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2obs_stats == complete
-            task jevs_subseasonal_grid2obs_prepbufr_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2obs_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2obs_stats == complete
-            task jevs_subseasonal_grid2grid_sst_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_sst_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_sea_ice_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_sea_ice_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_pres_lvls_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_pres_lvls_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_precip_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_precip_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_temp_plots_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
-            task jevs_subseasonal_grid2grid_temp_plots_last31days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_cfs_grid2grid_stats == complete and ../../../../12/evs/stats/subseasonal/jevs_subseasonal_gefs_grid2grid_stats == complete
+            task jevs_plots_subseasonal_grid2obs_prepbufr_last90days
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs == complete
+            task jevs_plots_subseasonal_grid2grid_sst_last90days
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+            task jevs_plots_subseasonal_grid2grid_sea_ice_last90days
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+            task jevs_plots_subseasonal_grid2grid_pres_lvls_last90days
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+            task jevs_plots_subseasonal_grid2grid_precip_last90days
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+            task jevs_plots_subseasonal_grid2grid_temp_last90days
+              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
           endfamily
           family mesoscale
             task jevs_mesoscale_snowfall_plots_last31days

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1109,9 +1109,9 @@ suite evs_nco
             task jevs_stats_subseasonal_cfs_grid2grid
               trigger :TIME >= 1600 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
             task jevs_stats_subseasonal_gefs_grid2obs
-              trigger :TIME >= 1630 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
-            task jevs_stats_subseasonal_gefs_grid2grid    # walltime=02:00:00
-              trigger :TIME >= 1610 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1730 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+            task jevs_stats_subseasonal_gefs_grid2grid
+              trigger :TIME >= 1710 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
           endfamily
           family mesoscale
             task jevs_mesoscale_nam_precip_stats_vhr_12

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last31days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last31days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_pres_lvls_plots_last90days
+#PBS -N evs_plots_subseasonal_grid2grid_precip_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,21 +46,22 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=120
+export nproc=200
+export ncpu=100
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=pres_lvls
-export NDAYS=90
-export DAYS=91
+export VERIF_TYPE=precip
+export NDAYS=31
+export DAYS=32
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last90days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_precip_last90days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_temp_plots_last90days
+#PBS -N evs_plots_subseasonal_grid2grid_precip_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,13 +46,14 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=80
+export nproc=200
+export ncpu=100
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=temp
+export VERIF_TYPE=precip
 export NDAYS=90
 export DAYS=91
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
@@ -60,7 +61,7 @@ export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last31days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_subseasonal_grid2grid_pres_lvls_plots_last31days
+#PBS -N evs_plots_subseasonal_grid2grid_pres_lvls_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -60,7 +60,7 @@ export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last90days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_pres_lvls_last90days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_sea_ice_plots_last31days
+#PBS -N evs_plots_subseasonal_grid2grid_pres_lvls_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=34:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=120:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,21 +46,21 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=34
+export nproc=120
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=sea_ice
-export NDAYS=31
-export DAYS=32
+export VERIF_TYPE=pres_lvls
+export NDAYS=90
+export DAYS=91
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last31days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last31days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_sst_plots_last90days
+#PBS -N evs_plots_subseasonal_grid2grid_sea_ice_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=34:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,21 +46,21 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=30
+export nproc=34
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=sst
-export NDAYS=90
-export DAYS=91
+export VERIF_TYPE=sea_ice
+export NDAYS=31
+export DAYS=32
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last90days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sea_ice_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_subseasonal_grid2grid_sea_ice_plots_last90days
+#PBS -N evs_plots_subseasonal_grid2grid_sea_ice_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -60,7 +60,7 @@ export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last31days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last31days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_precip_plots_last31days
+#PBS -N evs_plots_subseasonal_grid2grid_sst_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,14 +46,13 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=200
-export ncpu=100
+export nproc=30
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=precip
+export VERIF_TYPE=sst
 export NDAYS=31
 export DAYS=32
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
@@ -61,7 +60,7 @@ export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last90days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_sst_last90days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2obs_prepbufr_plots_last31days
+#PBS -N evs_plots_subseasonal_grid2grid_sst_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,21 +46,21 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=80
+export nproc=30
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
-export VERIF_CASE=grid2obs
-export VERIF_TYPE=prepbufr
-export NDAYS=31
-export DAYS=32
+export VERIF_CASE=grid2grid
+export VERIF_TYPE=sst
+export NDAYS=90
+export DAYS=91
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last31days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last31days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_precip_plots_last90days
+#PBS -N evs_plots_subseasonal_grid2grid_temp_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=2:ncpus=100:mem=200GB
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,22 +46,21 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=200
-export ncpu=100
+export nproc=80
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
-export VERIF_TYPE=precip
-export NDAYS=90
-export DAYS=91
+export VERIF_TYPE=temp
+export NDAYS=31
+export DAYS=32
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last90days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_subseasonal_grid2grid_temp_plots_last31days
+#PBS -N evs_plots_subseasonal_grid2grid_temp_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -53,14 +53,14 @@ export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2grid
 export VERIF_TYPE=temp
-export NDAYS=31
-export DAYS=32
+export NDAYS=90
+export DAYS=91
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last31days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_subseasonal_grid2obs_prepbufr_plots_last90days
+#PBS -N evs_plots_subseasonal_grid2obs_prepbufr_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -53,14 +53,14 @@ export RUN=atmos
 export MODELNAME="gefs cfs"
 export VERIF_CASE=grid2obs
 export VERIF_TYPE=prepbufr
-export NDAYS=90
-export DAYS=91
+export NDAYS=31
+export DAYS=32
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last90days.ecf
+++ b/ecf/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2obs_prepbufr_last90days.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_grid2grid_sst_plots_last31days
+#PBS -N evs_plots_subseasonal_grid2obs_prepbufr_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=30:ompthreads=1:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=80:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,21 +46,21 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=30
+export nproc=80
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME="gefs cfs"
-export VERIF_CASE=grid2grid
-export VERIF_TYPE=sst
-export NDAYS=31
-export DAYS=32
+export VERIF_CASE=grid2obs
+export VERIF_TYPE=prepbufr
+export NDAYS=90
+export DAYS=91
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${VERIF_CASE}.${STEP}.${VERIF_TYPE}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_obs_prep
+#PBS -N evs_prep_subseasonal_cfs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:10:00
-#PBS -l place=shared,select=1:ncpus=1:mem=5GB
+#PBS -l walltime=00:15:00
+#PBS -l place=shared,select=1:ncpus=1:mem=18GB
 #PBS -l debug=true
 
 export model=evs
@@ -34,9 +34,6 @@ module load udunits/${udunits_ver}
 module load nco/${nco_ver}
 module load grib_util/${grib_util_ver}
 module load cdo/${cdo_ver}
-module load met/${met_ver}
-module load metplus/${metplus_ver}
-module load bufr/${bufr_ver}
 module list
 
 ############################################################
@@ -50,14 +47,14 @@ fi
 export nproc=1
 export NET=evs
 export RUN=atmos
-export OBSNAME="gfs ecmwf osi ghrsst umd nam ccpa"
-export PREP_TYPE=obs
-export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${PREP_TYPE}.${STEP}
+export MODELNAME=cfs
+export PREP_TYPE=cfs
+export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${MODELNAME}.${STEP}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PREP
+$HOMEevs/jobs/JEVS_PREP_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:50:00
+#PBS -l walltime=02:30:00
 #PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=300GB
 #PBS -l debug=true
 

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_subseasonal_gefs_prep
+#PBS -N evs_prep_subseasonal_gefs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -55,7 +55,7 @@ export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PREP
+$HOMEevs/jobs/JEVS_PREP_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_cfs_prep
+#PBS -N evs_prep_subseasonal_obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=18GB
+#PBS -l walltime=00:10:00
+#PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 export model=evs
@@ -34,6 +34,9 @@ module load udunits/${udunits_ver}
 module load nco/${nco_ver}
 module load grib_util/${grib_util_ver}
 module load cdo/${cdo_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module load bufr/${bufr_ver}
 module list
 
 ############################################################
@@ -47,14 +50,14 @@ fi
 export nproc=1
 export NET=evs
 export RUN=atmos
-export MODELNAME=cfs
-export PREP_TYPE=cfs
-export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${MODELNAME}.${STEP}
+export OBSNAME="gfs ecmwf osi ghrsst umd nam ccpa"
+export PREP_TYPE=obs
+export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${PREP_TYPE}.${STEP}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_PREP
+$HOMEevs/jobs/JEVS_PREP_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.ecf
+++ b/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.ecf
@@ -1,9 +1,9 @@
-#PBS -N evs_subseasonal_gefs_grid2grid_stats
+#PBS -N evs_stats_subseasonal_cfs_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:20:00
+#PBS -l walltime=00:15:00
 #PBS -l place=vscatter:shared,select=1:ncpus=66:ompthreads=1:mem=70GB
 #PBS -l debug=true
 
@@ -50,14 +50,14 @@ export nproc=66
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
-export MODELNAME=gefs
+export MODELNAME=cfs
 export VERIF_CASE=grid2grid
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${MODELNAME}.${VERIF_CASE}.${STEP}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs.ecf
+++ b/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_cfs_grid2grid_stats
+#PBS -N evs_stats_subseasonal_cfs_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=1:ncpus=66:ompthreads=1:mem=70GB
+#PBS -l walltime=00:25:00
+#PBS -l place=vscatter:shared,select=1:ncpus=8:ompthreads=1:mem=60GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,18 +46,18 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=66
+export nproc=8
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME=cfs
-export VERIF_CASE=grid2grid
+export VERIF_CASE=grid2obs
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${MODELNAME}.${VERIF_CASE}.${STEP}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid.ecf
+++ b/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid.ecf
@@ -1,10 +1,10 @@
-#PBS -N evs_subseasonal_gefs_grid2obs_stats
+#PBS -N evs_stats_subseasonal_gefs_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:25:00
-#PBS -l place=vscatter:shared,select=1:ncpus=8:ompthreads=1:mem=60GB
+#PBS -l walltime=00:20:00
+#PBS -l place=vscatter:shared,select=1:ncpus=66:ompthreads=1:mem=70GB
 #PBS -l debug=true
 
 export model=evs
@@ -46,18 +46,18 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export nproc=8
+export nproc=66
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export MODELNAME=gefs
-export VERIF_CASE=grid2obs
+export VERIF_CASE=grid2grid
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${MODELNAME}.${VERIF_CASE}.${STEP}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs.ecf
+++ b/ecf/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_subseasonal_cfs_grid2obs_stats
+#PBS -N evs_stats_subseasonal_gefs_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -50,14 +50,14 @@ export nproc=8
 export USE_CFP=YES
 export NET=evs
 export RUN=atmos
-export MODELNAME=cfs
+export MODELNAME=gefs
 export VERIF_CASE=grid2obs
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${MODELNAME}.${VERIF_CASE}.${STEP}
 
 ############################################################
 # Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_SUBSEASONAL_STATS
+$HOMEevs/jobs/JEVS_STATS_SUBSEASONAL
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/jobs/JEVS_PLOTS_SUBSEASONAL
+++ b/jobs/JEVS_PLOTS_SUBSEASONAL
@@ -70,7 +70,7 @@ mkdir -p $COMOUT
 #######################################################################
 # Execute the script
 #######################################################################
-$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${VERIF_CASE}_${STEP}.sh
+$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}_${VERIF_CASE}.sh
 export err=$?; err_chk
 
 

--- a/jobs/JEVS_PREP_SUBSEASONAL
+++ b/jobs/JEVS_PREP_SUBSEASONAL
@@ -77,7 +77,7 @@ export COMOUT=${COMOUT:-$(compath.py -o $NET/$evs_ver/$STEP/$COMPONENT/$RUN)}
 #######################################################################
 # Execute the script
 #######################################################################
-$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${PREP_TYPE}_${STEP}.sh
+$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}_${PREP_TYPE}.sh
 export err=$?; err_chk
 
 

--- a/jobs/JEVS_STATS_SUBSEASONAL
+++ b/jobs/JEVS_STATS_SUBSEASONAL
@@ -75,7 +75,7 @@ mkdir -p $COMOUT $COMOUTfinal
 #######################################################################
 # Execute the script
 #######################################################################
-$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${COMPONENT}_${VERIF_CASE}_${STEP}.sh
+$HOMEevs/scripts/$STEP/$COMPONENT/exevs_${STEP}_${COMPONENT}_${VERIF_CASE}.sh
 export err=$?; err_chk
 
 

--- a/scripts/plots/subseasonal/exevs_plots_subseasonal_grid2grid.sh
+++ b/scripts/plots/subseasonal/exevs_plots_subseasonal_grid2grid.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_grid2obs_plots.sh
+# Program Name: exevs_plots_subseasonal_grid2grid.sh
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_PLOTS in jobs/.
-#           This script generates grid-to-obs verification plots
+# Abstract: This script is run by JEVS_PLOTS_SUBSEASONAL in jobs/.
+#           This script generates grid-to-grid verification plots
 #           using python for the subseasonal models.
 
 set -x
 
 echo
-echo "===== RUNNING GRID-TO-OBS PLOTS VERIFICATION  ====="
+echo "===== RUNNING GRID-TO-GRID PLOTS VERIFICATION  ====="
 export STEP="plots"
-export VERIF_CASE_STEP="grid2obs_plots"
-export VERIF_CASE_STEP_abbrev="g2oplots"
+export VERIF_CASE_STEP="grid2grid_plots"
+export VERIF_CASE_STEP_abbrev="g2gplots"
 
 # Source config
 source $config
@@ -42,8 +42,8 @@ export err=$?; err_chk
 # Create job scripts
 for group in condense_stats filter_stats make_plots tar_images; do
     export JOB_GROUP=$group
-    echo "Creating and running jobs for grid-to-obs plots: ${JOB_GROUP}"
-    python $USHevs/subseasonal/subseasonal_plots_grid2obs_create_job_scripts.py
+    echo "Creating and running jobs for grid-to-grid plots: ${JOB_GROUP}"
+    python $USHevs/subseasonal/subseasonal_plots_grid2grid_create_job_scripts.py
     export err=$?; err_chk
     # Run job scripts
     chmod u+x $DATA/$VERIF_CASE_STEP/plot_job_scripts/$group/*
@@ -58,7 +58,11 @@ for group in condense_stats filter_stats make_plots tar_images; do
 	    if [ $machine = WCOSS2 ]; then
 	        nselect=$(cat $PBS_NODEFILE | wc -l)
 	        nnp=$(($nselect * $nproc))
-	        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+		if [ $VERIF_TYPE = precip ]; then
+		    launcher="mpiexec -np $nproc -ppn $ncpu -depth 2 --cpu-bind verbose,depth cfp"
+		else
+	            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
+		fi
 	    elif [ $machine = HERA -o $machine = ORION ]; then
 	        export SLURM_KILL_BAD_EXIT=0
 	        launcher="srun --export=ALL --multi-prog"
@@ -111,6 +115,6 @@ fi
 
 # SENDDBN alert
 if [ $SENDDBN = YES ] ; then
-    tarname=evs.plots.${COMPONENT}.${RUN}.${VERIF_CASE}_prepbufr.last${NDAYS}days.v${end_date}.tar
+    tarname=evs.plots.${COMPONENT}.${RUN}.${VERIF_CASE}_${VERIF_TYPE}.last${NDAYS}days.v${end_date}.tar
     $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/$tarname
 fi

--- a/scripts/plots/subseasonal/exevs_plots_subseasonal_grid2obs.sh
+++ b/scripts/plots/subseasonal/exevs_plots_subseasonal_grid2obs.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_grid2grid_plots.sh
+# Program Name: exevs_plots_subseasonal_grid2obs.sh
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_PLOTS in jobs/.
-#           This script generates grid-to-grid verification plots
+# Abstract: This script is run by JEVS_PLOTS_SUBSEASONAL in jobs/.
+#           This script generates grid-to-obs verification plots
 #           using python for the subseasonal models.
 
 set -x
 
 echo
-echo "===== RUNNING GRID-TO-GRID PLOTS VERIFICATION  ====="
+echo "===== RUNNING GRID-TO-OBS PLOTS VERIFICATION  ====="
 export STEP="plots"
-export VERIF_CASE_STEP="grid2grid_plots"
-export VERIF_CASE_STEP_abbrev="g2gplots"
+export VERIF_CASE_STEP="grid2obs_plots"
+export VERIF_CASE_STEP_abbrev="g2oplots"
 
 # Source config
 source $config
@@ -42,8 +42,8 @@ export err=$?; err_chk
 # Create job scripts
 for group in condense_stats filter_stats make_plots tar_images; do
     export JOB_GROUP=$group
-    echo "Creating and running jobs for grid-to-grid plots: ${JOB_GROUP}"
-    python $USHevs/subseasonal/subseasonal_plots_grid2grid_create_job_scripts.py
+    echo "Creating and running jobs for grid-to-obs plots: ${JOB_GROUP}"
+    python $USHevs/subseasonal/subseasonal_plots_grid2obs_create_job_scripts.py
     export err=$?; err_chk
     # Run job scripts
     chmod u+x $DATA/$VERIF_CASE_STEP/plot_job_scripts/$group/*
@@ -58,11 +58,7 @@ for group in condense_stats filter_stats make_plots tar_images; do
 	    if [ $machine = WCOSS2 ]; then
 	        nselect=$(cat $PBS_NODEFILE | wc -l)
 	        nnp=$(($nselect * $nproc))
-		if [ $VERIF_TYPE = precip ]; then
-		    launcher="mpiexec -np $nproc -ppn $ncpu -depth 2 --cpu-bind verbose,depth cfp"
-		else
-	            launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
-		fi
+	        launcher="mpiexec -np ${nnp} -ppn ${nproc} --cpu-bind verbose,depth cfp"
 	    elif [ $machine = HERA -o $machine = ORION ]; then
 	        export SLURM_KILL_BAD_EXIT=0
 	        launcher="srun --export=ALL --multi-prog"
@@ -115,6 +111,6 @@ fi
 
 # SENDDBN alert
 if [ $SENDDBN = YES ] ; then
-    tarname=evs.plots.${COMPONENT}.${RUN}.${VERIF_CASE}_${VERIF_TYPE}.last${NDAYS}days.v${end_date}.tar
+    tarname=evs.plots.${COMPONENT}.${RUN}.${VERIF_CASE}_prepbufr.last${NDAYS}days.v${end_date}.tar
     $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/$tarname
 fi

--- a/scripts/prep/subseasonal/exevs_prep_subseasonal_cfs.sh
+++ b/scripts/prep/subseasonal/exevs_prep_subseasonal_cfs.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_cfs_prep
+# Program Name: exevs_prep_subseasonal_cfs
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_PREP in jobs/.
+# Abstract: This script is run by JEVS_PREP_SUBSEASONAL in jobs/.
 #           This script retrieves data for subseasonal CFS verification.
 
 set -x
 
 
 echo
-echo "===== RUNNING EVS SUBSEASONAL CFS PREP  ====="
+echo "===== RUNNING EVS PREP SUBSEASONAL CFS ====="
 export STEP="prep"
 
 # Source config

--- a/scripts/prep/subseasonal/exevs_prep_subseasonal_gefs.sh
+++ b/scripts/prep/subseasonal/exevs_prep_subseasonal_gefs.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_gefs_prep.sh
+# Program Name: exevs_prep_subseasonal_gefs.sh
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_PREP in jobs/.
+# Abstract: This script is run by JEVS_PREP_SUBSEASONAL in jobs/.
 #           This script retrieves data for subseasonal GEFS verification.
 
 set -x
 
 
 echo
-echo "===== RUNNING EVS SUBSEASONAL GEFS PREP  ====="
+echo "===== RUNNING EVS PREP SUBSEASONAL GEFS ====="
 export STEP="prep"
 
 # Source config

--- a/scripts/prep/subseasonal/exevs_prep_subseasonal_obs.sh
+++ b/scripts/prep/subseasonal/exevs_prep_subseasonal_obs.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_obs_prep
+# Program Name: exevs_prep_subseasonal_obs
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_PREP in jobs/.
+# Abstract: This script is run by JEVS_PREP_SUBSEASONAL in jobs/.
 #           This script retrieves data for subseasonal observations.
 
 set -x
 
 
 echo
-echo "===== RUNNING EVS SUBSEASONAL OBS PREP  ====="
+echo "===== RUNNING EVS PREP SUBSEASONAL OBS ====="
 export STEP="prep"
 
 # Source config

--- a/scripts/stats/subseasonal/exevs_stats_subseasonal_grid2grid.sh
+++ b/scripts/stats/subseasonal/exevs_stats_subseasonal_grid2grid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_grid2grid_stats.sh
+# Program Name: exevs_stats_subseasonal_grid2grid.sh
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_STATS in jobs/.
+# Abstract: This script is run by JEVS_STATS_SUBSEASONAL in jobs/.
 #           This script runs METplus for subseasonal grid-to-grid verification            to produce stats.
 
 set -x

--- a/scripts/stats/subseasonal/exevs_stats_subseasonal_grid2obs.sh
+++ b/scripts/stats/subseasonal/exevs_stats_subseasonal_grid2obs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Program Name: exevs_subseasonal_grid2obs_stats.sh
+# Program Name: exevs_stats_subseasonal_grid2obs.sh
 # Author(s)/Contact(s): Shannon Shields
-# Abstract: This script is run by JEVS_SUBSEASONAL_STATS in jobs/.
+# Abstract: This script is run by JEVS_STATS_SUBSEASONAL in jobs/.
 #           This script runs METplus for subseasonal grid-to-obs verification             to produce stats.
 
 set -x


### PR DESCRIPTION
## Description of Changes

NCO has requested that EVS script/job names match the EVS com/ structure: …/com/evs/v1.0/${STEP}/${COMPONENT}/…
This PR updates subseasonal scripts/job names by moving ${STEP} earlier in the filename. Tests showed that all updates worked, with no errors or warnings.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS/
git checkout feature/subseasonal_step_update
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh

Please edit and test all subseasonal dev drivers (prep, stats, and plots) using just qsub drivername.sh. To compare results, the emc.vpppg parallel output can be found here:

**prep:** /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/subseasonal/
**stats:** /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/subseasonal/
**plots:** /lfs/h2/emc/ptmp/emc.vpppg/evs/v2.0/plots/subseasonal/

Things to change in subseasonal dev drivers:
-HOMEevs to the directory that you are currently in (e.g., add /pr836test)
-COMIN from $USER to emc.vpppg
-KEEPDATA to YES (keeps working directories in stmp during PR testing)
-SENDMAIL to NO

Drivers to test (try to use an INITDATE or VDATE that as already run in the emc.vpppg parallel for comparison):
dev/drivers/scripts/prep/subseasonal/*
dev/drivers/scripts/stats/subseasonal/*
dev/drivers/scripts/plots/subseasonal/*
