### PR TITLE
Move ${STEP} in global_chem filenames

### DIFF
--- a/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.sh
+++ b/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_airnow_plots_last90days
+#PBS -N jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -23,7 +23,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
-export job=${PBS_JOBNAME:-jevs_global_chem_atmos_grid2obs_airnow_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days}
 export jobid=${job}.${PBS_JOBID:-$$}
 export vhr=00
 
@@ -44,8 +44,8 @@ export STEP=plots
 export COMPONENT=global_chem
 export RUN=atmos
 export VERIF_CASE=grid2obs
-export DATA_TYPE=airnow
-export NDAYS=90
+export DATA_TYPE=aeronet
+export NDAYS=31
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
 export TMPDIR=${DATAROOT}
@@ -55,9 +55,9 @@ export VDATE_END=$(finddate.sh ${today} d-4)
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 # CALL executable job script here
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 ######################################################################
 # Purpose: This does the plotting work for the global chemistry
-#          grid-to-observations airnow for last 90 days
+#          grid-to-observations aeronet for last 31 days
 ######################################################################

--- a/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.sh
+++ b/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_airnow_plots_last31days
+#PBS -N jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -23,7 +23,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
-export job=${PBS_JOBNAME:-jevs_global_chem_atmos_grid2obs_airnow_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days}
 export jobid=${job}.${PBS_JOBID:-$$}
 export vhr=00
 
@@ -44,8 +44,8 @@ export STEP=plots
 export COMPONENT=global_chem
 export RUN=atmos
 export VERIF_CASE=grid2obs
-export DATA_TYPE=airnow
-export NDAYS=31
+export DATA_TYPE=aeronet
+export NDAYS=90
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
 export TMPDIR=${DATAROOT}
@@ -55,9 +55,9 @@ export VDATE_END=$(finddate.sh ${today} d-4)
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 # CALL executable job script here
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 ######################################################################
 # Purpose: This does the plotting work for the global chemistry
-#          grid-to-observations airnow for last 31 days
+#          grid-to-observations aeronet for last 90 days
 ######################################################################

--- a/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.sh
+++ b/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_global_chem_headline_grid2obs_plots_last90days
+#PBS -N jevs_plots_global_chem_atmos_grid2obs_airnow_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=20GB
+#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=275GB
 #PBS -l debug=true
 
 set -x
@@ -23,7 +23,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
-export job=${PBS_JOBNAME:-jevs_global_chem_headline_grid2obs_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_global_chem_atmos_grid2obs_airnow_last31days}
 export jobid=${job}.${PBS_JOBID:-$$}
 export vhr=00
 
@@ -35,17 +35,17 @@ source $HOMEevs/dev/modulefiles/global_chem/global_chem_plots.sh
 evs_ver_2d=$(echo ${evs_ver} | cut -d'.' -f1-2)
 
 export machine=WCOSS2
-export USE_CFP=NO
-export nproc=1
+export USE_CFP=YES
+export nproc=128
 
 export envir=prod
 export NET=evs
 export STEP=plots
 export COMPONENT=global_chem
-export RUN=headline
+export RUN=atmos
 export VERIF_CASE=grid2obs
-export DATA_TYPE=aeronet
-export NDAYS=90
+export DATA_TYPE=airnow
+export NDAYS=31
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
 export TMPDIR=${DATAROOT}
@@ -55,9 +55,9 @@ export VDATE_END=$(finddate.sh ${today} d-4)
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 # CALL executable job script here
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 ######################################################################
 # Purpose: This does the plotting work for the global chemistry
-#          grid-to-observations airnow/aeronet headline for last 90 days
+#          grid-to-observations airnow for last 31 days
 ######################################################################

--- a/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.sh
+++ b/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_aeronet_plots_last90days
+#PBS -N jevs_plots_global_chem_atmos_grid2obs_airnow_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -23,7 +23,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
-export job=${PBS_JOBNAME:-jevs_global_chem_atmos_grid2obs_aeronet_plots_last90days}
+export job=${PBS_JOBNAME:-jevs_plots_global_chem_atmos_grid2obs_airnow_last90days}
 export jobid=${job}.${PBS_JOBID:-$$}
 export vhr=00
 
@@ -44,7 +44,7 @@ export STEP=plots
 export COMPONENT=global_chem
 export RUN=atmos
 export VERIF_CASE=grid2obs
