### PR TITLE
Add SPFH QC configs

### DIFF
--- a/ush/cam/cam_stats_grid2obs_var_defs.py
+++ b/ush/cam/cam_stats_grid2obs_var_defs.py
@@ -682,7 +682,7 @@ generate_stats_jobs_dict = {
                                     + "P250, P225, P200, P175, P150, P125, "
                                     + "P100, P75, P50'"),
                 'var1_obs_thresholds': '',
-                'var1_obs_options': 'set_attr_units = \\"g/kg\\"; convert(x)=x*1000',
+                'var1_obs_options': 'set_attr_units = \\"g/kg\\"; convert(x)=x*1000; censor_thresh = >1000.0&&<0.0; censor_val = -9999;',
             },
             'namnest': {
                 'var1_fcst_name': 'SPFH',
@@ -704,7 +704,7 @@ generate_stats_jobs_dict = {
                                     + "P250, P225, P200, P175, P150, P125, "
                                     + "P100, P75, P50, P30, P20, P10'"),
                 'var1_obs_thresholds': '',
-                'var1_obs_options': 'set_attr_units = \\"g/kg\\"; convert(x)=x*1000',
+                'var1_obs_options': 'set_attr_units = \\"g/kg\\"; convert(x)=x*1000; censor_thresh = >1000.0&&<0.0; censor_val = -9999;',
             },
             'output_types': {
                 'CTC': 'NONE',


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

SPFH verification statistics have been plagued by faulty observed data values (exceeding 1000 g/kg).  This fix restricts the validation data to those within the range of possible values, effectively removing the faulty data.  

**_NB:_  This can be considered a science change and should therefore be reviewed and merged _after_ EVSv2.0.0 is completed and submitted**

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

No - in fact this can be considered a science change and should be merged after EVSv2.0.0
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### Set up jobs

- symlink the EVS_fix directory locally as "fix"
- In each driver script for the listed jobs, edit the following environment variables:
**HOMEevs** - set to your test EVS directory
**COMIN** - if it exists, set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**SENDMAIL** - (_optional_) set to `"NO"`
**KEEPDATA** - (_optional_) set to `"YES"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### Running jobs

I recommend testing the following jobs:
```
jevs_stats_cam_hrrr_grid2obs.sh
jevs_stats_cam_namnest_grid2obs.sh
```
[Total: 2 stats jobs]

#### Testing jobs

- submit **both drivers** using `qsub -v vhr=12 $driver`

#### Checking jobs
- I will check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- I will also check that SPFH statistics output have possible observed values (<1000 g/kg)