### PR TITLE
Cleaning up evs-nco.def file

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -431,18 +431,12 @@ suite evs_nco
               time 00:45
           endfamily
           family aqm
-            task jevs_aqm_atmos_grid2grid_hourly_plots_last90days
-              time 05:10
             task jevs_aqm_atmos_grid2grid_hourly_plots_last31days
               time 05:20
             task jevs_aqm_atmos_grid2obs_daily_plots_last90days
               time 05:30
-            task jevs_aqm_atmos_grid2obs_hourly_plots_last90days
-              time 05:40
             task jevs_aqm_atmos_grid2obs_headline_plots_last90days
               time 05:45
-            task jevs_aqm_atmos_grid2obs_daily_plots_last31days
-              time 05:50
             task jevs_aqm_atmos_grid2obs_hourly_plots_last31days
               time 05:58
           endfamily
@@ -622,15 +616,6 @@ suite evs_nco
             task jevs_mesoscale_rap_snowfall_stats_vhr_06
               time 06:00
               edit VHR '06'
-            task jevs_mesoscale_grid2obs_plots_last31days
-              edit VHR '09'
-              time 09:00
-            task jevs_mesoscale_grid2obs_plots_last90days
-              edit VHR '09'
-              time 09:00
-            task jevs_mesoscale_headline_plots
-              edit VHR '09'
-              time 09:00
             task jevs_mesoscale_sref_precip_stats
               time 09:30
             task jevs_mesoscale_sref_grid2obs_stats
@@ -988,9 +973,15 @@ suite evs_nco
         endfamily    # 06 stats
         family plots
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
+          family mesoscale
+            task jevs_mesoscale_grid2obs_plots_last90days
+              edit VHR '09'
+              time 09:00
+            task jevs_mesoscale_headline_plots
+              edit VHR '09'
+              time 09:00
+          endfamily
           family global_ens
-            task jevs_global_ens_wave_gefs_grid2obs_last31days_plots
-              trigger :TIME >= 1130 and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_wave_grid2obs_stats == complete
 	    task jevs_global_ens_wave_gefs_grid2obs_last90days_plots
               trigger :TIME >= 1135 and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_wave_grid2obs_stats == complete
           endfamily
@@ -1018,14 +1009,6 @@ suite evs_nco
           family nfcens
             task jevs_prep_nfcens_wave_grid2obs
               time 14:00
-          endfamily
-	  family glwu
-            task jevs_glwu_wave_grid2obs_prep
-              time 14:30
-	  endfamily
-	  family nwps
-            task jevs_nwps_wave_grid2obs_prep
-              time 14:45
           endfamily
           family global_det
             task jevs_global_det_wave_prep
@@ -1091,14 +1074,6 @@ suite evs_nco
             task jevs_stats_nfcens_wave_grid2obs
               trigger :TIME >= 1430 and ../../prep/nfcens == complete
           endfamily
-	  family glwu
-	    task jevs_glwu_wave_grid2obs_stats
-	      trigger :TIME >= 1500 and ../../prep/glwu == complete
-	  endfamily
-	  family nwps
-	    task jevs_nwps_wave_grid2obs_stats
-	      trigger :TIME >= 1515 and ../../prep/nwps == complete
-	  endfamily
           family subseasonal
             task jevs_stats_subseasonal_cfs_grid2obs
               trigger :TIME >= 1530 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
@@ -1474,43 +1449,23 @@ suite evs_nco
           family global_ens
             task jevs_global_ens_atmos_naefs_precip_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_precip_stats == complete
-            task jevs_global_ens_atmos_naefs_precip_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_precip_stats == complete
             task jevs_global_ens_atmos_naefs_grid2obs_last90days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_naefs_grid2obs_last31days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_naefs_grid2grid_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_grid2grid_stats == complete
-            task jevs_global_ens_atmos_naefs_grid2grid_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_grid2grid_stats == complete
             task jevs_global_ens_atmos_gefs_sst_last90days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_sst_stats == complete
-            task jevs_global_ens_atmos_gefs_sst_last31days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_sst_stats == complete
             task jevs_global_ens_atmos_gefs_snowfall_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_snowfall_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_snowfall_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_snowfall_stats == complete
-            task jevs_global_ens_atmos_gefs_snowfall_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_snowfall_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_snowfall_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_snowfall_stats == complete
             task jevs_global_ens_atmos_gefs_sea_ice_last90days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_sea_ice_stats == complete
-            task jevs_global_ens_atmos_gefs_sea_ice_last31days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_sea_ice_stats == complete
             task jevs_global_ens_atmos_gefs_cape_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_gefs_cape_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_gefs_profile3_last90days_plots
-              trigger :TIME >= 1500 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_gefs_profile3_last31days_plots
               trigger :TIME >= 1500 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_gefs_profile2_last90days_plots
               trigger :TIME >= 1600 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_gefs_profile2_last31days_plots