-export DATA_TYPE=aeronet
+export DATA_TYPE=airnow
 export NDAYS=90
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
@@ -55,9 +55,9 @@ export VDATE_END=$(finddate.sh ${today} d-4)
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 # CALL executable job script here
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 ######################################################################
 # Purpose: This does the plotting work for the global chemistry
-#          grid-to-observations aeronet for last 90 days
+#          grid-to-observations airnow for last 90 days
 ######################################################################

--- a/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.sh
+++ b/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_aeronet_plots_last31days
+#PBS -N jevs_plots_global_chem_headline_grid2obs_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=275GB
+#PBS -l place=shared,select=1:ncpus=1:mem=20GB
 #PBS -l debug=true
 
 set -x
@@ -23,7 +23,7 @@ export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
 export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
-export job=${PBS_JOBNAME:-jevs_global_chem_atmos_grid2obs_aeronet_plots_last31days}
+export job=${PBS_JOBNAME:-jevs_plots_global_chem_headline_grid2obs_last90days}
 export jobid=${job}.${PBS_JOBID:-$$}
 export vhr=00
 
@@ -35,17 +35,17 @@ source $HOMEevs/dev/modulefiles/global_chem/global_chem_plots.sh
 evs_ver_2d=$(echo ${evs_ver} | cut -d'.' -f1-2)
 
 export machine=WCOSS2
-export USE_CFP=YES
-export nproc=128
+export USE_CFP=NO
+export nproc=1
 
 export envir=prod
 export NET=evs
 export STEP=plots
 export COMPONENT=global_chem
-export RUN=atmos
+export RUN=headline
 export VERIF_CASE=grid2obs
 export DATA_TYPE=aeronet
-export NDAYS=31
+export NDAYS=90
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
 export TMPDIR=${DATAROOT}
@@ -55,9 +55,9 @@ export VDATE_END=$(finddate.sh ${today} d-4)
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 # CALL executable job script here
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 ######################################################################
 # Purpose: This does the plotting work for the global chemistry
-#          grid-to-observations aeronet for last 31 days
+#          grid-to-observations airnow/aeronet headline for last 90 days
 ######################################################################

