### PR TITLE
Chore/analyses pns remove plots

### DIFF
--- a/dev/drivers/scripts/plots/analyses/jevs_analyses_grid2obs_plots_last31days.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_analyses_grid2obs_plots_last31days.sh
@@ -4,8 +4,8 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=05:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=20GB
+#PBS -l walltime=01:30:00
+#PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/plots/analyses/jevs_analyses_grid2obs_plots_last31days.ecf
+++ b/ecf/scripts/plots/analyses/jevs_analyses_grid2obs_plots_last31days.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=05:15:00
-#PBS -l place=shared,select=1:ncpus=1:mem=20GB
+#PBS -l walltime=01:30:00
+#PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 
 export model=evs

--- a/scripts/plots/analyses/exevs_analyses_grid2obs_plots.sh
+++ b/scripts/plots/analyses/exevs_analyses_grid2obs_plots.sh
@@ -395,65 +395,6 @@ do
 	echo "Note: No plot made due to lack of data in region for last 31 days",$varb,$region,$anl
         fi
 
-	if [ $var = VISsfc ]
-	then
-        for thresh in 805 1609 4828 8045 16090
-	do
-        
-        if [ ! -e $COMOUTplots/$varb/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]; then
-	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/py_plotting.config_timeseries_ctc
-	export err=$?; err_chk
-        else
-	echo "RESTART - plot exists; copying over to plot directory"
-	cp $COMOUTplots/$varb/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png $PLOTDIR
-	fi
-
-	if [ -e ${PLOTDIR}/ceil_vis/*/evs*png ]
-	then
-	mv ${PLOTDIR}/ceil_vis/*/evs*png ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png
-	if [ $SENDCOM = "YES" ]; then
-	if [ -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]; then
-        cp ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png $COMOUTplots/$varb
-	fi
-	fi
-        elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
-	then
-	echo "Note: No plot made. The threshold does not occur over the region in the last 31 days",$varb,$region,$anl,$thresh
-	fi
-
-        done
-	fi
-
-	if [ $var = HGTcldceil ]
-        then
-        for thresh in 152 305 914 1524 3048 
-        do
-
-	if [ ! -e $COMOUTplots/$varb/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]; then
-        $PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/py_plotting.config_timeseries_ctc
-	export err=$?; err_chk
-        else
-	echo "RESTART - plot exists; copying over to plot directory"
-	cp $COMOUTplots/$varb/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png $PLOTDIR
-        fi
-
-	if [ -e ${PLOTDIR}/ceil_vis/*/evs*png ]
-	then
-        mv ${PLOTDIR}/ceil_vis/*/evs*png ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png
-	if [ $SENDCOM = "YES" ]; then
-	if [ -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]; then
-	cp ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png $COMOUTplots/$varb
-	fi
-	fi
-        elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_lt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
-	then
-	echo "Note: No plot made. The threshold does not occur over the region in the last 31 days",$varb,$region,$anl,$thresh
-	fi
-
-        done
-        fi
-
-        
         done
  fi
 done
@@ -468,7 +409,6 @@ if [ $plot = yes ]; then
 	export lev=L0
 	export lev_obs=L0
 	export linetype=CTC
-#	export thresh=">10,>50,>90"
 	smlev=`echo $lev | tr A-Z a-z`
 	smvar=`echo $var | tr A-Z a-z`
 
@@ -497,32 +437,6 @@ if [ $plot = yes ]; then
 	then
 	echo "Note: No plot made due to lack of data in region for last 31 days",$var,$region,$anl
         fi
-
-        for thresh in 10 50 90
-	do
-	
-	if [ ! -e $COMOUTplots/$var/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]; then
-	$PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/py_plotting.config_timeseries_ctc_tcdc
-	export err=$?; err_chk
-        else
-	echo "RESTART - plot exists; copying over to plot directory"
-	cp $COMOUTplots/$var//evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png $PLOTDIR
-	fi
-
-	if [ -e ${PLOTDIR}/sfc_upper/*/evs*png ]
-	then
-        mv ${PLOTDIR}/sfc_upper/*/evs*png ${PLOTDIR}/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png
-	if [ $SENDCOM = "YES" ]; then
-	if [ -e ${PLOTDIR}/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]; then
-	cp ${PLOTDIR}/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png $COMOUTplots/$var
-	fi
-	fi
-        elif [ ! -e ${PLOTDIR}/evs.${anl}.${stat}_gt${thresh}.${smvar}_${smlev}.last31days.timeseries.buk_${smregion}.png ]
-	then
-	echo "Note: No plot made. The threshold does not occur over the region in the last 31 days",$var,$region,$anl,$thresh
-	fi
-
-        done
 
         done
         fi


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR includes the following changes:
- Removed all thresholded timeseries graphics (all CEILING, VIS, and TCDC timeseries), reducing total graphics output from 950 to 357
- Adjusted memory allocations and wallclock times accordingly


## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Maybe.  October 30th, 2025
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### Running jobs

I recommend testing the following jobs:
```
jevs_analyses_grid2obs_plots_last31days
```
[Total: 1 plots job]

#### Testing jobs

- submit the driver using `qsub -v vhr=00 $driver`

#### Checking jobs
- I will check the log for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- I will also check that output graphics are reduced to 357 total