### PR TITLE
clean the fhr_list before loop to prevent failure

### DIFF
--- a/ush/global_det/global_det_atmos_stats_grid2grid_create_anomaly.py
+++ b/ush/global_det/global_det_atmos_stats_grid2grid_create_anomaly.py
@@ -66,8 +66,8 @@ ENDDATE_dt = datetime.datetime.strptime(
 )
 valid_date_dt = STARTDATE_dt
 while valid_date_dt <= ENDDATE_dt:
-    for fhr_str in fhr_list:
-        fhr = int(fhr_str)
+    for fhr_str in [f for f in fhr_list if f.strip()]:
+        fhr = int(fhr_str)        
         init_date_dt = valid_date_dt - datetime.timedelta(hours=fhr)
         input_file = gda_util.format_filler(
             file_format, valid_date_dt, init_date_dt, str(fhr), {}

--- a/ush/global_det/global_det_atmos_stats_grid2grid_create_anomaly.py
+++ b/ush/global_det/global_det_atmos_stats_grid2grid_create_anomaly.py
@@ -67,7 +67,7 @@ ENDDATE_dt = datetime.datetime.strptime(
 valid_date_dt = STARTDATE_dt
 while valid_date_dt <= ENDDATE_dt:
     for fhr_str in [f for f in fhr_list if f.strip()]:
-        fhr = int(fhr_str)        
+        fhr = int(fhr_str)
         init_date_dt = valid_date_dt - datetime.timedelta(hours=fhr)
         input_file = gda_util.format_filler(
             file_format, valid_date_dt, init_date_dt, str(fhr), {}

--- a/ush/global_det/global_det_atmos_stats_grid2grid_create_wind_shear.py
+++ b/ush/global_det/global_det_atmos_stats_grid2grid_create_wind_shear.py
@@ -62,7 +62,7 @@ ENDDATE_dt = datetime.datetime.strptime(
 )
 valid_date_dt = STARTDATE_dt
 while valid_date_dt <= ENDDATE_dt:
-    for fhr_str in fhr_list:
+    for fhr_str in [f for f in fhr_list if f.strip()]:
         fhr = int(fhr_str)
         init_date_dt = valid_date_dt - datetime.timedelta(hours=fhr)
         input_file = gda_util.format_filler(


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

clean the fhr_list before loop to prevent failure

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? NO
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Test the  script jevs_global_det_imd_atmos_grid2grid_stats.sh
