### PR TITLE
Removing some FHRs to meet PNS requirements for global_ens (wave)

### DIFF
--- a/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_gefs_grid2obs_last90days_plots.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_gefs_grid2obs_last90days_plots.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_ens/jevs_global_ens_wave_gefs_grid2obs_last90days_plots.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_global_ens_wave_gefs_grid2obs_last90days_plots.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:10:00
 #PBS -l place=vscatter:exclhost,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
 

--- a/ush/global_ens/evs_wave_timeseries.sh
+++ b/ush/global_ens/evs_wave_timeseries.sh
@@ -16,8 +16,8 @@ set -x
 periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
 
 validhours='00 12'
-fhrs='000 024 048 072 096 120 144 168
-      192 216 240 264 288 312 336 360 384'
+fhrs='000 024 072 120 168
+      240 312 384'
 wave_vars='WIND HTSGW PERPW'
 stats_list='stats1 stats2 stats3 stats4 stats5'
 ptype='time_series'


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

In this PR, some of the forecast hours are removed from timeseries plots for global_ens (wave) to meet the recent PNS.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Note: Please test this PR after a specific new branch for PNS is created by @AliciaBentley-NOAA or @AndrewBenjamin-NOAA.
1- To test this PR, you need to run the driver scripts for **global_ens wave plots** step.
2- Clone my fork in your local and checkout branch `feature/EVSv2-global_ens_timeseries_plots_PNS`.
3- `ln -sf` fix directory.
4- Set your `HOMEevs` directory to your test directory.
5- In plots driver scripts:
5-1- For COMIN, replace the `${USER}` with `emc.vpppg`.
5-2- Set `KEEPDATA=YES`
6- Run **wave** driver scripts for plots step using `qsub` command: 
`$HOMEevs/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_gefs_grid2obs_last31days_plots.sh`
`$HOMEevs/dev/drivers/scripts/plots/global_ens/jevs_global_ens_wave_gefs_grid2obs_last90days_plots.sh`