--- a/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_prep
+#PBS -N jevs_prep_global_chem_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -57,7 +57,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
-export job=${PBS_JOBNAME:-jevs_${MODELNAME}_${RUN}_${VERIF_CASE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 ############################################################
@@ -71,7 +71,7 @@ if [ -z "$MAILTO" ]; then
 
 else
 
-    ${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PREP
+    ${HOMEevs}/jobs/JEVS_PREP_GLOBAL_CHEM
 
 fi
 

--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_aeronet_stats
+#PBS -N jevs_stats_global_chem_atmos_grid2obs_aeronet
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -50,7 +50,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
-export job=${PBS_JOBNAME:-jevs_${COMPONENT}_${RUN}_${VERIF_CASE}_${DATA_TYPE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${RUN}_${VERIF_CASE}_${DATA_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 ############################################################
@@ -63,7 +63,7 @@ if [ -z "$MAILTO" ]; then
 else
     export vhr
     echo "vhr = ${vhr}"
-    ${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_STATS
+    ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_CHEM
 fi
 ######################################################################
 ## Purpose: This job will generate the grid2obs statistics using AERONET AOD

--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_global_chem_atmos_grid2obs_airnow_stats
+#PBS -N jevs_stats_global_chem_atmos_grid2obs_airnow
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -51,7 +51,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/${envir}/tmp
-export job=${PBS_JOBNAME:-jevs_${COMPONENT}_${RUN}_${VERIF_CASE}_${DATA_TYPE}_${STEP}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${RUN}_${VERIF_CASE}_${DATA_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 ############################################################
@@ -64,7 +64,7 @@ if [ -z "$MAILTO" ]; then
 else
     export vhr
     echo "vhr = ${vhr}"
-    ${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_STATS
+    ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_CHEM
 fi
 ######################################################################
 ## Purpose: This job will generate the grid2obs statistics using AirNOW PM2.5

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -90,7 +90,7 @@ suite evs_nco
               time 05:15
           endfamily
           family global_chem
-            task jevs_global_chem_atmos_grid2obs_prep
+            task jevs_prep_global_chem_atmos_grid2obs
               time 05:30
           endfamily
         endfamily    # 00 prep
@@ -390,11 +390,11 @@ suite evs_nco
               edit VHR '05'
           endfamily
           family global_chem
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_00
-              trigger :TIME >= 0545 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00
+              trigger :TIME >= 0545 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_00
-              trigger :TIME >= 0545 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00
+              trigger :TIME >= 0545 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
           endfamily
         endfamily    # 00 stats
@@ -423,16 +423,12 @@ suite evs_nco
               time 00:30
           endfamily
           family global_chem
-            task jevs_global_chem_atmos_grid2obs_aeronet_plots_last90days
+            task jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days
               time 00:45
-            task jevs_global_chem_atmos_grid2obs_airnow_plots_last90days
+            task jevs_plots_global_chem_atmos_grid2obs_airnow_last90days
               time 00:45
-            task jevs_global_chem_headline_grid2obs_plots_last90days
+            task jevs_plots_global_chem_headline_grid2obs_last90days
               time 00:45
-            task jevs_global_chem_atmos_grid2obs_aeronet_plots_last31days
-              time 01:45
-            task jevs_global_chem_atmos_grid2obs_airnow_plots_last31days
-              time 02:45
           endfamily
           family aqm
             task jevs_aqm_atmos_grid2grid_hourly_plots_last90days
@@ -970,23 +966,23 @@ suite evs_nco
               edit VHR '11'
           endfamily
           family global_chem
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_03
-              trigger :TIME >= 0615 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03
+              trigger :TIME >= 0615 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_03
-              trigger :TIME >= 0615 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03
+              trigger :TIME >= 0615 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_06
-              trigger :TIME >= 0705 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06
+              trigger :TIME >= 0705 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '06'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_06
-              trigger :TIME >= 0705 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06
+              trigger :TIME >= 0705 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '06'
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_09
-              trigger :TIME >= 0730 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09
+              trigger :TIME >= 0730 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '09'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_09
-              trigger :TIME >= 0730 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09
+              trigger :TIME >= 0730 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '09'
           endfamily
         endfamily    # 06 stats
@@ -1447,29 +1443,29 @@ suite evs_nco
               edit VHR '17'
           endfamily
           family global_chem
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_12
-              trigger :TIME >= 1330 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_12
+              trigger :TIME >= 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '12'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_12
-              trigger :TIME >= 1330 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_12
+              trigger :TIME >= 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '12'
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_15
-              trigger :TIME >= 1345 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_15
+              trigger :TIME >= 1345 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '15'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_15
-              trigger :TIME >= 1345 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_15
+              trigger :TIME >= 1345 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '15'
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_18
-              trigger :TIME >= 1400 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_18
+              trigger :TIME >= 1400 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '18'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_18
-              trigger :TIME >= 1400 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_18
+              trigger :TIME >= 1400 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '18'
-            task jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_21
-              trigger :TIME >= 1430 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete and ../../../../00/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_00 == complete and ../../../../06/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_06 == complete and ../../../../06/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_09 == complete and ./jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_12 == complete and ./jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_15 == complete and ./jevs_global_chem_atmos_grid2obs_airnow_stats_vhr_18 == complete
+            task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_21
+              trigger :TIME >= 1430 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ../../../../00/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_12 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_15 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_18 == complete
               edit VHR '21'
-            task jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_21
-              trigger :TIME >= 1415 and ../../../../00/evs/prep/global_chem/jevs_global_chem_atmos_grid2obs_prep == complete and ../../../../00/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_00 == complete ../../../../06/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_06 == complete ../../../../06/evs/stats/global_chem/jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_09 == complete and ./jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_12 == complete and ./jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_15 == complete and ./jevs_global_chem_atmos_grid2obs_aeronet_stats_vhr_18 == complete
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_21
+              trigger :TIME >= 1415 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ../../../../00/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00 == complete ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_12 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_15 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_18 == complete
               edit VHR '21'
           endfamily
         endfamily   # 12 stats

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_airnow_plots_last31days
+#PBS -N evs_plots_global_chem_atmos_grid2obs_aeronet_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -57,13 +57,13 @@ export USE_CFP=YES
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=grid2obs
-export DATA_TYPE=airnow
+export DATA_TYPE=aeronet
 export NDAYS=31
 
 ######################################################################
 # Execute j-job
 ######################################################################
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_aeronet_plots_last90days
+#PBS -N evs_plots_global_chem_atmos_grid2obs_aeronet_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -63,7 +63,7 @@ export NDAYS=90
 ######################################################################
 # Execute j-job
 ######################################################################
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_airnow_plots_last90days
+#PBS -N evs_plots_global_chem_atmos_grid2obs_airnow_last31days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -54,17 +54,16 @@ fi
 export nproc=128
 export USE_CFP=YES
 
-export envir=prod
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=grid2obs
 export DATA_TYPE=airnow
-export NDAYS=90
+export NDAYS=31
 
 ######################################################################
 # Execute j-job
 ######################################################################
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_aeronet_plots_last31days
+#PBS -N evs_plots_global_chem_atmos_grid2obs_airnow_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -54,16 +54,17 @@ fi
 export nproc=128
 export USE_CFP=YES
 
+export envir=prod
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=grid2obs
-export DATA_TYPE=aeronet
-export NDAYS=31
+export DATA_TYPE=airnow
+export NDAYS=90
 
 ######################################################################
 # Execute j-job
 ######################################################################
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_headline_grid2obs_plots_last90days
+#PBS -N evs_plots_global_chem_headline_grid2obs_last90days
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -63,7 +63,7 @@ export NDAYS=90
 ######################################################################
 # Execute j-job
 ######################################################################
-${HOMEevs}/jobs/JEVS_GLOBAL_CHEM_PLOTS
+${HOMEevs}/jobs/JEVS_PLOTS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.ecf
+++ b/ecf/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_prep
+#PBS -N evs_prep_global_chem_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -54,7 +54,7 @@ export MODELNAME=gefs
 ############################################################
 ##  Execute j-job
 #############################################################
-$HOMEevs/jobs/JEVS_GLOBAL_CHEM_PREP
+$HOMEevs/jobs/JEVS_PREP_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_master.ecf
+++ b/ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_master.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_aeronet_stats_vhr_%VHR%
+#PBS -N evs_stats_global_chem_atmos_grid2obs_aeronet_vhr_%VHR%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -56,7 +56,7 @@ export DATA_TYPE=aeronet
 ############################################################
 #  Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_GLOBAL_CHEM_STATS
+$HOMEevs/jobs/JEVS_STATS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_master.ecf
+++ b/ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_master.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_global_chem_atmos_grid2obs_airnow_stats_vhr_%VHR%
+#PBS -N evs_stats_global_chem_atmos_grid2obs_airnow_vhr_%VHR%
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -56,7 +56,7 @@ export DATA_TYPE=airnow
 ############################################################
 #  Execute j-job
 ############################################################
-$HOMEevs/jobs/JEVS_GLOBAL_CHEM_STATS
+$HOMEevs/jobs/JEVS_STATS_GLOBAL_CHEM
 
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"

--- a/jobs/JEVS_PLOTS_GLOBAL_CHEM
+++ b/jobs/JEVS_PLOTS_GLOBAL_CHEM
@@ -85,7 +85,7 @@ fi
 # Execute the script
 ########################################
 
-${HOMEevs}/scripts/${STEP}/${COMPONENT}/exevs_${COMPONENT}_${RUN}_${VERIF_CASE}_${STEP}.sh
+${HOMEevs}/scripts/${STEP}/${COMPONENT}/exevs_${STEP}_${COMPONENT}_${RUN}_${VERIF_CASE}.sh
 export err=$?; err_chk
 
 msg="JOB ${job} HAS COMPLETED NORMALLY."

--- a/jobs/JEVS_PREP_GLOBAL_CHEM
+++ b/jobs/JEVS_PREP_GLOBAL_CHEM
@@ -76,7 +76,7 @@ export HOURLY_NCOL=${HOURLY_NCOL:-34}
 # Execute the script.
 ##########################################################
 
-${HOMEevs}/scripts/${STEP}/${COMPONENT}/exevs_${COMPONENT}_${RUN}_${VERIF_CASE}_${STEP}.sh
+${HOMEevs}/scripts/${STEP}/${COMPONENT}/exevs_${STEP}_${COMPONENT}_${RUN}_${VERIF_CASE}.sh
 export err=$?; err_chk
 
 msg="JOB ${job} HAS COMPLETED NORMALLY."

--- a/jobs/JEVS_STATS_GLOBAL_CHEM
+++ b/jobs/JEVS_STATS_GLOBAL_CHEM
@@ -76,7 +76,7 @@ mkdir -p ${COMOUT}
 # Execute the script.
 ##########################################################
 
-${HOMEevs}/scripts/${STEP}/${COMPONENT}/exevs_${COMPONENT}_${RUN}_${VERIF_CASE}_${STEP}.sh
+${HOMEevs}/scripts/${STEP}/${COMPONENT}/exevs_${STEP}_${COMPONENT}_${RUN}_${VERIF_CASE}.sh
 export err=$?; err_chk
 
 msg="JOB ${job} HAS COMPLETED NORMALLY."

--- a/scripts/plots/global_chem/exevs_plots_global_chem_atmos_grid2obs.sh
+++ b/scripts/plots/global_chem/exevs_plots_global_chem_atmos_grid2obs.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 ###############################################################################
-# Name of Script: exevs_global_chem_atmos_grid2obs_plots.sh
+# Name of Script: exevs_plots_global_chem_atmos_grid2obs.sh
 # Developers: Ho-Chun Huang / Ho-Chun.Huang@noaa.gov
-#
-# Original Name of Script: exevs_global_det_atmos_grid2obs_plots.sh
 # Original Author: Mallory Row / Mallory.Row@noaa.gov
 # Purpose of Script: This script is run for the global_chem_atmos plots step
 #                    for the grid-to-obs verification. It uses EMC-developed

--- a/scripts/plots/global_chem/exevs_plots_global_chem_headline_grid2obs.sh
+++ b/scripts/plots/global_chem/exevs_plots_global_chem_headline_grid2obs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# Name of Script: exevs_global_chem_headline_grid2obs_plots.sh
+# Name of Script: exevs_plots_global_chem_headline_grid2obs.sh
 # Developers: Ho-Chun Huang / Ho-Chun.Huang@noaa.gov
 #
 # Purpose of Script: This script is run for the global_chem plots step for

--- a/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
+++ b/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
@@ -2,7 +2,7 @@
 ########################################################################
 ###  UNIX Script Documentation Block
 ###                      .
-### Script name:         exevs_global_chem_atmos_grid2obs_prep.sh
+### Script name:         exevs_prep_global_chem_atmos_grid2obs.sh
 ### Script description:  To run grid-to-obs verification on Global Chemical modeling
 ### Original Author   :  Partha Bhattacharjee
 ###

--- a/scripts/stats/global_chem/exevs_stats_global_chem_atmos_grid2obs.sh
+++ b/scripts/stats/global_chem/exevs_stats_global_chem_atmos_grid2obs.sh
@@ -2,7 +2,7 @@
 ########################################################################
 ###  UNIX Script Documentation Block
 ###                      .
-### Script name:         exevs_global_chem_atmos_grid2obs_stats.sh
+### Script name:         exevs_stats_global_chem_atmos_grid2obs.sh
 ### Script description:  To run grid-to-grid verification on all global chem
 ### Original Author   :  Partha Bhattacharjee
 ###


### PR DESCRIPTION
## Description of Changes

NCO has requested that EVS script/job names match the EVS com/ structure: …/com/evs/v1.0/${STEP}/${COMPONENT}/…
This PR updates global_chem scripts/job names by moving ${STEP} earlier in the filename. Tests showed that all updates worked for prep, with no errors or warnings. I'm actively testing stats and plots now, and will push updates if there are any issues. Trying to be super efficient, as the GCAFS near real-time parallel has started and this code needs to be final form ASAP!

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes. It should be tested and merged as soon as possible. 

* Do you have any planned upcoming annual leave/PTO?
Yes. Afternoon on Wed 10/8–noon on Tuesday 10/14. Dates may change due to shutdown...

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS/
git checkout feature/global_chem_step
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh

Please edit and test all global_chem dev drivers (prep, stats, and plots). 

Things to change in dev drivers:
-HOMEevs to the directory that you are currently in (e.g., add /pr###test)
-COMIN from $USER to emc.vpppg
-KEEPDATA to YES (keeps working directories in stmp during PR testing)
-SENDMAIL to NO

Drivers to test (try to use an INITDATE or VDATE that as already run in the emc.vpppg parallel for comparison):
dev/drivers/scripts/prep/global_chem/*
qsub jevs_prep_global_chem_atmos_grid2obs.sh

dev/drivers/scripts/stats/global_chem/*
Run for vhrs 00, 03, 06, 09, 12, 15, 18, and 21
**Note: Only run vhr=21 after all previous hours are complete**
qsub -v vhr=${run_vhr} jevs_stats_global_chem_atmos_grid2obs_airnow.sh
qsub -v vhr=${run_vhr} jevs_stats_global_chem_atmos_grid2obs_aeronet.sh

dev/drivers/scripts/plots/global_chem/*
qsub jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.sh
qsub jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.sh
qsub jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.sh
qsub jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.sh
qsub jevs_plots_global_chem_headline_grid2obs_last90days.sh

**To compare results, the emc.vpppg parallel output can be found here:**
prep: /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/global_chem/
stats: /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/global_chem/
plots: /lfs/h2/emc/ptmp/emc.vpppg/evs/v2.0/plots/global_chem/