-              trigger :TIME >= 1600 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_gefs_profile1_last90days_plots
-              trigger :TIME >= 1700 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_gefs_profile1_last31days_plots
               trigger :TIME >= 1700 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_gefs_precip_spatial_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_precip_stats == complete
@@ -1518,34 +1473,16 @@ suite evs_nco
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_naefs_atmos_precip_stats == complete
             task jevs_global_ens_atmos_gefs_precip_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete
-            task jevs_global_ens_atmos_gefs_precip_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete
             task jevs_global_ens_atmos_gefs_grid2obs_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_gefs_grid2obs_separate_last90days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_gefs_grid2obs_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
-            task jevs_global_ens_atmos_gefs_grid2obs_separate_last31days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_global_ens_atmos_gefs_grid2grid_last90days_plots
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats == complete
-            task jevs_global_ens_atmos_gefs_grid2grid_last31days_plots
               trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_global_ens_cmce_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_ecme_atmos_grid2grid_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2grid_stats == complete
           endfamily
           family nfcens
-            task jevs_plots_nfcens_wave_grid2obs_last31days
-              trigger :TIME >= 1500 and ../../stats/nfcens == complete
 	    task jevs_plots_nfcens_wave_grid2obs_last90days
 	      trigger :TIME >= 1500 and ../../stats/nfcens == complete
-          endfamily
-          family glwu
-            task jevs_glwu_wave_grid2obs_plots
-              trigger :TIME >= 1515 and ../../stats/glwu == complete
-          endfamily
-	  family nwps
-            task jevs_nwps_wave_grid2obs_plots
-              trigger :TIME >= 1530 and ../../stats/nwps == complete
           endfamily
           family mesoscale
             task jevs_mesoscale_sref_grid2obs_last90days_plots
@@ -1562,49 +1499,30 @@ suite evs_nco
               trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_mesoscale_sref_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_grid2obs_stats == complete
             task jevs_mesoscale_sref_precip_spatial_plots
               trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_mesoscale_sref_precip_stats == complete and ../../../../06/evs/stats/global_ens/jevs_global_ens_gefs_atmos_precip_stats == complete
-            task jevs_mesoscale_precip_plots_last31days
-              edit VHR '13'
-              time 14:40
             task jevs_mesoscale_precip_plots_last90days
               edit VHR '13'
               time 14:40
           endfamily
           family global_det
-            task jevs_global_det_wave_grid2obs_plots_last31days
-              trigger :TIME >= 1355 and ../../stats/global_det/jevs_global_det_gfs_wave_grid2obs_stats == complete
             task jevs_global_det_wave_grid2obs_plots_last90days
               trigger :TIME >= 1355 and ../../stats/global_det/jevs_global_det_gfs_wave_grid2obs_stats == complete
           endfamily
           family cam
             task jevs_cam_href_grid2obs_ecnt_last90days_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
-            task jevs_cam_href_grid2obs_ecnt_last31days_plots
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
             task jevs_cam_href_grid2obs_ctc_last90days_plots
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
-            task jevs_cam_href_grid2obs_ctc_last31days_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
             task jevs_cam_href_snowfall_last90days_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_precip_stats == complete
-            task jevs_cam_href_snowfall_last31days_plots
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_precip_stats == complete
             task jevs_cam_href_profile_last90days_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
-            task jevs_cam_href_profile_last31days_plots
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
             task jevs_cam_href_precip_last90days_plots
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_precip_stats == complete
-            task jevs_cam_href_precip_last31days_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_precip_stats == complete
             task jevs_cam_href_precip_spatial_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_precip_stats == complete
             task jevs_cam_href_spcoutlook_last90days_plots
               trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_spcoutlook_stats == complete
-            task jevs_cam_href_spcoutlook_last31days_plots
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_cam_href_spcoutlook_stats == complete
             task jevs_cam_href_grid2obs_cape_last90days_plots
-              trigger :TIME >= 1430 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
-            task jevs_cam_href_grid2obs_cape_last31days_plots
               trigger :TIME >= 1430 and ../../../../06/evs/stats/cam/jevs_cam_href_grid2obs_stats == complete
           endfamily 
         endfamily   # 12 plots
@@ -2080,10 +1998,7 @@ suite evs_nco
               trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
           endfamily
           family mesoscale
-            task jevs_mesoscale_snowfall_plots_last31days
-              edit VHR '13'
-              trigger ../../../../06/evs/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats_vhr_18 == complete
-          task jevs_mesoscale_snowfall_plots_last90days
+            task jevs_mesoscale_snowfall_plots_last90days
               edit VHR '13'
               trigger ../../../../06/evs/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_mesoscale_nam_snowfall_stats_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_mesoscale_rap_snowfall_stats_vhr_18 == complete
           endfamily
