### PR TITLE
Move ${STEP} in wafs filenames

### DIFF
--- a/dev/drivers/scripts/plots/wafs/jevs_plots_wafs_atmos.sh
+++ b/dev/drivers/scripts/plots/wafs/jevs_plots_wafs_atmos.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_wafs_atmos_plots
+#PBS -N jevs_plots_wafs_atmos
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -55,18 +55,18 @@ export DAYS_LIST=${DAYS_LIST:-"90"}
 # CALL executable job script here
 ############################################################
 export pid=${PBS_JOBID:-$$}
-export job=${PBS_JOBNAME:-jevs_wafs_atmos_plots}
+export job=${PBS_JOBNAME:-jevs_plots_wafs_atmos}
 export jobid=$job.$pid
 
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
 export KEEPDATA=NO
 
-$HOMEevs/jobs/JEVS_WAFS_PLOTS
+$HOMEevs/jobs/JEVS_PLOTS_WAFS
 
 ############################################################
 ## Purpose: This job generates the grid2grid statistics stat
-##          files for GFS WAFS
+##          files for WAFS
 ############################################################
 #
 

--- a/dev/drivers/scripts/plots/wafs/jevs_plots_wafs_atmos.sh
+++ b/dev/drivers/scripts/plots/wafs/jevs_plots_wafs_atmos.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=0:30:00
-#PBS -l place=shared,select=1:ncpus=40:mem=200GB
+#PBS -l place=shared,select=1:ncpus=45:mem=200GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/wafs/jevs_plots_wafs_atmos.sh
+++ b/dev/drivers/scripts/plots/wafs/jevs_plots_wafs_atmos.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=0:15:00
+#PBS -l walltime=0:30:00
 #PBS -l place=shared,select=1:ncpus=40:mem=200GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/stats/wafs/jevs_stats_wafs_atmos.sh
+++ b/dev/drivers/scripts/stats/wafs/jevs_stats_wafs_atmos.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_wafs_atmos_stats
+#PBS -N jevs_stats_wafs_atmos
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -42,7 +42,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/$evs_ver_2d
 # set up for email alerts of missing data
 ############################################################
 export pid=${PBS_JOBID:-$$}
-export job=${PBS_JOBNAME:-jevs_wafs_atmos_stats}
+export job=${PBS_JOBNAME:-jevs_stats_wafs_atmos}
 export jobid=$job.$pid
 
 export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,yali.mao@noaa.gov'}
@@ -55,11 +55,11 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
 export KEEPDATA=NO
 
-$HOMEevs/jobs/JEVS_WAFS_STATS
+$HOMEevs/jobs/JEVS_STATS_WAFS
 
 ############################################################
 ## Purpose: This job generates the grid2grid statistics stat
-##          files for GFS WAFS
+##          files for WAFS
 ############################################################
 #
 exit

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -570,7 +570,7 @@ suite evs_nco
               trigger :TIME >= 1000 and ../../../../06/evs/prep/global_ens/jevs_global_ens_wave_prep == complete
           endfamily
           family wafs
-            task jevs_wafs_atmos_stats
+            task jevs_stats_wafs_atmos
               time 09:00
           endfamily
           family mesoscale

--- a/ecf/scripts/stats/wafs/jevs_stats_wafs_atmos.ecf
+++ b/ecf/scripts/stats/wafs/jevs_stats_wafs_atmos.ecf
@@ -1,4 +1,4 @@
-#PBS -N evs_wafs_atmos_stats
+#PBS -N evs_stats_wafs_atmos
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
@@ -50,7 +50,7 @@ export VERIF_CASE=grid2grid
 ############################################################
 # Execute j-job
 ############################################################
-${HOMEevs}/jobs/JEVS_WAFS_STATS
+${HOMEevs}/jobs/JEVS_STATS_WAFS
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/jobs/JEVS_PLOTS_WAFS
+++ b/jobs/JEVS_PLOTS_WAFS
@@ -90,7 +90,7 @@ export USH_DIR=${USH_DIR:-$HOMEevs/ush/$COMPONENT}
 # Execute the script.
 ############################################
 export DAYS_LIST=${DAYS_LIST:-"90"}
-$SCRIPTSevs/exevs_wafs_atmos_plots.sh
+$SCRIPTSevs/exevs_plots_wafs_atmos.sh
 
 export err=$?; err_chk
 

--- a/jobs/JEVS_STATS_WAFS
+++ b/jobs/JEVS_STATS_WAFS
@@ -93,7 +93,7 @@ export MASKS=${MASKS:-$FIXevs/masks}
 ############################################
 # Execute the script using MPMD
 ############################################
-$SCRIPTSevs/exevs_wafs_atmos_stats.sh
+$SCRIPTSevs/exevs_stats_wafs_atmos.sh
 export err=$?; err_chk
 
 echo "JOB $job HAS COMPLETED NORMALLY!"

--- a/scripts/plots/wafs/exevs_plots_wafs_atmos.sh
+++ b/scripts/plots/wafs/exevs_plots_wafs_atmos.sh
@@ -100,4 +100,4 @@ if [[ $log_file_count -ne 0 ]]; then
 	done
 fi
 
-echo "********SCRIPT exevs_wafs_atmos_plots.sh COMPLETED NORMALLY on `$NDATE`"
+echo "********SCRIPT exevs_plots_wafs_atmos.sh COMPLETED NORMALLY on `$NDATE`"

--- a/scripts/stats/wafs/exevs_stats_wafs_atmos.sh
+++ b/scripts/stats/wafs/exevs_stats_wafs_atmos.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 ########################################################################################
-# Name of Script: exevs_wafs_atmos_stats.sh
+# Name of Script: exevs_stats_wafs_atmos.sh
 # Purpose of Script: To generate the verification products for WAFS verification
-# Arguments: exevs_wafs_atmos_stats.sh
+# Arguments: exevs_stats_wafs_atmos.sh
 #   
 ########################################################################################
 set -x


### PR DESCRIPTION
## Description of Changes

NCO has requested that EVS script/job names match the EVS com/ structure: …/com/evs/v1.0/${STEP}/${COMPONENT}/…
This PR updates wafs scripts/job names by moving ${STEP} earlier in the filename. Note that only wafs stats runs in ops (plots runs in dev), but I think it's important to change and test both stats and plots in this PR.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No

* Do you have any planned upcoming annual leave/PTO?
I will be unavailable Thursday–Monday and next Tuesday morning. 

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS/
git checkout feature/wafs_step_update
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh

Please edit and test wafs stats and plots dev drivers. Note there there is no prep and that plots are only run in dev.

Things to change in dev drivers:
-HOMEevs to the directory that you are currently in (e.g., add /pr###test)
-COMIN from $USER to emc.vpppg
-KEEPDATA to YES (keeps working directories in stmp during PR testing)
-SENDMAIL to NO

Drivers to test (wafs stats and plots):
dev/drivers/scripts/stats/wafs/
**qsub jevs_stats_wafs_atmos.sh**

dev/drivers/scripts/plots/wafs/
**qsub jevs_plots_wafs_atmos.sh**


To compare results, the emc.vpppg parallel output can be found here:
stats: /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/stats/wafs/
plots: N/A

Please include @YaliMao-NOAA to confirm test results. 