@@ -2092,53 +2007,28 @@ suite evs_nco
               trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_cfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_fnmoc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete
             task jevs_global_det_atmos_grid2obs_sfc_plots_last90days
               trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete
-            task jevs_global_det_atmos_grid2obs_sfc_plots_last31days
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete
             task jevs_global_det_atmos_grid2obs_ptype_plots_last90days
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete
-            task jevs_global_det_atmos_grid2obs_ptype_plots_last31days
               trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete
             task jevs_global_det_atmos_grid2obs_pres_levs_plots_last90days
               trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_cfs_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_fnmoc_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_jma_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2obs_stats == complete
-            task jevs_global_det_atmos_grid2obs_pres_levs_plots_last31days
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_global_det_cfs_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_fnmoc_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_jma_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2obs_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2obs_stats == complete
             task jevs_global_det_atmos_grid2grid_sst_plots_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2grid_stats == complete
-            task jevs_global_det_atmos_grid2grid_sst_plots_last31days
               trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2grid_stats == complete
             task jevs_global_det_atmos_grid2grid_snow_plots_last90days
               trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2grid_stats == complete
-            task jevs_global_det_atmos_grid2grid_snow_plots_last31days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2grid_stats == complete
             task jevs_global_det_atmos_grid2grid_sea_ice_plots_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete
-            task jevs_global_det_atmos_grid2grid_sea_ice_plots_last31days
               trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete
             task jevs_global_det_atmos_grid2grid_pres_levs_plots_last90days
               trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_cfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_fnmoc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_jma_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2grid_stats == complete
-            task jevs_global_det_atmos_grid2grid_pres_levs_plots_last31days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_cfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_fnmoc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_jma_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_imd_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ukmet_atmos_grid2grid_stats == complete
             task jevs_global_det_atmos_grid2grid_precip_plots_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_cmc_regional_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_dwd_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_jma_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_metfra_atmos_grid2grid_stats == complete
-            task jevs_global_det_atmos_grid2grid_precip_plots_last31days
               trigger :TIME >= 1945 and ../../stats/global_det/jevs_global_det_cmc_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_cmc_regional_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_dwd_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_ecmwf_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_gfs_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_jma_atmos_grid2grid_stats == complete and ../../stats/global_det/jevs_global_det_metfra_atmos_grid2grid_stats == complete
           endfamily
           family cam
-            task jevs_cam_precip_plots_last31days
-              edit VHR '21'
-              trigger ../../stats/cam/jevs_cam_hireswarw_precip_stats_vhr_22 == complete and  ../../stats/cam/jevs_cam_hireswarwmem2_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_hireswfv3_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_hrrr_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_namnest_precip_stats_vhr_22 == complete
             task jevs_cam_precip_plots_last90days
               edit VHR '21'
               trigger ../../stats/cam/jevs_cam_hireswarw_precip_stats_vhr_22 == complete and  ../../stats/cam/jevs_cam_hireswarwmem2_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_hireswfv3_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_hrrr_precip_stats_vhr_22 == complete and ../../stats/cam/jevs_cam_namnest_precip_stats_vhr_22 == complete
-            task jevs_cam_snowfall_plots_last31days
-              edit VHR '21'
-              trigger ../../stats/cam/jevs_cam_hireswarw_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswarwmem2_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswfv3_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hrrr_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_namnest_snowfall_stats_vhr_18 == complete
             task jevs_cam_snowfall_plots_last90days
               edit VHR '21'
               trigger ../../stats/cam/jevs_cam_hireswarw_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswarwmem2_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hireswfv3_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_hrrr_snowfall_stats_vhr_18 == complete and ../../stats/cam/jevs_cam_namnest_snowfall_stats_vhr_18 == complete
-            task jevs_cam_grid2obs_plots_last31days
-              edit VHR '21'
-              trigger ../../stats/cam/jevs_cam_hireswarw_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_hireswarwmem2_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_hireswfv3_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_hrrr_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_namnest_grid2obs_stats_vhr_21 == complete
             task jevs_cam_grid2obs_plots_last90days
               edit VHR '21'
               trigger ../../stats/cam/jevs_cam_hireswarw_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_hireswarwmem2_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_hireswfv3_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_hrrr_grid2obs_stats_vhr_21 == complete and ../../stats/cam/jevs_cam_namnest_grid2obs_stats_vhr_21 == complete


### PR DESCRIPTION
## Description of Changes

Cleaning up evs-nco.def files for EVS v2.0 by removing last31day jobs, removing a few last90day jobs for aqm, removing glwu and nwps jobs, and moving a few mesoscale jobs that were added to the wrong sections (prep, stats, plots) in previously merged PRs. I do not think this PR needs to be tested, but it does need to be looked at by a few developers before it is approved and merged. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

I do not think this PR needs to be tested, but it does need to be looked at by a few developers before it is approved and merged. 
