### PR TITLE
Updating evs-nco.defs file (including job start times)

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -318,19 +318,19 @@ suite evs_nco
               trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2obs_vhr_01
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_00 == complete
+              trigger :TIME >= 0535 and :TIME < 1135 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2obs_vhr_02
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_01 == complete
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '02'
             task jevs_stats_aqm_atmos_grid2grid_vhr_00
               trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2grid_vhr_01
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_00 == complete
+              trigger :TIME >= 0535 and :TIME < 1135 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2grid_vhr_02
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_01 == complete
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '02'
           endfamily
           family analyses
@@ -818,55 +818,55 @@ suite evs_nco
               trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_aqm_atmos_grid2obs_vhr_04
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_03 == complete
+              trigger :TIME >= 0605 and :TIME < 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '04'
             task jevs_stats_aqm_atmos_grid2obs_vhr_05
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_04 == complete
+              trigger :TIME >= 0610 and :TIME < 1210 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '05'
             task jevs_stats_aqm_atmos_grid2obs_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_05 == complete
+              trigger :TIME >= 0615 and :TIME < 1215 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '06'
             task jevs_stats_aqm_atmos_grid2obs_vhr_07
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_06 == complete
+              trigger :TIME >= 0620 and :TIME < 1220 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '07'
             task jevs_stats_aqm_atmos_grid2obs_vhr_08
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_07 == complete
+              trigger :TIME >= 0625 and :TIME < 1225 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '08'
             task jevs_stats_aqm_atmos_grid2obs_vhr_09
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_08 == complete
+              trigger :TIME >= 0630 and :TIME < 1230 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '09'
             task jevs_stats_aqm_atmos_grid2obs_vhr_10
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_09 == complete
+              trigger :TIME >= 0635 and :TIME < 1235 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '10'
             task jevs_stats_aqm_atmos_grid2obs_vhr_11
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_10 == complete
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '11'
             task jevs_stats_aqm_atmos_grid2grid_vhr_03
               trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '03'
             task jevs_stats_aqm_atmos_grid2grid_vhr_04
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_03 == complete
+              trigger :TIME >= 0605 and :TIME < 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '04'
             task jevs_stats_aqm_atmos_grid2grid_vhr_05
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_04 == complete
+              trigger :TIME >= 0610 and :TIME < 1210 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '05'
             task jevs_stats_aqm_atmos_grid2grid_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_05 == complete
+              trigger :TIME >= 0615 and :TIME < 1215 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '06'
             task jevs_stats_aqm_atmos_grid2grid_vhr_07
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_06 == complete
+              trigger :TIME >= 0620 and :TIME < 1220 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '07'
             task jevs_stats_aqm_atmos_grid2grid_vhr_08
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_07 == complete
+              trigger :TIME >= 0625 and :TIME < 1225 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '08'
             task jevs_stats_aqm_atmos_grid2grid_vhr_09
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_08 == complete
+              trigger :TIME >= 0630 and :TIME < 1230 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '09'
             task jevs_stats_aqm_atmos_grid2grid_vhr_10
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_09 == complete
+              trigger :TIME >= 0635 and :TIME < 1235 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '10'
             task jevs_stats_aqm_atmos_grid2grid_vhr_11
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_10 == complete
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '11'
           endfamily
           family analyses
@@ -975,68 +975,68 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family subseasonal
             task jevs_prep_subseasonal_obs
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
             task jevs_prep_subseasonal_gefs
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
             task jevs_prep_subseasonal_cfs
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
           endfamily
           family nfcens
             task jevs_prep_nfcens_wave_grid2obs
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
           endfamily
           family global_det
             task jevs_prep_global_det_wave
-              time 13:15
+              trigger :TIME >= 1315 and :TIME < 1915
           endfamily
           family cam
             task jevs_prep_cam_radar_vhr_12
-              time 12:15
+              trigger :TIME >= 1220 and :TIME < 1815
               edit VHR '12'
             task jevs_prep_cam_radar_vhr_13
-              time 13:05
+              trigger :TIME >= 1305 and :TIME < 1905
               edit VHR '13'
             task jevs_prep_cam_radar_vhr_14
-              time 14:05
+              trigger :TIME >= 1405 and :TIME < 2005
               edit VHR '14'
             task jevs_prep_cam_radar_vhr_15
-              time 15:05
+              trigger :TIME >= 1505 and :TIME < 2105
               edit VHR '15'
             task jevs_prep_cam_radar_vhr_16
-              time 16:05
+              trigger :TIME >= 1605 and :TIME < 2205
               edit VHR '16'
             task jevs_prep_cam_radar_vhr_17
-              time 17:05
+              trigger :TIME >= 1705 and :TIME < 2305
               edit VHR '17'
-            task jevs_prep_cam_namnest_precip_vhr_12
-              time 12:00
-              edit VHR '12'
-            task jevs_prep_cam_hrrr_precip_vhr_12
-              time 12:00
-              edit VHR '12'
-            task jevs_prep_cam_hireswfv3_precip_vhr_12
-              time 12:00
-              edit VHR '12'
             task jevs_prep_cam_hireswarw_precip_vhr_12
               time 12:00
               edit VHR '12'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswarw_precip_vhr_12 == complete
               edit VHR '12'
-            task jevs_prep_cam_hrrr_severe_vhr_12
-              time 12:00
+            task jevs_prep_cam_hireswfv3_precip_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswarwmem2_precip_vhr_12 == complete
               edit VHR '12'
-            task jevs_prep_cam_namnest_severe_vhr_12
-              time 12:00
+            task jevs_prep_cam_hrrr_precip_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswfv3_precip_vhr_12 == complete
+              edit VHR '12'
+            task jevs_prep_cam_namnest_precip_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hrrr_precip_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_hireswarw_severe_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800
               edit VHR '12'
             task jevs_prep_cam_hireswarwmem2_severe_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswarw_severe_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_hireswfv3_severe_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete
+              edit VHR '12'
+            task jevs_prep_cam_hrrr_severe_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswfv3_severe_vhr_12 == complete
+              edit VHR '12'
+            task jevs_prep_cam_namnest_severe_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hrrr_severe_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_href_severe_vhr_12
               trigger ./jevs_prep_cam_hireswarw_severe_vhr_12 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_12 == complete and ./jevs_prep_cam_hrrr_severe_vhr_12 == complete and ./jevs_prep_cam_namnest_severe_vhr_12 == complete
@@ -1047,67 +1047,238 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family nfcens
             task jevs_stats_nfcens_wave_grid2obs
-              trigger :TIME >= 1430 and ../../prep/nfcens == complete
+              trigger :TIME >= 1430 and :TIME < 2030 and ../../prep/nfcens == complete
           endfamily
           family subseasonal
             task jevs_stats_subseasonal_cfs_grid2obs
-              trigger :TIME >= 1530 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1530 and :TIME < 2130 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
             task jevs_stats_subseasonal_cfs_grid2grid
-              trigger :TIME >= 1600 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1600 and :TIME < 2200 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
             task jevs_stats_subseasonal_gefs_grid2obs
-              trigger :TIME >= 1730 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1630 and :TIME < 2230 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
             task jevs_stats_subseasonal_gefs_grid2grid
-              trigger :TIME >= 1710 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1610 and :TIME < 2210 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
           endfamily
           family mesoscale
             task jevs_stats_mesoscale_nam_precip_vhr_12
-              time 12:10
+              trigger :TIME >= 1220 and :TIME < 1810
               edit VHR '12'
             task jevs_stats_mesoscale_nam_precip_vhr_13
-              time 13:10
+              trigger :TIME >= 1310 and :TIME < 1910
               edit VHR '13'
             task jevs_stats_mesoscale_nam_precip_vhr_14
-              time 14:10
+              trigger :TIME >= 1410 and :TIME < 2010
               edit VHR '14'
             task jevs_stats_mesoscale_nam_precip_vhr_15
-              time 15:10
+              trigger :TIME >= 1510 and :TIME < 2110
               edit VHR '15'
             task jevs_stats_mesoscale_nam_precip_vhr_16
-              time 16:10
+              trigger :TIME >= 1610 and :TIME < 2210
               edit VHR '16'
             task jevs_stats_mesoscale_nam_precip_vhr_17
-              time 17:10
+              trigger :TIME >= 1710 and :TIME < 2310
               edit VHR '17'
             task jevs_stats_mesoscale_rap_precip_vhr_12
-              time 12:10
+              trigger :TIME >= 1220 and :TIME < 1810
               edit VHR '12'
             task jevs_stats_mesoscale_rap_precip_vhr_13
-              time 13:10
+              trigger :TIME >= 1310 and :TIME < 1910
               edit VHR '13'
             task jevs_stats_mesoscale_rap_precip_vhr_14
-              time 14:10
+              trigger :TIME >= 1410 and :TIME < 2010
               edit VHR '14'
             task jevs_stats_mesoscale_rap_precip_vhr_15
-              time 15:10
+              trigger :TIME >= 1510 and :TIME < 2110
               edit VHR '15'
             task jevs_stats_mesoscale_rap_precip_vhr_16
-              time 16:10
+              trigger :TIME >= 1610 and :TIME < 2210
               edit VHR '16'
             task jevs_stats_mesoscale_rap_precip_vhr_17
-              time 17:10
+              trigger :TIME >= 1710 and :TIME < 2310
               edit VHR '17'
             task jevs_stats_mesoscale_nam_snowfall_vhr_12
-              time 12:15
+              trigger :TIME >= 1220 and :TIME < 1815
               edit VHR '12'
             task jevs_stats_mesoscale_rap_snowfall_vhr_12
-              time 12:15
+              trigger :TIME >= 1220 and :TIME < 1815
               edit VHR '12'
           endfamily
           family global_det
             task jevs_stats_global_det_gfs_wave_grid2obs
-              trigger :TIME >= 1325 and ../../prep/global_det/jevs_prep_global_det_wave == complete
+              trigger :TIME >= 1325 and :TIME < 1925 and ../../prep/global_det/jevs_prep_global_det_wave == complete
           endfamily
           family cam
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_12
+              trigger :TIME >= 1220 and :TIME < 1815
+              edit VHR '12'
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_13
+              trigger :TIME >= 1300 and :TIME < 1900
+              edit VHR '13'
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_14
+              trigger :TIME >= 1400 and :TIME < 2000
+              edit VHR '14'
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_15
+              trigger :TIME >= 1500 and :TIME < 2100
+              edit VHR '15'
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_16
+              trigger :TIME >= 1600 and :TIME < 2200
+              edit VHR '16'
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_17
+              trigger :TIME >= 1610 and :TIME < 2210
+              edit VHR '17'
+            task jevs_stats_cam_hireswarwmem2_radar_vhr_12
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../prep/cam/jevs_prep_cam_radar_vhr_12 == complete
+              edit VHR '12'
+            task jevs_stats_cam_hireswarwmem2_radar_vhr_13
+              trigger :TIME >= 1340 and :TIME < 1940 and ../../prep/cam/jevs_prep_cam_radar_vhr_13 == complete
+              edit VHR '13'
+            task jevs_stats_cam_hireswarwmem2_radar_vhr_14
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../prep/cam/jevs_prep_cam_radar_vhr_14 == complete
+              edit VHR '14'
+            task jevs_stats_cam_hireswarwmem2_radar_vhr_15
+              trigger :TIME >= 1540 and :TIME < 2140 and ../../prep/cam/jevs_prep_cam_radar_vhr_15 == complete
+              edit VHR '15'
+            task jevs_stats_cam_hireswarwmem2_radar_vhr_16
+              trigger :TIME >= 1640 and :TIME < 2240 and ../../prep/cam/jevs_prep_cam_radar_vhr_16 == complete
+              edit VHR '16'
+            task jevs_stats_cam_hireswarwmem2_radar_vhr_17
+              trigger :TIME >= 1740 and :TIME < 2340 and ../../prep/cam/jevs_prep_cam_radar_vhr_17 == complete
+              edit VHR '17'
+            task jevs_stats_cam_hireswarw_radar_vhr_12
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../prep/cam/jevs_prep_cam_radar_vhr_12 == complete
+              edit VHR '12'
+            task jevs_stats_cam_hireswarw_radar_vhr_13
+              trigger :TIME >= 1340 and :TIME < 1940 and ../../prep/cam/jevs_prep_cam_radar_vhr_13 == complete
+              edit VHR '13'
+            task jevs_stats_cam_hireswarw_radar_vhr_14
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../prep/cam/jevs_prep_cam_radar_vhr_14 == complete
+              edit VHR '14'
+            task jevs_stats_cam_hireswarw_radar_vhr_15
+              trigger :TIME >= 1540 and :TIME < 2140 and ../../prep/cam/jevs_prep_cam_radar_vhr_15 == complete
+              edit VHR '15'
+            task jevs_stats_cam_hireswarw_radar_vhr_16
+              trigger :TIME >= 1640 and :TIME < 2240 and ../../prep/cam/jevs_prep_cam_radar_vhr_16 == complete
+              edit VHR '16'
+            task jevs_stats_cam_hireswarw_radar_vhr_17
+              trigger :TIME >= 1740 and :TIME < 2340 and ../../prep/cam/jevs_prep_cam_radar_vhr_17 == complete
+              edit VHR '17'
+            task jevs_stats_cam_hireswfv3_radar_vhr_12
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../prep/cam/jevs_prep_cam_radar_vhr_12 == complete
+              edit VHR '12'
+            task jevs_stats_cam_hireswfv3_radar_vhr_13
+              trigger :TIME >= 1340 and :TIME < 1940 and ../../prep/cam/jevs_prep_cam_radar_vhr_13 == complete
+              edit VHR '13'
+            task jevs_stats_cam_hireswfv3_radar_vhr_14
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../prep/cam/jevs_prep_cam_radar_vhr_14 == complete
+              edit VHR '14'
+            task jevs_stats_cam_hireswfv3_radar_vhr_15
+              trigger :TIME >= 1540 and :TIME < 2140 and ../../prep/cam/jevs_prep_cam_radar_vhr_15 == complete
+              edit VHR '15'
+            task jevs_stats_cam_hireswfv3_radar_vhr_16
+              trigger :TIME >= 1640 and :TIME < 2240 and ../../prep/cam/jevs_prep_cam_radar_vhr_16 == complete
+              edit VHR '16'
+            task jevs_stats_cam_hireswfv3_radar_vhr_17
+              trigger :TIME >= 1740 and :TIME < 2340 and ../../prep/cam/jevs_prep_cam_radar_vhr_17 == complete
+              edit VHR '17'
+            task jevs_stats_cam_href_radar_vhr_12
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../prep/cam/jevs_prep_cam_radar_vhr_12 == complete
+              edit VHR '12'
+            task jevs_stats_cam_href_radar_vhr_13
+              trigger :TIME >= 1340 and :TIME < 1940 and ../../prep/cam/jevs_prep_cam_radar_vhr_13 == complete
+              edit VHR '13'
+            task jevs_stats_cam_href_radar_vhr_14
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../prep/cam/jevs_prep_cam_radar_vhr_14 == complete
+              edit VHR '14'
+            task jevs_stats_cam_href_radar_vhr_15
+              trigger :TIME >= 1540 and :TIME < 2140 and ../../prep/cam/jevs_prep_cam_radar_vhr_15 == complete
+              edit VHR '15'
+            task jevs_stats_cam_href_radar_vhr_16
+              trigger :TIME >= 1640 and :TIME < 2240 and ../../prep/cam/jevs_prep_cam_radar_vhr_16 == complete
+              edit VHR '16'
+            task jevs_stats_cam_href_radar_vhr_17
+              trigger :TIME >= 1740 and :TIME < 2340 and ../../prep/cam/jevs_prep_cam_radar_vhr_17 == complete
+              edit VHR '17'
+            task jevs_stats_cam_hrrr_radar_vhr_12
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../prep/cam/jevs_prep_cam_radar_vhr_12 == complete
+              edit VHR '12'
+            task jevs_stats_cam_hrrr_radar_vhr_13
+              trigger :TIME >= 1340 and :TIME < 1940 and ../../prep/cam/jevs_prep_cam_radar_vhr_13 == complete
+              edit VHR '13'
+            task jevs_stats_cam_hrrr_radar_vhr_14
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../prep/cam/jevs_prep_cam_radar_vhr_14 == complete
+              edit VHR '14'
+            task jevs_stats_cam_hrrr_radar_vhr_15
+              trigger :TIME >= 1540 and :TIME < 2140 and ../../prep/cam/jevs_prep_cam_radar_vhr_15 == complete
+              edit VHR '15'
+            task jevs_stats_cam_hrrr_radar_vhr_16
+              trigger :TIME >= 1640 and :TIME < 2240 and ../../prep/cam/jevs_prep_cam_radar_vhr_16 == complete
+              edit VHR '16'
+            task jevs_stats_cam_hrrr_radar_vhr_17
+              trigger :TIME >= 1740 and :TIME < 2340 and ../../prep/cam/jevs_prep_cam_radar_vhr_17 == complete
+              edit VHR '17'
+            task jevs_stats_cam_namnest_radar_vhr_12
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../prep/cam/jevs_prep_cam_radar_vhr_12 == complete
+              edit VHR '12'
+            task jevs_stats_cam_namnest_radar_vhr_13
+              trigger :TIME >= 1340 and :TIME < 1940 and ../../prep/cam/jevs_prep_cam_radar_vhr_13 == complete
+              edit VHR '13'
+            task jevs_stats_cam_namnest_radar_vhr_14
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../prep/cam/jevs_prep_cam_radar_vhr_14 == complete
+              edit VHR '14'
+            task jevs_stats_cam_namnest_radar_vhr_15
+              trigger :TIME >= 1540 and :TIME < 2140 and ../../prep/cam/jevs_prep_cam_radar_vhr_15 == complete
+              edit VHR '15'
+            task jevs_stats_cam_namnest_radar_vhr_16
+              trigger :TIME >= 1640 and :TIME < 2240 and ../../prep/cam/jevs_prep_cam_radar_vhr_16 == complete
+              edit VHR '16'
+            task jevs_stats_cam_namnest_radar_vhr_17
+              trigger :TIME >= 1740 and :TIME < 2340 and ../../prep/cam/jevs_prep_cam_radar_vhr_17 == complete
+              edit VHR '17'
+            task jevs_stats_cam_hireswarw_snowfall_vhr_12
+              trigger :TIME >= 1230 and :TIME < 1830
+              edit VHR '12'
+            task jevs_stats_cam_hireswarwmem2_snowfall_vhr_12
+              trigger :TIME >= 1230 and :TIME < 1830
+              edit VHR '12'
+            task jevs_stats_cam_hireswfv3_snowfall_vhr_12
+              trigger :TIME >= 1230 and :TIME < 1830
+              edit VHR '12'
+            task jevs_stats_cam_hrrr_snowfall_vhr_12
+              trigger :TIME >= 1230 and :TIME < 1830
+              edit VHR '12'
+            task jevs_stats_cam_namnest_snowfall_vhr_12
+              trigger :TIME >= 1230 and :TIME < 1830
+              edit VHR '12'
+            task jevs_stats_cam_hireswarw_grid2obs_vhr_12
+              trigger :TIME >= 1220 and :TIME < 1815
+              edit VHR '12'
+            task jevs_stats_cam_hireswarw_grid2obs_vhr_15
+              trigger :TIME >= 1500 and :TIME < 2100
+              edit VHR '15'
+            task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12
+              trigger :TIME >= 1220 and :TIME < 1815
+              edit VHR '12'
+            task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15
+              trigger :TIME >= 1500 and :TIME < 2100
+              edit VHR '15'
+            task jevs_stats_cam_hireswfv3_grid2obs_vhr_12
+              trigger :TIME >= 1220 and :TIME < 1815
+              edit VHR '12'
+            task jevs_stats_cam_hireswfv3_grid2obs_vhr_15
+              trigger :TIME >= 1500 and :TIME < 2100
+              edit VHR '15'
+            task jevs_stats_cam_hrrr_grid2obs_vhr_12
+              trigger :TIME >= 1220 and :TIME < 1815
+              edit VHR '12'
+            task jevs_stats_cam_hrrr_grid2obs_vhr_15
+              trigger :TIME >= 1500 and :TIME < 2100
+              edit VHR '15'
+            task jevs_stats_cam_namnest_grid2obs_vhr_12
+              trigger :TIME >= 1220 and :TIME < 1815
+              edit VHR '12'
+            task jevs_stats_cam_namnest_grid2obs_vhr_15
+              trigger :TIME >= 1500 and :TIME < 2100
+              edit VHR '15'
             task jevs_stats_cam_hireswarwmem2_severe
               trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_12 == complete
               edit VHR '08'
@@ -1120,333 +1291,161 @@ suite evs_nco
             task jevs_stats_cam_href_severe
               trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_href_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_href_severe_prep_vhr_12 == complete
               edit VHR '08'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_12
-              time 12:15
-              edit VHR '12'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_13
-              time 13:00
-              edit VHR '13'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_14
-              time 14:00
-              edit VHR '14'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_16
-              time 16:00
-              edit VHR '16'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_17    # walltime=02:00:00
-              time 16:10
-              edit VHR '17'
-            task jevs_stats_cam_hireswarwmem2_radar_vhr_12
-              time 12:40
-              edit VHR '12'
-            task jevs_stats_cam_hireswarwmem2_radar_vhr_13
-              time 13:40
-              edit VHR '13'
-            task jevs_stats_cam_hireswarwmem2_radar_vhr_14
-              time 14:40
-              edit VHR '14'
-            task jevs_stats_cam_hireswarwmem2_radar_vhr_15
-              time 15:40
-              edit VHR '15'
-            task jevs_stats_cam_hireswarwmem2_radar_vhr_16
-              time 16:40
-              edit VHR '16'
-            task jevs_stats_cam_hireswarwmem2_radar_vhr_17
-              time 17:40
-              edit VHR '17'
-            task jevs_stats_cam_hireswarw_radar_vhr_12
-              time 12:40
-              edit VHR '12'
-            task jevs_stats_cam_hireswarw_radar_vhr_13
-              time 13:40
-              edit VHR '13'
-            task jevs_stats_cam_hireswarw_radar_vhr_14
-              time 14:40
-              edit VHR '14'
-            task jevs_stats_cam_hireswarw_radar_vhr_15
-              time 15:40
-              edit VHR '15'
-            task jevs_stats_cam_hireswarw_radar_vhr_16
-              time 16:40
-              edit VHR '16'
-            task jevs_stats_cam_hireswarw_radar_vhr_17
-              time 17:40
-              edit VHR '17'
-            task jevs_stats_cam_hireswfv3_radar_vhr_12
-              time 12:40
-              edit VHR '12'
-            task jevs_stats_cam_hireswfv3_radar_vhr_13
-              time 13:40
-              edit VHR '13'
-            task jevs_stats_cam_hireswfv3_radar_vhr_14
-              time 14:40
-              edit VHR '14'
-            task jevs_stats_cam_hireswfv3_radar_vhr_15
-              time 15:40
-              edit VHR '15'
-            task jevs_stats_cam_hireswfv3_radar_vhr_16
-              time 16:40
-              edit VHR '16'
-            task jevs_stats_cam_hireswfv3_radar_vhr_17
-              time 17:40
-              edit VHR '17'
-            task jevs_stats_cam_href_radar_vhr_12
-              time 12:40
-              edit VHR '12'
-            task jevs_stats_cam_href_radar_vhr_13
-              time 13:40
-              edit VHR '13'
-            task jevs_stats_cam_href_radar_vhr_14
-              time 14:40
-              edit VHR '14'
-            task jevs_stats_cam_href_radar_vhr_15
-              time 15:40
-              edit VHR '15'
-            task jevs_stats_cam_href_radar_vhr_16
-              time 16:40
-              edit VHR '16'
-            task jevs_stats_cam_href_radar_vhr_17
-              time 17:40
-              edit VHR '17'
-            task jevs_stats_cam_hrrr_radar_vhr_12
-              time 12:40
-              edit VHR '12'
-            task jevs_stats_cam_hrrr_radar_vhr_13
-              time 13:40
-              edit VHR '13'
-            task jevs_stats_cam_hrrr_radar_vhr_14
-              time 14:40
-              edit VHR '14'
-            task jevs_stats_cam_hrrr_radar_vhr_15
-              time 15:40
-              edit VHR '15'
-            task jevs_stats_cam_hrrr_radar_vhr_16
-              time 16:40
-              edit VHR '16'
-            task jevs_stats_cam_hrrr_radar_vhr_17
-              time 17:40
-              edit VHR '17'
-            task jevs_stats_cam_namnest_radar_vhr_12
-              time 12:40
-              edit VHR '12'
-            task jevs_stats_cam_namnest_radar_vhr_13
-              time 13:40
-              edit VHR '13'
-            task jevs_stats_cam_namnest_radar_vhr_14
-              time 14:40
-              edit VHR '14'
-            task jevs_stats_cam_namnest_radar_vhr_15
-              time 15:40
-              edit VHR '15'
-            task jevs_stats_cam_namnest_radar_vhr_16
-              time 16:40
-              edit VHR '16'
-            task jevs_stats_cam_namnest_radar_vhr_17
-              time 17:40
-              edit VHR '17'
-            task jevs_stats_cam_hireswarw_snowfall_vhr_12
-              time 12:30
-              edit VHR '12'
-            task jevs_stats_cam_hireswarwmem2_snowfall_vhr_12
-              time 12:30
-              edit VHR '12'
-            task jevs_stats_cam_hireswfv3_snowfall_vhr_12
-              time 12:30
-              edit VHR '12'
-            task jevs_stats_cam_hrrr_snowfall_vhr_12
-              time 12:30
-              edit VHR '12'
-            task jevs_stats_cam_namnest_snowfall_vhr_12
-              time 12:30
-              edit VHR '12'
-            task jevs_stats_cam_hireswarw_grid2obs_vhr_12
-              time 12:00
-              edit VHR '12'
-            task jevs_stats_cam_hireswarw_grid2obs_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12
-              time 12:15
-              edit VHR '12'
-            task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_stats_cam_hireswfv3_grid2obs_vhr_12
-              time 12:15
-              edit VHR '12'
-            task jevs_stats_cam_hireswfv3_grid2obs_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_stats_cam_hrrr_grid2obs_vhr_12
-              time 12:15
-              edit VHR '12'
-            task jevs_stats_cam_hrrr_grid2obs_vhr_15
-              time 15:00
-              edit VHR '15'
-            task jevs_stats_cam_namnest_grid2obs_vhr_12
-              time 12:15
-              edit VHR '12'
-            task jevs_stats_cam_namnest_grid2obs_vhr_15
-              time 15:00
-              edit VHR '15'
           endfamily
           family aqm
             task jevs_stats_aqm_atmos_grid2obs_vhr_12
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1220 and :TIME < 1810 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '12'
             task jevs_stats_aqm_atmos_grid2obs_vhr_13
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete
+              trigger :TIME >= 1225 and :TIME < 1825 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete
               edit VHR '13'
             task jevs_stats_aqm_atmos_grid2obs_vhr_14
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete
               edit VHR '14'
             task jevs_stats_aqm_atmos_grid2obs_vhr_15
-              trigger :TIME >= 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1235 and :TIME < 1835 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_14 == complete
               edit VHR '15'
             task jevs_stats_aqm_atmos_grid2obs_vhr_16
-              trigger :TIME >= 1215 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_15 == complete
               edit VHR '16'
             task jevs_stats_aqm_atmos_grid2obs_vhr_17
-              trigger :TIME >= 1225 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1245 and :TIME < 1845 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_16 == complete
               edit VHR '17'
             task jevs_stats_aqm_atmos_grid2obs_vhr_18
-              trigger :TIME >= 1235 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1250 and :TIME < 1850 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_17 == complete
               edit VHR '18'
             task jevs_stats_aqm_atmos_grid2obs_vhr_19
-              trigger :TIME >= 1245 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1255 and :TIME < 1855 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_aqm_atmos_grid2obs_vhr_20
-              trigger :TIME >= 1255 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_19 == complete
               edit VHR '20'
             task jevs_stats_aqm_atmos_grid2obs_vhr_21
-              trigger :TIME >= 1305 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1305 and :TIME < 1905 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_20 == complete
               edit VHR '21'
             task jevs_stats_aqm_atmos_grid2obs_vhr_22
-              trigger :TIME >= 1315 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 1310 and :TIME < 1910 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_aqm_atmos_grid2obs_vhr_23
-              trigger :TIME >= 1330 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_11 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_22 == complete
+              trigger :TIME >= 1330 and :TIME < 1930 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_aqm_atmos_grid2grid_vhr_12
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1220 and :TIME < 1820 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '12'
             task jevs_stats_aqm_atmos_grid2grid_vhr_13
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete
+              trigger :TIME >= 1225 and :TIME < 1825 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete
               edit VHR '13'
             task jevs_stats_aqm_atmos_grid2grid_vhr_14
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete
               edit VHR '14'
             task jevs_stats_aqm_atmos_grid2grid_vhr_15
-              trigger :TIME >= 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1235 and :TIME < 1835 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_14 == complete
               edit VHR '15'
             task jevs_stats_aqm_atmos_grid2grid_vhr_16
-              trigger :TIME >= 1215 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_15 == complete
               edit VHR '16'
             task jevs_stats_aqm_atmos_grid2grid_vhr_17
-              trigger :TIME >= 1225 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1245 and :TIME < 1845 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_16 == complete
               edit VHR '17'
             task jevs_stats_aqm_atmos_grid2grid_vhr_18
-              trigger :TIME >= 1235 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1250 and :TIME < 1850 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_17 == complete
               edit VHR '18'
             task jevs_stats_aqm_atmos_grid2grid_vhr_19
-              trigger :TIME >= 1245 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1255 and :TIME < 1855 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_aqm_atmos_grid2grid_vhr_20
-              trigger :TIME >= 1255 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_19 == complete
               edit VHR '20'
             task jevs_stats_aqm_atmos_grid2grid_vhr_21
-              trigger :TIME >= 1305 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1305 and :TIME < 1905 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_20 == complete
               edit VHR '21'
-              edit VHR '23'
             task jevs_stats_aqm_atmos_grid2grid_vhr_22
-              trigger :TIME >= 1315 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 1310 and :TIME < 1910 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_aqm_atmos_grid2grid_vhr_23
-              trigger :TIME >= 1330 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_11 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_22 == complete
+              trigger :TIME >= 1330 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_11 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_22 == complete
               edit VHR '23'
           endfamily
           family analyses
             task jevs_stats_analyses_urma_grid2obs_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800
               edit VHR '12'
             task jevs_stats_analyses_urma_grid2obs_vhr_13
-              time 13:00
+              trigger :TIME >= 1300 and :TIME < 1900
               edit VHR '13'
             task jevs_stats_analyses_urma_grid2obs_vhr_14
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
               edit VHR '14'
             task jevs_stats_analyses_urma_grid2obs_vhr_15
-              time 15:00
+              trigger :TIME >= 1500 and :TIME < 2100
               edit VHR '15'
             task jevs_stats_analyses_urma_grid2obs_vhr_16
-              time 16:00
+              trigger :TIME >= 1600 and :TIME < 2200
               edit VHR '16'
             task jevs_stats_analyses_urma_grid2obs_vhr_17
-              time 17:00
+              trigger :TIME >= 1700 and :TIME < 2300
               edit VHR '17'
             task jevs_stats_analyses_rtma_grid2obs_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800
               edit VHR '12'
             task jevs_stats_analyses_rtma_grid2obs_vhr_13
-              time 13:00
+              trigger :TIME >= 1300 and :TIME < 1900
               edit VHR '13'
             task jevs_stats_analyses_rtma_grid2obs_vhr_14
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
               edit VHR '14'
             task jevs_stats_analyses_rtma_grid2obs_vhr_15
-              time 15:00
+              trigger :TIME >= 1500 and :TIME < 2100
               edit VHR '15'
             task jevs_stats_analyses_rtma_grid2obs_vhr_16
-              time 16:00
+              trigger :TIME >= 1600 and :TIME < 2200
               edit VHR '16'
             task jevs_stats_analyses_rtma_grid2obs_vhr_17
-              time 17:00
+              trigger :TIME >= 1700 and :TIME < 2300
               edit VHR '17'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_12
-              time 12:00
+              trigger :TIME >= 1200 and :TIME < 1800
               edit VHR '12'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_13
-              time 13:00
+              trigger :TIME >= 1300 and :TIME < 1900
               edit VHR '13'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_14
-              time 14:00
+              trigger :TIME >= 1400 and :TIME < 2000
               edit VHR '14'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_15
-              time 15:00
+              trigger :TIME >= 1500 and :TIME < 2100
               edit VHR '15'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_16
-              time 16:00
+              trigger :TIME >= 1600 and :TIME < 2200
               edit VHR '16'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_17
-              time 17:00
+              trigger :TIME >= 1700 and :TIME < 2300
               edit VHR '17'
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_12
-              trigger :TIME >= 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
-              edit VHR '12'
-            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_12
-              trigger :TIME >= 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 1330 and :TIME < 1930 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '12'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_15
-              trigger :TIME >= 1345 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
-              edit VHR '15'
-            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_15
-              trigger :TIME >= 1345 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 1345 and :TIME < 1945 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '15'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_18
-              trigger :TIME >= 1400 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
-              edit VHR '18'
-            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_18
-              trigger :TIME >= 1400 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '18'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_21
-              trigger :TIME >= 1430 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ../../../../00/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_12 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_15 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_18 == complete
+              trigger :TIME >= 1430 and :TIME < 2030 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ../../../../00/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_12 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_15 == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_18 == complete
               edit VHR '21'
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_12
+              trigger :TIME >= 1330 and :TIME < 1930 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              edit VHR '12'
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_15
+              trigger :TIME >= 1345 and :TIME < 1945 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              edit VHR '15'
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_18
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              edit VHR '18'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_21
-              trigger :TIME >= 1415 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ../../../../00/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00 == complete ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_12 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_15 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_18 == complete
+              trigger :TIME >= 1430 and :TIME < 2030 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ../../../../00/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00 == complete ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete and ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete ../../../../06/evs/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_12 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_15 == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_18 == complete
               edit VHR '21'
           endfamily
         endfamily   # 12 stats
@@ -1454,82 +1453,82 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family global_ens
             task jevs_plots_global_ens_atmos_naefs_precip_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
             task jevs_plots_global_ens_atmos_naefs_grid2obs_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_naefs_grid2grid_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid == complete
             task jevs_plots_global_ens_atmos_gefs_sst_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst == complete
             task jevs_plots_global_ens_atmos_gefs_snowfall_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall == complete
             task jevs_plots_global_ens_atmos_gefs_sea_ice_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice == complete
             task jevs_plots_global_ens_atmos_gefs_cape_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_profile3_last90days
-              trigger :TIME >= 1500 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1500 and :TIME < 2100 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_profile2_last90days
-              trigger :TIME >= 1600 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1600 and :TIME < 2200 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_profile1_last90days
               trigger :TIME >= 1700 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_precip_spatial
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip_ == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip_ == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
             task jevs_plots_global_ens_atmos_naefs_precip_spatial
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
             task jevs_plots_global_ens_atmos_gefs_precip_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
             task jevs_plots_global_ens_atmos_gefs_grid2obs_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_grid2obs_separate_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_grid2grid_last90days
-              trigger :TIME >= 1400 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid == complete
           endfamily
           family nfcens
 	    task jevs_plots_nfcens_wave_grid2obs_last90days
-	      trigger :TIME >= 1500 and ../../stats/nfcens == complete
+	      trigger :TIME >= 1500 and :TIME < 2100 and ../../stats/nfcens == complete
           endfamily
           family mesoscale
             task jevs_plots_mesoscale_sref_grid2obs_last90days
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_mesoscale_sref_precip_last90days
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
             task jevs_plots_mesoscale_sref_cnv_last90days
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_mesoscale_sref_cape_last90days
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs_stats == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_mesoscale_sref_cloud_last90days
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_mesoscale_sref_td2m_last90days
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_mesoscale_sref_precip_spatial
-              trigger :TIME >= 1300 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
             task jevs_plots_mesoscale_precip_last90days
+              trigger :TIME >= 1440 and :TIME < 2040 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_mesoscale_rap_precip == complete
               edit VHR '13'
-              trigger :TIME >= 1440 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_mesoscale_rap_precip == complete
           endfamily
           family global_det
             task jevs_plots_global_det_wave_grid2obs_last90days
-              trigger :TIME >= 1355 and ../../stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs == complete
+              trigger :TIME >= 1355 and :TIME >= 1955 and ../../stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs == complete
           endfamily
           family cam
             task jevs_plots_cam_href_grid2obs_ecnt_last90days
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
             task jevs_plots_cam_href_grid2obs_ctc_last90days
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
             task jevs_plots_cam_href_snowfall_last90days
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_precip == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_snowfall == complete
             task jevs_plots_cam_href_profile_last90days
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
             task jevs_plots_cam_href_precip_last90days
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_precip == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_precip == complete
             task jevs_plots_cam_href_precip_spatial
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_precip == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_precip == complete
             task jevs_plots_cam_href_spcoutlook_last90days
-              trigger :TIME >= 1230 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_spcoutlook == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_spcoutlook == complete
             task jevs_plots_cam_href_grid2obs_cape_last90days
-              trigger :TIME >= 1430 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
+              trigger :TIME >= 1430 and :TIME < 2030 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
           endfamily 
         endfamily   # 12 plots
       endfamily  # evs
@@ -2005,8 +2004,8 @@ suite evs_nco
           endfamily
           family mesoscale
             task jevs_plots_mesoscale_snowfall_last90days
+              trigger :TIME >= 1830 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_18 == complete
               edit VHR '13'
-              trigger ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_18 == complete
           endfamily
           family global_det
             task jevs_plots_global_det_atmos_headline

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1508,7 +1508,7 @@ suite evs_nco
           endfamily
           family global_det
             task jevs_plots_global_det_wave_grid2obs_last90days
-              trigger :TIME >= 1355 and :TIME >= 1955 and ../../stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs == complete
+              trigger :TIME >= 1355 and :TIME < 1955 and ../../stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs == complete
           endfamily
           family cam
             task jevs_plots_cam_href_grid2obs_ecnt_last90days

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -50,19 +50,19 @@ suite evs_nco
               trigger :TIME >= 0505 and :TIME < 1105
               edit VHR '05'
             task jevs_prep_cam_hireswarw_precip_vhr_00
-              trigger :TIME >= 0000 and :TIME < 0600
+              trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_00
-              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswarw_precip_vhr_00 == complete
+              trigger :TIME >= 0030 and :TIME < 0630 and jevs_prep_cam_hireswarw_precip_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_hireswfv3_precip_vhr_00
-              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswarwmem2_precip_vhr_00 == complete
+              trigger :TIME >= 0030 and :TIME < 0630 and jevs_prep_cam_hireswarwmem2_precip_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_hrrr_precip_vhr_00
-              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswfv3_precip_vhr_00 == complete
+              trigger :TIME >= 0030 and :TIME < 0630 and jevs_prep_cam_hireswfv3_precip_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_namnest_precip_vhr_00
-              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hrrr_precip_vhr_00 == complete
+              trigger :TIME >= 0030 and :TIME < 0630 and jevs_prep_cam_hrrr_precip_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_hireswarw_severe_vhr_00
               trigger :TIME >= 0000 and :TIME < 0600
@@ -495,19 +495,19 @@ suite evs_nco
               trigger :TIME >= 1105 and :TIME < 1705
               edit VHR '11'
             task jevs_prep_cam_hireswarw_precip_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hireswarw_precip_vhr_06 == complete
+              trigger :TIME >= 0630 and :TIME < 1230 and jevs_prep_cam_hireswarw_precip_vhr_06 == complete
               edit VHR '06'
             task jevs_prep_cam_hireswfv3_precip_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hireswarwmem2_precip_vhr_06 == complete
+              trigger :TIME >= 0630 and :TIME < 1230 and jevs_prep_cam_hireswarwmem2_precip_vhr_06 == complete
               edit VHR '06'
             task jevs_prep_cam_hrrr_precip_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hireswfv3_precip_vhr_06 == complete
+              trigger :TIME >= 0630 and :TIME < 1230 and jevs_prep_cam_hireswfv3_precip_vhr_06 == complete
               edit VHR '06'
             task jevs_prep_cam_namnest_precip_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hrrr_precip_vhr_06 == complete
+              trigger :TIME >= 0630 and :TIME < 1230 and jevs_prep_cam_hrrr_precip_vhr_06 == complete
               edit VHR '06'
             task jevs_prep_cam_hrrr_severe_vhr_06
               trigger :TIME >= 0600 and :TIME < 1200
@@ -1009,19 +1009,19 @@ suite evs_nco
               trigger :TIME >= 1705 and :TIME < 2305
               edit VHR '17'
             task jevs_prep_cam_hireswarw_precip_vhr_12
-              time 12:00
+              trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_12
-              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswarw_precip_vhr_12 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and jevs_prep_cam_hireswarw_precip_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_hireswfv3_precip_vhr_12
-              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswarwmem2_precip_vhr_12 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and jevs_prep_cam_hireswarwmem2_precip_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_hrrr_precip_vhr_12
-              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hireswfv3_precip_vhr_12 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and jevs_prep_cam_hireswfv3_precip_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_namnest_precip_vhr_12
-              trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hrrr_precip_vhr_12 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and jevs_prep_cam_hrrr_precip_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_hireswarw_severe_vhr_12
               trigger :TIME >= 1200 and :TIME < 1800
@@ -1545,7 +1545,7 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family global_det
             task jevs_prep_global_det_atmos
-              trigger :TIME >= 1810 or :TIME < 0010
+              trigger :TIME >= 1815 or :TIME < 0015
           endfamily
           family cam
             task jevs_prep_cam_radar_vhr_18
@@ -1567,19 +1567,19 @@ suite evs_nco
               trigger :TIME >= 2305 or :TIME < 0505
               edit VHR '23'
             task jevs_prep_cam_hireswarw_precip_vhr_18
-              trigger :TIME >= 1815 or :TIME < 0015
+              trigger :TIME >= 1830 or :TIME < 0030
               edit VHR '18'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_18
-              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hireswarw_precip_vhr_18 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and jevs_prep_cam_hireswarw_precip_vhr_18 == complete
               edit VHR '18'
             task jevs_prep_cam_hireswfv3_precip_vhr_18
-              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hireswarwmem2_precip_vhr_18 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and jevs_prep_cam_hireswarwmem2_precip_vhr_18 == complete
               edit VHR '18'
             task jevs_prep_cam_hrrr_precip_vhr_18
-              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hireswfv3_precip_vhr_18 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and jevs_prep_cam_hireswfv3_precip_vhr_18 == complete
               edit VHR '18'
             task jevs_prep_cam_namnest_precip_vhr_18
-              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hrrr_precip_vhr_18 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and jevs_prep_cam_hrrr_precip_vhr_18 == complete
               edit VHR '18'
             task jevs_prep_cam_hrrr_severe_vhr_18
               trigger :TIME >= 1815 or :TIME < 0015
@@ -1609,293 +1609,291 @@ suite evs_nco
           endfamily
           family mesoscale
             task jevs_stats_mesoscale_nam_precip_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_mesoscale_nam_precip_vhr_19
-              time 19:10
+              trigger :TIME >= 1910 or :TIME < 0110
               edit VHR '19'
             task jevs_stats_mesoscale_nam_precip_vhr_20
-              time 20:10
+              trigger :TIME >= 2010 or :TIME < 0210
               edit VHR '20'
             task jevs_stats_mesoscale_nam_precip_vhr_21
-              time 21:10
+              trigger :TIME >= 2110 or :TIME < 0310
               edit VHR '21'
             task jevs_stats_mesoscale_nam_precip_vhr_22
-              time 22:10
+              trigger :TIME >= 2210 or :TIME < 0410
               edit VHR '22'
             task jevs_stats_mesoscale_nam_precip_vhr_23
-              trigger :TIME >= 2310 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_06 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_07 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_08 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_09 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_10 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_11 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_12 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_13 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_14 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_15 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_16 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_17 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_18 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_19 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_20 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_21 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_22 == complete
+              trigger (:TIME >= 2310 or :TIME < 0510) and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_06 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_07 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_08 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_09 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_10 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_11 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_12 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_13 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_14 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_15 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_16 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_17 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_18 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_19 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_20 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_21 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_mesoscale_rap_precip_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_mesoscale_rap_precip_vhr_19
-              time 19:10
+              trigger :TIME >= 1910 or :TIME < 0110
               edit VHR '19'
             task jevs_stats_mesoscale_rap_precip_vhr_20
-              time 20:10
+              trigger :TIME >= 2010 or :TIME < 0210
               edit VHR '20'
             task jevs_stats_mesoscale_rap_precip_vhr_21
-              time 21:10
+              trigger :TIME >= 2110 or :TIME < 0310
               edit VHR '21'
             task jevs_stats_mesoscale_rap_precip_vhr_22
-              time 22:10
+              trigger :TIME >= 2210 or :TIME < 0410
               edit VHR '22'
             task jevs_stats_mesoscale_rap_precip_vhr_23
-              trigger :TIME >= 2310 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_06 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_07 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_08 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_09 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_10 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_11 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_12 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_13 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_14 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_15 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_16 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_17 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_18 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_19 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_20 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_21 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_22 == complete
+              trigger (:TIME >= 2310 or :TIME < 0510) and and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_06 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_07 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_08 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_09 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_10 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_11 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_12 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_13 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_14 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_15 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_16 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_17 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_18 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_19 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_20 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_21 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_mesoscale_nam_snowfall_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_mesoscale_rap_snowfall_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
           endfamily
           family global_det
             task jevs_stats_global_det_ukmet_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_ukmet_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_metfra_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_jma_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_jma_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_imd_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_imd_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_wmo_daily
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_fnmoc_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_fnmoc_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_ecmwf_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_ecmwf_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_dwd_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_cmc_regional_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_cmc_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_cmc_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_cfs_atmos_grid2obs
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_cfs_atmos_grid2grid
-              trigger :TIME >= 1845 and ../../prep/global_det/jevs_prep_global_det_atmos == complete
-            task jevs_stats_global_det_gfs_atmos_wmo_monthly
-              trigger :TIME >= 2015 and ./jevs_stats_global_det_atmos_wmo_daily == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
           endfamily
           family cam
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_19
-              time 19:00
+              trigger :TIME >= 1900 or :TIME < 0100
               edit VHR '19'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_20
-              time 20:00
+              trigger :TIME >= 2000 or :TIME < 0200
               edit VHR '20'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_21
-              time 21:00
+              trigger :TIME >= 2100 or :TIME < 0300
               edit VHR '21'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_22
-              time 22:00
+              trigger :TIME >= 2200 or :TIME < 0400
               edit VHR '22'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_23
-              trigger :TIME >= 2300 and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_22 == complete
+              trigger (:TIME >= 2300 or :TIME < 0500) and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_18
-              time 18:40
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_19
-              time 19:40
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_20
-              time 20:40
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_21
-              time 21:40
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_22
-              time 22:40
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_23
-              trigger :TIME >= 2340 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_hireswarw_radar_vhr_18
-              time 18:40
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_hireswarw_radar_vhr_19
-              time 19:40
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_hireswarw_radar_vhr_20
-              time 20:40
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_hireswarw_radar_vhr_21
-              time 21:40
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswarw_radar_vhr_22
-              time 22:40
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswarw_radar_vhr_23
-              trigger :TIME >= 2340 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_hireswfv3_radar_vhr_18
-              time 18:40
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_hireswfv3_radar_vhr_19
-              time 19:40
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_hireswfv3_radar_vhr_20
-              time 20:40
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_hireswfv3_radar_vhr_21
-              time 21:40
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswfv3_radar_vhr_22
-              time 22:40
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswfv3_radar_vhr_23
-              trigger :TIME >= 2340 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_href_radar_vhr_18
-              time 18:40
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_href_radar_vhr_19
-              time 19:40
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_href_radar_vhr_20
-              time 20:40
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_href_radar_vhr_21
-              time 21:40
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_href_radar_vhr_22
-              time 22:40
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_href_radar_vhr_23
-              trigger :TIME >= 2340 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_href_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_href_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_href_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_hrrr_radar_vhr_18
-              time 18:40
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_hrrr_radar_vhr_19
-              time 19:40
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_hrrr_radar_vhr_20
-              time 20:40
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_hrrr_radar_vhr_21
-              time 21:40
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_hrrr_radar_vhr_22
-              time 22:40
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_hrrr_radar_vhr_23
-              trigger :TIME >= 2340 and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_namnest_radar_vhr_18
-              time 18:40
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_namnest_radar_vhr_19
-              time 19:40
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_namnest_radar_vhr_20
-              time 20:40
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_namnest_radar_vhr_21
-              time 21:40
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_namnest_radar_vhr_22
-              time 22:40
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_namnest_radar_vhr_23
-              trigger :TIME >= 2340 and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_hireswarw_snowfall_vhr_18
-              trigger :TIME >= 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_snowfall_vhr_12 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_snowfall_vhr_12 == complete
               edit VHR '18'
             task jevs_stats_cam_hireswarwmem2_snowfall_vhr_18
-              trigger :TIME >= 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_snowfall_vhr_12 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_snowfall_vhr_12 == complete
               edit VHR '18'
             task jevs_stats_cam_hireswfv3_snowfall_vhr_18
-              trigger :TIME >= 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_snowfall_vhr_12 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_snowfall_vhr_12 == complete
               edit VHR '18'
             task jevs_stats_cam_hrrr_snowfall_vhr_18
-              trigger :TIME >= 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_snowfall_vhr_12 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_snowfall_vhr_12 == complete
               edit VHR '18'
             task jevs_stats_cam_namnest_snowfall_vhr_18
-              trigger :TIME >= 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_snowfall_vhr_12 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_snowfall_vhr_06 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_snowfall_vhr_12 == complete
               edit VHR '18'
             task jevs_stats_cam_hireswarwmem2_precip_vhr_19
-              time 19:00
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_hireswarwmem2_precip_prep_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_hireswarwmem2_precip_vhr_20
-              time 20:00
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_hireswarwmem2_precip_prep_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_hireswarwmem2_precip_vhr_21
-              time 21:00
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_hireswarwmem2_precip_prep_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswarwmem2_precip_vhr_22
-              trigger :TIME >= 2200 and ./jevs_stats_cam_hireswarwmem2_precip_vhr_19 == complete and ./jevs_stats_cam_hireswarwmem2_precip_vhr_20 == complete and ./jevs_stats_cam_hireswarwmem2_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_hireswarwmem2_precip_prep_vhr_18 == complete and ./jevs_cam_hireswarwmem2_precip_stats_vhr_19 == complete and ./jevs_cam_hireswarwmem2_precip_stats_vhr_20 == complete and ./jevs_cam_hireswarwmem2_precip_stats_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswarw_precip_vhr_19
-              time 19:00
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_hireswarw_precip_prep_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_hireswarw_precip_vhr_20
-              time 20:00
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_hireswarw_precip_prep_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_hireswarw_precip_vhr_21
-              time 21:00
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_hireswarw_precip_prep_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswarw_precip_vhr_22
-              trigger :TIME >= 2200 and ./jevs_stats_cam_hireswarw_precip_vhr_19 == complete and ./jevs_stats_cam_hireswarw_precip_vhr_20 == complete and ./jevs_stats_cam_hireswarw_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_hireswarw_precip_prep_vhr_18 == complete and ./jevs_stats_cam_hireswarw_precip_vhr_19 == complete and ./jevs_stats_cam_hireswarw_precip_vhr_20 == complete and ./jevs_stats_cam_hireswarw_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswfv3_precip_vhr_19
-              time 19:00
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_hireswfv3_precip_prep_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_hireswfv3_precip_vhr_20
-              time 20:00
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_hireswfv3_precip_prep_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_hireswfv3_precip_vhr_21
-              time 21:00
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_hireswfv3_precip_prep_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswfv3_precip_vhr_22
-              trigger :TIME >= 2200 and ./jevs_stats_cam_hireswfv3_precip_vhr_19 == complete and ./jevs_stats_cam_hireswfv3_precip_vhr_20 == complete and ./jevs_stats_cam_hireswfv3_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_hireswfv3_precip_prep_vhr_18 == complete and ./jevs_stats_cam_hireswfv3_precip_vhr_19 == complete and ./jevs_stats_cam_hireswfv3_precip_vhr_20 == complete and ./jevs_stats_cam_hireswfv3_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_hrrr_precip_vhr_19
-              time 19:00
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_hrrr_precip_vhr_20
-              time 20:00
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_hrrr_precip_vhr_21
-              time 21:00
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hrrr_precip_vhr_22
-              trigger :TIME >= 2200 and ./jevs_stats_cam_hrrr_precip_vhr_19 == complete and ./jevs_stats_cam_hrrr_precip_vhr_20 == complete and ./jevs_stats_cam_hrrr_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete and ./jevs_stats_cam_hrrr_precip_vhr_19 == complete and ./jevs_stats_cam_hrrr_precip_vhr_20 == complete and ./jevs_stats_cam_hrrr_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_namnest_precip_vhr_19
-              time 19:00
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_namnest_precip_prep_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_namnest_precip_vhr_20
-              time 20:00
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_namnest_precip_prep_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_namnest_precip_vhr_21
-              time 21:00
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_namnest_precip_prep_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_namnest_precip_vhr_22
-              trigger :TIME >= 2200 and ./jevs_stats_cam_namnest_precip_vhr_19 == complete and ./jevs_stats_cam_namnest_precip_vhr_20 == complete and ./jevs_stats_cam_namnest_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_namnest_precip_prep_vhr_18 == complete and ./jevs_stats_cam_namnest_precip_vhr_19 == complete and ./jevs_stats_cam_namnest_precip_vhr_20 == complete and ./jevs_stats_cam_namnest_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_18
               time 18:15
@@ -1904,84 +1902,84 @@ suite evs_nco
               trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_21
-              trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_21
-              trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hrrr_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_cam_hrrr_grid2obs_vhr_21
-              trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_namnest_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_cam_namnest_grid2obs_vhr_21
-              trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_18 == complete
               edit VHR '21'
           endfamily
           family analyses
             task jevs_stats_analyses_urma_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_analyses_urma_grid2obs_vhr_19
-              time 19:00
+              trigger :TIME >= 1900 or :TIME < 0100
               edit VHR '19'
             task jevs_stats_analyses_urma_grid2obs_vhr_20
-              time 20:00
+              trigger :TIME >= 2000 or :TIME < 0200
               edit VHR '20'
             task jevs_stats_analyses_urma_grid2obs_vhr_21
-              time 21:00
+              trigger :TIME >= 2100 or :TIME < 0300
               edit VHR '21'
             task jevs_stats_analyses_urma_grid2obs_vhr_22
-              time 22:00
+              trigger :TIME >= 2200 or :TIME < 0400
               edit VHR '22'
             task jevs_stats_analyses_urma_grid2obs_vhr_23
-              trigger :TIME >= 2300 and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_22 == complete
+              trigger (:TIME >= 2300 or :TIME < 0500) and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_analyses_rtma_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_analyses_rtma_grid2obs_vhr_19
-              time 19:00
+              trigger :TIME >= 1900 or :TIME < 0100
               edit VHR '19'
             task jevs_stats_analyses_rtma_grid2obs_vhr_20
-              time 20:00
+              trigger :TIME >= 2000 or :TIME < 0200
               edit VHR '20'
             task jevs_stats_analyses_rtma_grid2obs_vhr_21
-              time 21:00
+              trigger :TIME >= 2100 or :TIME < 0300
               edit VHR '21'
             task jevs_stats_analyses_rtma_grid2obs_vhr_22
-              time 22:00
+              trigger :TIME >= 2200 or :TIME < 0400
               edit VHR '22'
             task jevs_stats_analyses_rtma_grid2obs_vhr_23
-              trigger :TIME >= 2300 and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_22 == complete
+              trigger (:TIME >= 2300 or :TIME < 0500) and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_19
-              time 19:00
+              trigger :TIME >= 1900 or :TIME < 0100
               edit VHR '19'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_20
-              time 20:00
+              trigger :TIME >= 2000 or :TIME < 0200
               edit VHR '20'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_21
-              time 21:00
+              trigger :TIME >= 2100 or :TIME < 0300
               edit VHR '21'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_22
-              time 22:00
+              trigger :TIME >= 2200 or :TIME < 0400
               edit VHR '22'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_23
-              trigger :TIME >= 2300 and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_22 == complete
+              trigger (:TIME >= 2300 or :TIME < 0500) and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_22 == complete
               edit VHR '23'
           endfamily
         endfamily   # 18 stats
@@ -1989,56 +1987,56 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family subseasonal
             task jevs_plots_subseasonal_grid2obs_prepbufr_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs == complete
             task jevs_plots_subseasonal_grid2grid_sst_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
             task jevs_plots_subseasonal_grid2grid_sea_ice_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
             task jevs_plots_subseasonal_grid2grid_pres_lvls_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
             task jevs_plots_subseasonal_grid2grid_precip_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
             task jevs_plots_subseasonal_grid2grid_temp_last90days
-              trigger :TIME >= 1900 and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
           endfamily
           family mesoscale
             task jevs_plots_mesoscale_snowfall_last90days
-              trigger :TIME >= 1830 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_18 == complete
+              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_18 == complete
               edit VHR '13'
           endfamily
           family global_det
             task jevs_plots_global_det_atmos_headline
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_grid2obs_sfc_last90days
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_grid2obs_ptype_last90days
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_grid2obs_pres_levs_last90days
-              trigger :TIME >= 2015 and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_grid2grid_sst_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_snow_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_sea_ice_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_pres_levs_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_precip_last90days
-              trigger :TIME >= 1945 and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid == complete
           endfamily
           family cam
             task jevs_plots_cam_precip_last90days
+              trigger (:TIME >= 2230 or :TIME < 0430) and ../../stats/cam/jevs_stats_cam_hireswarw_precip_vhr_22 == complete and  ../../stats/cam/jevs_stats_cam_hireswarwmem2_precip_vhr_22 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_precip_vhr_22 == complete and ../../stats/cam/jevs_stats_cam_hrrr_precip_vhr_22 == complete and ../../stats/cam/jevs_stats_cam_namnest_precip_vhr_22 == complete
               edit VHR '21'
-              trigger ../../stats/cam/jevs_stats_cam_hireswarw_precip_vhr_22 == complete and  ../../stats/cam/jevs_stats_cam_hireswarwmem2_precip_vhr_22 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_precip_vhr_22 == complete and ../../stats/cam/jevs_stats_cam_hrrr_precip_vhr_22 == complete and ../../stats/cam/jevs_stats_cam_namnest_precip_vhr_22 == complete
             task jevs_plots_cam_snowfall_last90days
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../stats/cam/jevs_stats_cam_hireswarw_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_hireswarwmem2_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_hrrr_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_namnest_snowfall_vhr_18 == complete
               edit VHR '21'
-              trigger ../../stats/cam/jevs_stats_cam_hireswarw_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_hireswarwmem2_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_hrrr_snowfall_vhr_18 == complete and ../../stats/cam/jevs_stats_cam_namnest_snowfall_vhr_18 == complete
             task jevs_plots_cam_grid2obs_last90days
+              trigger (:TIME >= 2100 or :TIME < 0300) ../../stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
               edit VHR '21'
-              trigger ../../stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
             task jevs_plots_cam_headline
+              trigger (:TIME >= 2100 or :TIME < 0300) ../../stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
               edit VHR '21'
-              trigger ../../stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
           endfamily 
         endfamily   # 18 plots
       endfamily  # evs

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -28,7 +28,7 @@ suite evs_nco
             task jevs_prep_global_ens_naefs_atmos
               trigger :TIME >= 0300 and :TIME < 0900
             task jevs_prep_global_ens_headline
-              trigger :TIME >= 0400 and :TIME < 1000 and ./jevs_prep_global_ens_atmos == complete and ./jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ./jevs_prep_global_ens_atmos == complete and ./jevs_prep_global_ens_naefs_atmos == complete
           endfamily
           family cam
             task jevs_prep_cam_radar_vhr_00

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1050,9 +1050,9 @@ suite evs_nco
             task jevs_stats_subseasonal_cfs_grid2grid
               trigger :TIME >= 1600 and :TIME < 2200 and ../../prep/subseasonal/jevs_prep_subseasonal_cfs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
             task jevs_stats_subseasonal_gefs_grid2obs
-              trigger :TIME >= 1630 and :TIME < 2230 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1700 and :TIME < 2300 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
             task jevs_stats_subseasonal_gefs_grid2grid
-              trigger :TIME >= 1610 and :TIME < 2210 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
+              trigger :TIME >= 1650 and :TIME < 2250 and ../../prep/subseasonal/jevs_prep_subseasonal_gefs == complete and ../../prep/subseasonal/jevs_prep_subseasonal_obs == complete
           endfamily
           family mesoscale
             task jevs_stats_mesoscale_nam_precip_vhr_12

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1034,7 +1034,7 @@ suite evs_nco
               trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hrrr_severe_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_href_severe_vhr_12
-              trigger :TIME >= 1220 and :TIME < 1220 and ./jevs_prep_cam_hireswarw_severe_vhr_12 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_12 == complete and ./jevs_prep_cam_hrrr_severe_vhr_12 == complete and ./jevs_prep_cam_namnest_severe_vhr_12 == complete
+              trigger :TIME >= 1220 and :TIME < 1820 and ./jevs_prep_cam_hireswarw_severe_vhr_12 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_12 == complete and ./jevs_prep_cam_hrrr_severe_vhr_12 == complete and ./jevs_prep_cam_namnest_severe_vhr_12 == complete
               edit VHR '12'
           endfamily
         endfamily   # 12 prep
@@ -1466,7 +1466,7 @@ suite evs_nco
             task jevs_plots_global_ens_atmos_gefs_profile2_last90days
               trigger :TIME >= 1600 and :TIME < 2200 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_profile1_last90days
-              trigger :TIME >= 1700 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1700 and :TIME < 2300 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_precip_spatial
               trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip_ == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip == complete
             task jevs_plots_global_ens_atmos_naefs_precip_spatial

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -318,19 +318,19 @@ suite evs_nco
               trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2obs_vhr_01
-              trigger :TIME >= 0535 and :TIME < 1135 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0535 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2obs_vhr_02
-              trigger :TIME >= 0540 and :TIME < 1140 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0540 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '02'
             task jevs_stats_aqm_atmos_grid2grid_vhr_00
               trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2grid_vhr_01
-              trigger :TIME >= 0535 and :TIME < 1135 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0535 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2grid_vhr_02
-              trigger :TIME >= 0540 and :TIME < 1140 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0540 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '02'
           endfamily
           family analyses
@@ -391,10 +391,10 @@ suite evs_nco
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00
-              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00
-              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
           endfamily
         endfamily    # 00 stats

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -442,11 +442,11 @@ suite evs_nco
             task jevs_plots_aqm_headline_grid2obs_last90days
               trigger :TIME >= 0500 and :TIME < 1100
             task jevs_plots_aqm_atmos_grid2obs_hourly_last31days
-              trigger :TIME >= 0500 and :TIME < 1100 and ./jevs_plots_aqm_headline_grid2obs_last90days == complete
+              trigger :TIME >= 0530 and :TIME < 1130
             task jevs_plots_aqm_atmos_grid2obs_daily_last90days
-              trigger :TIME >= 0500 and :TIME < 1100 and ./jevs_plots_aqm_atmos_grid2obs_hourly_last31days == complete
+              trigger :TIME >= 0600 and :TIME < 1200
             task jevs_plots_aqm_atmos_grid2grid_hourly_last31days
-              trigger :TIME >= 0500 and :TIME < 1100 and ./jevs_plots_aqm_atmos_grid2obs_daily_last90days = complete
+              trigger :TIME >= 0630 and :TIME < 1230
           endfamily
           family analyses
             task jevs_plots_analyses_grid2obs_last31days
@@ -818,58 +818,58 @@ suite evs_nco
           endfamily
           family aqm
             task jevs_stats_aqm_atmos_grid2obs_vhr_03
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_aqm_atmos_grid2obs_vhr_04
-              trigger :TIME >= 0605 and :TIME < 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0605 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '04'
             task jevs_stats_aqm_atmos_grid2obs_vhr_05
-              trigger :TIME >= 0610 and :TIME < 1210 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0610 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '05'
             task jevs_stats_aqm_atmos_grid2obs_vhr_06
-              trigger :TIME >= 0615 and :TIME < 1215 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0615 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '06'
             task jevs_stats_aqm_atmos_grid2obs_vhr_07
-              trigger :TIME >= 0620 and :TIME < 1220 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0620 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '07'
             task jevs_stats_aqm_atmos_grid2obs_vhr_08
-              trigger :TIME >= 0625 and :TIME < 1225 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0625 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '08'
             task jevs_stats_aqm_atmos_grid2obs_vhr_09
-              trigger :TIME >= 0630 and :TIME < 1230 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0630 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '09'
             task jevs_stats_aqm_atmos_grid2obs_vhr_10
-              trigger :TIME >= 0635 and :TIME < 1235 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0635 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '10'
             task jevs_stats_aqm_atmos_grid2obs_vhr_11
-              trigger :TIME >= 0640 and :TIME < 1240 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0640 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '11'
             task jevs_stats_aqm_atmos_grid2grid_vhr_03
-              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '03'
             task jevs_stats_aqm_atmos_grid2grid_vhr_04
-              trigger :TIME >= 0605 and :TIME < 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0605 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '04'
             task jevs_stats_aqm_atmos_grid2grid_vhr_05
-              trigger :TIME >= 0610 and :TIME < 1210 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0610 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '05'
             task jevs_stats_aqm_atmos_grid2grid_vhr_06
-              trigger :TIME >= 0615 and :TIME < 1215 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0615 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '06'
             task jevs_stats_aqm_atmos_grid2grid_vhr_07
-              trigger :TIME >= 0620 and :TIME < 1220 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0620 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '07'
             task jevs_stats_aqm_atmos_grid2grid_vhr_08
-              trigger :TIME >= 0625 and :TIME < 1225 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0625 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '08'
             task jevs_stats_aqm_atmos_grid2grid_vhr_09
-              trigger :TIME >= 0630 and :TIME < 1230 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0630 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '09'
             task jevs_stats_aqm_atmos_grid2grid_vhr_10
-              trigger :TIME >= 0635 and :TIME < 1235 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0635 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '10'
             task jevs_stats_aqm_atmos_grid2grid_vhr_11
-              trigger :TIME >= 0640 and :TIME < 1240 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0640 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '11'
           endfamily
           family analyses
@@ -930,22 +930,22 @@ suite evs_nco
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03
-              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06
-              trigger :TIME >= 0715 and :TIME < 1315 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete
+              trigger :TIME >= 0715 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '06'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09
-              trigger :TIME >= 0730 and :TIME < 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete
+              trigger :TIME >= 0730 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '09'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03
-              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06
-              trigger :TIME >= 0715 and :TIME < 1315 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete
+              trigger :TIME >= 0715 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '06'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09
-              trigger :TIME >= 0730 and :TIME < 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete
+              trigger :TIME >= 0730 and :TIME < 1130 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '09'
           endfamily
         endfamily    # 06 stats
@@ -1292,34 +1292,34 @@ suite evs_nco
               trigger :TIME >= 1220 and :TIME < 1810 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '12'
             task jevs_stats_aqm_atmos_grid2obs_vhr_13
-              trigger :TIME >= 1225 and :TIME < 1825 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete
+              trigger :TIME >= 1225 and :TIME < 1825 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '13'
             task jevs_stats_aqm_atmos_grid2obs_vhr_14
-              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '14'
             task jevs_stats_aqm_atmos_grid2obs_vhr_15
-              trigger :TIME >= 1235 and :TIME < 1835 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_14 == complete
+              trigger :TIME >= 1235 and :TIME < 1835 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '15'
             task jevs_stats_aqm_atmos_grid2obs_vhr_16
-              trigger :TIME >= 1240 and :TIME < 1840 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_15 == complete
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '16'
             task jevs_stats_aqm_atmos_grid2obs_vhr_17
-              trigger :TIME >= 1245 and :TIME < 1845 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_16 == complete
+              trigger :TIME >= 1245 and :TIME < 1845 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '17'
             task jevs_stats_aqm_atmos_grid2obs_vhr_18
-              trigger :TIME >= 1250 and :TIME < 1850 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_17 == complete
+              trigger :TIME >= 1250 and :TIME < 1850 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '18'
             task jevs_stats_aqm_atmos_grid2obs_vhr_19
-              trigger :TIME >= 1255 and :TIME < 1855 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_18 == complete
+              trigger :TIME >= 1255 and :TIME < 1855 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '19'
             task jevs_stats_aqm_atmos_grid2obs_vhr_20
-              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_19 == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '20'
             task jevs_stats_aqm_atmos_grid2obs_vhr_21
-              trigger :TIME >= 1305 and :TIME < 1905 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_20 == complete
+              trigger :TIME >= 1305 and :TIME < 1905 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '21'
             task jevs_stats_aqm_atmos_grid2obs_vhr_22
-              trigger :TIME >= 1310 and :TIME < 1910 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_21 == complete
+              trigger :TIME >= 1310 and :TIME < 1910 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '22'
             task jevs_stats_aqm_atmos_grid2obs_vhr_23
               trigger :TIME >= 1330 and :TIME < 1930 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_22 == complete
@@ -1328,34 +1328,34 @@ suite evs_nco
               trigger :TIME >= 1220 and :TIME < 1820 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '12'
             task jevs_stats_aqm_atmos_grid2grid_vhr_13
-              trigger :TIME >= 1225 and :TIME < 1825 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete
+              trigger :TIME >= 1225 and :TIME < 1825 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '13'
             task jevs_stats_aqm_atmos_grid2grid_vhr_14
-              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '14'
             task jevs_stats_aqm_atmos_grid2grid_vhr_15
-              trigger :TIME >= 1235 and :TIME < 1835 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_14 == complete
+              trigger :TIME >= 1235 and :TIME < 1835 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '15'
             task jevs_stats_aqm_atmos_grid2grid_vhr_16
-              trigger :TIME >= 1240 and :TIME < 1840 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_15 == complete
+              trigger :TIME >= 1240 and :TIME < 1840 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '16'
             task jevs_stats_aqm_atmos_grid2grid_vhr_17
-              trigger :TIME >= 1245 and :TIME < 1845 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_16 == complete
+              trigger :TIME >= 1245 and :TIME < 1845 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '17'
             task jevs_stats_aqm_atmos_grid2grid_vhr_18
-              trigger :TIME >= 1250 and :TIME < 1850 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_17 == complete
+              trigger :TIME >= 1250 and :TIME < 1850 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '18'
             task jevs_stats_aqm_atmos_grid2grid_vhr_19
-              trigger :TIME >= 1255 and :TIME < 1855 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_18 == complete
+              trigger :TIME >= 1255 and :TIME < 1855 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '19'
             task jevs_stats_aqm_atmos_grid2grid_vhr_20
-              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_19 == complete
+              trigger :TIME >= 1300 and :TIME < 1900 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '20'
             task jevs_stats_aqm_atmos_grid2grid_vhr_21
-              trigger :TIME >= 1305 and :TIME < 1905 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_20 == complete
+              trigger :TIME >= 1305 and :TIME < 1905 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '21'
             task jevs_stats_aqm_atmos_grid2grid_vhr_22
-              trigger :TIME >= 1310 and :TIME < 1910 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_21 == complete
+              trigger :TIME >= 1310 and :TIME < 1910 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '22'
             task jevs_stats_aqm_atmos_grid2grid_vhr_23
               trigger :TIME >= 1330 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_11 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2grid_vhr_22 == complete

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -91,7 +91,7 @@ suite evs_nco
           endfamily
           family global_chem
             task jevs_prep_global_chem_atmos_grid2obs
-              time 05:30
+              trigger :TIME >= 0530 and :TIME < 1130
           endfamily
         endfamily    # 00 prep
         family stats
@@ -1896,7 +1896,7 @@ suite evs_nco
               trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_namnest_precip_prep_vhr_18 == complete and ./jevs_stats_cam_namnest_precip_vhr_19 == complete and ./jevs_stats_cam_namnest_precip_vhr_20 == complete and ./jevs_stats_cam_namnest_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_21
               trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_18 == complete

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1503,7 +1503,7 @@ suite evs_nco
             task jevs_plots_mesoscale_sref_precip_spatial
               trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
             task jevs_plots_mesoscale_precip_last90days
-              trigger :TIME >= 1440 and :TIME < 2040 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_mesoscale_rap_precip == complete
+              trigger :TIME >= 1815 or :TIME < 0015 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_mesoscale_rap_precip == complete
               edit VHR '13'
           endfamily
           family global_det

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -391,10 +391,10 @@ suite evs_nco
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00
-              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../../00/evs/v2.0/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00
-              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../../00/evs/v2.0/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
           endfamily
         endfamily    # 00 stats
@@ -402,21 +402,21 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family rtofs
             task jevs_plots_rtofs_argo_grid2obs_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete
             task jevs_plots_rtofs_aviso_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid == complete
             task jevs_plots_rtofs_ghrsst_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete
             task jevs_plots_rtofs_osisaf_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
             task jevs_plots_rtofs_smap_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_smap_grid2grid == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_smap_grid2grid == complete
             task jevs_plots_rtofs_smos_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_smos_grid2grid == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_smos_grid2grid == complete
             task jevs_plots_rtofs_ndbc_grid2obs_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete
             task jevs_plots_rtofs_headline_grid2grid_last90days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
           endfamily
           family mesoscale
             task jevs_plots_mesoscale_headline
@@ -425,7 +425,7 @@ suite evs_nco
           endfamily
           family cam
             task jevs_plots_cam_nam_firewxnest_grid2obs_last31days
-              trigger :TIME >= 0030 and :TIME < 0630 and ../../../../../18/evs/v2.0/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_23 == complete and ../../../../../18/evs/v2.0/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../../../../18/evs/v2.0/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
+              trigger :TIME >= 0030 and :TIME < 0630 and ../../../../18/evs/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_23 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
           endfamily
           family global_chem
             task jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days
@@ -436,18 +436,18 @@ suite evs_nco
               trigger :TIME >= 0045 and :TIME < 0645
           endfamily
           family aqm
-            task jevs_plots_aqm_atmos_grid2grid_hourly_last31days
-              trigger :TIME >= 0520 and :TIME < 1120
-            task jevs_plots_aqm_atmos_grid2obs_daily_last90days
-              trigger :TIME >= 0520 and :TIME < 1120 and jevs_plots_aqm_atmos_grid2grid_hourly_last31days == complete
-            task jevs_plots_aqm_atmos_grid2obs_hourly_last31days
-              trigger :TIME >= 0520 and :TIME < 1120 and jevs_plots_aqm_atmos_grid2obs_daily_last90days == complete
             task jevs_plots_aqm_headline_grid2obs_last90days
-              trigger :TIME >= 0520 and :TIME < 1120 and jevs_plots_aqm_atmos_grid2obs_hourly_last31days == complete
+              trigger :TIME >= 0500 and :TIME < 1100
+            task jevs_plots_aqm_atmos_grid2obs_hourly_last31days
+              trigger :TIME >= 0500 and :TIME < 1100 and ./jevs_plots_aqm_headline_grid2obs_last90days == complete
+            task jevs_plots_aqm_atmos_grid2obs_daily_last90days
+              trigger :TIME >= 0500 and :TIME < 1100 and ./jevs_plots_aqm_atmos_grid2obs_hourly_last31days == complete
+            task jevs_plots_aqm_atmos_grid2grid_hourly_last31days
+              trigger :TIME >= 0500 and :TIME < 1100 and ./jevs_plots_aqm_atmos_grid2obs_daily_last90days = complete
           endfamily
           family analyses
             task jevs_plots_analyses_grid2obs_last31days
-            trigger :TIME >= 0030 and :TIME < 0630 and ../../../../../18/evs/v2.0/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_23 == complete and ../../../../../18/evs/v2.0/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_23 == complete and ../../../../../18/evs/v2.0/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_23 == complete
+            trigger :TIME >= 0030 and :TIME < 0630 and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_23 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_23 == complete and ../../../../18/evs/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_23 == complete
           endfamily
         endfamily    # 00 plots
       endfamily  # evs
@@ -524,49 +524,49 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family global_ens
             task jevs_stats_global_ens_gefs_atmos_snowfall
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_snowfall
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_snowfall
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_sst
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_sea_ice
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_cnv
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_grid2grid
-              trigger :TIME >= 0830 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0830 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_grid2obs
-              trigger :TIME >= 0945 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0945 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_precip
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_grid2grid
-              trigger :TIME >= 0930 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0930 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_grid2obs
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_precip
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_grid2grid
-              trigger :TIME >= 0900 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0900 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_grid2obs
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_precip
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_naefs_atmos_grid2grid
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
             task jevs_stats_global_ens_naefs_atmos_grid2obs
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_naefs_atmos_precip
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
             task jevs_stats_global_ens_gfs_headline_grid2grid
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_headline == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_headline == complete
             task jevs_stats_global_ens_gefs_headline_grid2grid
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_headline == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_headline == complete
             task jevs_stats_global_ens_naefs_headline_grid2grid
-              trigger :TIME >= 1100 and :TIME < 1700 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_headline == complete
+              trigger :TIME >= 1100 and :TIME < 1700 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_headline == complete
             task jevs_stats_global_ens_gefs_wave_grid2obs
-              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../06/evs/v2.0/prep/global_ens/jevs_prep_global_ens_wave == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../06/evs/prep/global_ens/jevs_prep_global_ens_wave == complete
           endfamily
           family wafs
             task jevs_stats_wafs_atmos
@@ -799,10 +799,10 @@ suite evs_nco
               trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_hrrr_severe
-              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hrrr_severe_prep_vhr_00 == complete and ../../../../../06/evs/v2.0/prep/cam/jevs_cam_hrrr_severe_prep_vhr_06 == complete
+              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_cam_hrrr_severe_prep_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_cam_hrrr_severe_prep_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_namnest_severe
-              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_namnest_severe_prep_vhr_00 == complete and ../../../../../06/evs/v2.0/prep/cam/jevs_cam_namnest_severe_prep_vhr_06 == complete
+              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_cam_namnest_severe_prep_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_cam_namnest_severe_prep_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_href_grid2obs
               trigger :TIME >= 0730 and :TIME < 1330
@@ -1109,16 +1109,16 @@ suite evs_nco
           endfamily
           family cam
             task jevs_stats_cam_hireswarwmem2_severe
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_12 == complete
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_12 == complete
               edit VHR '08'
             task jevs_stats_cam_hireswarw_severe
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hireswarw_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_hireswarw_severe_prep_vhr_12 == complete
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_hireswarw_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_hireswarw_severe_prep_vhr_12 == complete
               edit VHR '08'
             task jevs_stats_cam_hireswfv3_severe
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hireswfv3_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_hireswfv3_severe_prep_vhr_12 == complete
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_hireswfv3_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_hireswfv3_severe_prep_vhr_12 == complete
               edit VHR '08'
             task jevs_stats_cam_href_severe
-              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_href_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_href_severe_prep_vhr_12 == complete
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_href_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_href_severe_prep_vhr_12 == complete
               edit VHR '08'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_12
               time 12:15

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -24,60 +24,60 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family global_ens
             task jevs_prep_global_ens_atmos
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
             task jevs_prep_global_ens_naefs_atmos
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
             task jevs_prep_global_ens_headline
-              trigger :TIME >= 0400 and ./jevs_prep_global_ens_atmos == complete and ./jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 0400 and :TIME < 1000 and ./jevs_prep_global_ens_atmos == complete and ./jevs_prep_global_ens_naefs_atmos == complete
           endfamily
           family cam
             task jevs_prep_cam_radar_vhr_00
-              time 00:05
+              trigger :TIME >= 0005 and :TIME < 0605
               edit VHR '00'
             task jevs_prep_cam_radar_vhr_01
-              time 01:05
+              trigger :TIME >= 0105 and :TIME < 0705
               edit VHR '01'
             task jevs_prep_cam_radar_vhr_02
-              time 02:05
+              trigger :TIME >= 0205 and :TIME < 0805
               edit VHR '02'
             task jevs_prep_cam_radar_vhr_03
-              time 03:05
+              trigger :TIME >= 0305 and :TIME < 0905
               edit VHR '03'
             task jevs_prep_cam_radar_vhr_04
-              time 04:05
+              trigger :TIME >= 0405 and :TIME < 1005
               edit VHR '04'
             task jevs_prep_cam_radar_vhr_05
-              time 05:05
+              trigger :TIME >= 0505 and :TIME < 1105
               edit VHR '05'
-            task jevs_prep_cam_namnest_precip_vhr_00
-              time 00:00
-              edit VHR '00'
-            task jevs_prep_cam_hrrr_precip_vhr_00
-              time 00:00
-              edit VHR '00'
-            task jevs_prep_cam_hireswfv3_precip_vhr_00
-              time 00:00
-              edit VHR '00'
             task jevs_prep_cam_hireswarw_precip_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswarw_precip_vhr_00 == complete
               edit VHR '00'
-            task jevs_prep_cam_hrrr_severe_vhr_00
-              time 00:00
+            task jevs_prep_cam_hireswfv3_precip_vhr_00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswarwmem2_precip_vhr_00 == complete
               edit VHR '00'
-            task jevs_prep_cam_namnest_severe_vhr_00
-              time 00:00
+            task jevs_prep_cam_hrrr_precip_vhr_00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswfv3_precip_vhr_00 == complete
+              edit VHR '00'
+            task jevs_prep_cam_namnest_precip_vhr_00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hrrr_precip_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_hireswarw_severe_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_prep_cam_hireswarwmem2_severe_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswarw_severe_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_hireswfv3_severe_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswarwmem2_severe_vhr_00 == complete
+              edit VHR '00'
+            task jevs_prep_cam_hrrr_severe_vhr_00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hireswfv3_severe_vhr_00 == complete
+              edit VHR '00'
+            task jevs_prep_cam_namnest_severe_vhr_00
+              trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hrrr_severe_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_href_severe_vhr_00
               trigger ./jevs_prep_cam_hireswarw_severe_vhr_00 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_00 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_00 == complete and ./jevs_prep_cam_hrrr_severe_vhr_00 == complete and ./jevs_prep_cam_namnest_severe_vhr_00 == complete
@@ -85,9 +85,9 @@ suite evs_nco
           endfamily
           family aqm
             task jevs_prep_aqm_atmos_grid2obs
-              time 05:10
+              trigger :TIME >= 0000 and :TIME < 0600
             task jevs_prep_aqm_atmos_grid2grid
-              time 05:15
+              trigger :TIME >= 0000 and :TIME < 0600
           endfamily
           family global_chem
             task jevs_prep_global_chem_atmos_grid2obs
@@ -98,351 +98,356 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family mesoscale
             task jevs_stats_mesoscale_nam_precip_vhr_00
-              time 00:10
+              trigger :TIME >= 0010 and :TIME < 0610
               edit VHR '00'
             task jevs_stats_mesoscale_nam_precip_vhr_01
-              time 01:10
+              trigger :TIME >= 0110 and :TIME < 0710
               edit VHR '01'
             task jevs_stats_mesoscale_nam_precip_vhr_02
-              time 02:10
+              trigger :TIME >= 0210 and :TIME < 0810
               edit VHR '02'
             task jevs_stats_mesoscale_nam_precip_vhr_03
-              time 03:10
+	      trigger :TIME >= 0310 and :TIME < 0910
               edit VHR '03'
             task jevs_stats_mesoscale_nam_precip_vhr_04
-              time 04:10
+               trigger :TIME >= 0410 and :TIME < 1010
               edit VHR '04'
             task jevs_stats_mesoscale_nam_precip_vhr_05
-              time 05:10
+              trigger :TIME >= 0510 and :TIME < 1110
               edit VHR '05'
             task jevs_stats_mesoscale_rap_precip_vhr_00
-              time 00:10
+              trigger :TIME >= 0010 and :TIME < 0610
               edit VHR '00'
             task jevs_stats_mesoscale_rap_precip_vhr_01
-              time 01:10
+              trigger :TIME >= 0110 and :TIME < 0710
               edit VHR '01'
             task jevs_stats_mesoscale_rap_precip_vhr_02
-              time 02:10
+              trigger :TIME >= 0210 and :TIME < 0810
               edit VHR '02'
             task jevs_stats_mesoscale_rap_precip_vhr_03
-              time 03:10
+              trigger :TIME >= 0310 and :TIME < 0910
               edit VHR '03'
             task jevs_stats_mesoscale_rap_precip_vhr_04
-              time 04:10
+              trigger :TIME >= 0410 and :TIME < 1010
               edit VHR '04'
             task jevs_stats_mesoscale_rap_precip_vhr_05
-              time 05:10
+              trigger :TIME >= 0510 and :TIME < 1110
               edit VHR '05'
             task jevs_stats_mesoscale_nam_snowfall_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_stats_mesoscale_rap_snowfall_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
           endfamily
           family cam
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_01
-              time 01:00
+              trigger :TIME >= 0100 and :TIME < 0700
               edit VHR '01'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_04
-              time 04:00
+              trigger :TIME >= 0400 and :TIME < 1000
               edit VHR '04'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_05
-              time 05:00
+              trigger :TIME >= 0500 and :TIME < 1100
               edit VHR '05'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_00
-              time 00:40
+              trigger :TIME >= 0040 and :TIME < 0640 and ../../prep/cam/jevs_prep_cam_radar_vhr_00 == complete
               edit VHR '00'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_01
-              time 01:40
+              trigger :TIME >= 0140 and :TIME < 0740 and ../../prep/cam/jevs_prep_cam_radar_vhr_01 == complete
               edit VHR '01'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_02
-              time 02:40
+              trigger :TIME >= 0240 and :TIME < 0840 and ../../prep/cam/jevs_prep_cam_radar_vhr_02 == complete
               edit VHR '02'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_03
-              time 03:40
+              trigger :TIME >= 0340 and :TIME < 0940 and ../../prep/cam/jevs_prep_cam_radar_vhr_03 == complete
               edit VHR '03'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_04
-              time 04:40
+              trigger :TIME >= 0440 and :TIME < 1040 and ../../prep/cam/jevs_prep_cam_radar_vhr_04 == complete
               edit VHR '04'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_05
-              time 05:40
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../prep/cam/jevs_prep_cam_radar_vhr_05 == complete
               edit VHR '05'
             task jevs_stats_cam_hireswarw_radar_vhr_00
-              time 00:40
+              trigger :TIME >= 0040 and :TIME < 0640 and ../../prep/cam/jevs_prep_cam_radar_vhr_00 == complete
               edit VHR '00'
             task jevs_stats_cam_hireswarw_radar_vhr_01
-              time 01:40
+              trigger :TIME >= 0140 and :TIME < 0740 and ../../prep/cam/jevs_prep_cam_radar_vhr_01 == complete
               edit VHR '01'
             task jevs_stats_cam_hireswarw_radar_vhr_02
-              time 02:40
+              trigger :TIME >= 0240 and :TIME < 0840 and ../../prep/cam/jevs_prep_cam_radar_vhr_02 == complete
               edit VHR '02'
             task jevs_stats_cam_hireswarw_radar_vhr_03
-              time 03:40
+              trigger :TIME >= 0340 and :TIME < 0940 and ../../prep/cam/jevs_prep_cam_radar_vhr_03 == complete
               edit VHR '03'
             task jevs_stats_cam_hireswarw_radar_vhr_04
-              time 04:40
+              trigger :TIME >= 0440 and :TIME < 1040 and ../../prep/cam/jevs_prep_cam_radar_vhr_04 == complete
               edit VHR '04'
             task jevs_stats_cam_hireswarw_radar_vhr_05
-              time 05:40
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../prep/cam/jevs_prep_cam_radar_vhr_05 == complete
               edit VHR '05'
             task jevs_stats_cam_hireswfv3_radar_vhr_00
-              time 00:40
+              trigger :TIME >= 0040 and :TIME < 0640 and ../../prep/cam/jevs_prep_cam_radar_vhr_00 == complete
               edit VHR '00'
             task jevs_stats_cam_hireswfv3_radar_vhr_01
-              time 01:40
+              trigger :TIME >= 0140 and :TIME < 0740 and ../../prep/cam/jevs_prep_cam_radar_vhr_01 == complete
               edit VHR '01'
             task jevs_stats_cam_hireswfv3_radar_vhr_02
-              time 02:40
+              trigger :TIME >= 0240 and :TIME < 0840 and ../../prep/cam/jevs_prep_cam_radar_vhr_02 == complete
               edit VHR '02'
             task jevs_stats_cam_hireswfv3_radar_vhr_03
-              time 03:40
+              trigger :TIME >= 0340 and :TIME < 0940 and ../../prep/cam/jevs_prep_cam_radar_vhr_03 == complete
               edit VHR '03'
             task jevs_stats_cam_hireswfv3_radar_vhr_04
-              time 04:40
+              trigger :TIME >= 0440 and :TIME < 1040 and ../../prep/cam/jevs_prep_cam_radar_vhr_04 == complete
               edit VHR '04'
             task jevs_stats_cam_hireswfv3_radar_vhr_05
-              time 05:40
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../prep/cam/jevs_prep_cam_radar_vhr_05 == complete
               edit VHR '05'
             task jevs_stats_cam_href_radar_vhr_00
-              time 00:40
+              trigger :TIME >= 0040 and :TIME < 0640 and ../../prep/cam/jevs_prep_cam_radar_vhr_00 == complete
               edit VHR '00'
             task jevs_stats_cam_href_radar_vhr_01
-              time 01:40
+              trigger :TIME >= 0140 and :TIME < 0740 and ../../prep/cam/jevs_prep_cam_radar_vhr_01 == complete
               edit VHR '01'
             task jevs_stats_cam_href_radar_vhr_02
-              time 02:40
+              trigger :TIME >= 0240 and :TIME < 0840 and ../../prep/cam/jevs_prep_cam_radar_vhr_02 == complete
               edit VHR '02'
             task jevs_stats_cam_href_radar_vhr_03
-              time 03:40
+              trigger :TIME >= 0340 and :TIME < 0940 and ../../prep/cam/jevs_prep_cam_radar_vhr_03 == complete
               edit VHR '03'
             task jevs_stats_cam_href_radar_vhr_04
-              time 04:40
+              trigger :TIME >= 0440 and :TIME < 1040 and ../../prep/cam/jevs_prep_cam_radar_vhr_04 == complete
               edit VHR '04'
             task jevs_stats_cam_href_radar_vhr_05
-              time 05:40
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../prep/cam/jevs_prep_cam_radar_vhr_05 == complete
               edit VHR '05'
             task jevs_stats_cam_hrrr_radar_vhr_00
-              time 00:40
+              trigger :TIME >= 0040 and :TIME < 0640 and ../../prep/cam/jevs_prep_cam_radar_vhr_00 == complete
               edit VHR '00'
             task jevs_stats_cam_hrrr_radar_vhr_01
-              time 01:40
+              trigger :TIME >= 0140 and :TIME < 0740 and ../../prep/cam/jevs_prep_cam_radar_vhr_01 == complete
               edit VHR '01'
             task jevs_stats_cam_hrrr_radar_vhr_02
-              time 02:40
+              trigger :TIME >= 0240 and :TIME < 0840 and ../../prep/cam/jevs_prep_cam_radar_vhr_02 == complete
               edit VHR '02'
             task jevs_stats_cam_hrrr_radar_vhr_03
-              time 03:40
+              trigger :TIME >= 0340 and :TIME < 0940 and ../../prep/cam/jevs_prep_cam_radar_vhr_03 == complete
               edit VHR '03'
             task jevs_stats_cam_hrrr_radar_vhr_04
-              time 04:40
+              trigger :TIME >= 0440 and :TIME < 1040 and ../../prep/cam/jevs_prep_cam_radar_vhr_04 == complete
               edit VHR '04'
             task jevs_stats_cam_hrrr_radar_vhr_05
-              time 05:40
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../prep/cam/jevs_prep_cam_radar_vhr_05 == complete
               edit VHR '05'
             task jevs_stats_cam_namnest_radar_vhr_00
-              time 00:40
+              trigger :TIME >= 0040 and :TIME < 0640 and ../../prep/cam/jevs_prep_cam_radar_vhr_00 == complete
               edit VHR '00'
             task jevs_stats_cam_namnest_radar_vhr_01
-              time 01:40
+              trigger :TIME >= 0140 and :TIME < 0740 and ../../prep/cam/jevs_prep_cam_radar_vhr_01 == complete
               edit VHR '01'
             task jevs_stats_cam_namnest_radar_vhr_02
-              time 02:40
+              trigger :TIME >= 0240 and :TIME < 0840 and ../../prep/cam/jevs_prep_cam_radar_vhr_02 == complete
               edit VHR '02'
             task jevs_stats_cam_namnest_radar_vhr_03
-              time 03:40
+              trigger :TIME >= 0340 and :TIME < 0940 and ../../prep/cam/jevs_prep_cam_radar_vhr_03 == complete
               edit VHR '03'
             task jevs_stats_cam_namnest_radar_vhr_04
-              time 04:40
+              trigger :TIME >= 0440 and :TIME < 1040 and ../../prep/cam/jevs_prep_cam_radar_vhr_04 == complete
               edit VHR '04'
             task jevs_stats_cam_namnest_radar_vhr_05
-              time 05:40
+              trigger :TIME >= 0540 and :TIME < 1140 and ../../prep/cam/jevs_prep_cam_radar_vhr_05 == complete
               edit VHR '05'
             task jevs_stats_cam_hireswarw_snowfall_vhr_00
-              time 00:30
+              trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_stats_cam_hireswarwmem2_snowfall_vhr_00
-              time 00:30
+              trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_stats_cam_hireswfv3_snowfall_vhr_00
-              time 00:30
+              trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_stats_cam_hrrr_snowfall_vhr_00
-              time 00:30
+              trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_stats_cam_namnest_snowfall_vhr_00
-              time 00:30
+              trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_03
-              time 03:00
+               trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_cam_hrrr_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_cam_hrrr_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_cam_namnest_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_cam_namnest_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
           endfamily
           family aqm
             task jevs_stats_aqm_atmos_grid2obs_vhr_00
-              trigger :TIME >= 0530 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2obs_vhr_01
-              trigger :TIME >= 0540 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2obs_vhr_02
-              trigger :TIME >= 0550 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '02'
             task jevs_stats_aqm_atmos_grid2grid_vhr_00
-              trigger :TIME >= 0530 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2grid_vhr_01
-              trigger :TIME >= 0540 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2grid_vhr_02
-              trigger :TIME >= 0550 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '02'
           endfamily
           family analyses
             task jevs_stats_analyses_urma_grid2obs_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_stats_analyses_urma_grid2obs_vhr_01
-              time 01:00
+              trigger :TIME >= 0100 and :TIME < 0700
               edit VHR '01'
             task jevs_stats_analyses_urma_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_analyses_urma_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_analyses_urma_grid2obs_vhr_04
-              time 04:00
+              trigger :TIME >= 0400 and :TIME < 1000
               edit VHR '04'
             task jevs_stats_analyses_urma_grid2obs_vhr_05
-              time 05:00
+              trigger :TIME >= 0500 and :TIME < 1100
               edit VHR '05'
             task jevs_stats_analyses_rtma_grid2obs_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_stats_analyses_rtma_grid2obs_vhr_01
-              time 01:00
+              trigger :TIME >= 0100 and :TIME < 0700
               edit VHR '01'
             task jevs_stats_analyses_rtma_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_analyses_rtma_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_analyses_rtma_grid2obs_vhr_04
-              time 04:00
+              trigger :TIME >= 0400 and :TIME < 1000
               edit VHR '04'
             task jevs_stats_analyses_rtma_grid2obs_vhr_05
-              time 05:00
+              trigger :TIME >= 0500 and :TIME < 1100
               edit VHR '05'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_00
-              time 00:00
+              trigger :TIME >= 0000 and :TIME < 0600
               edit VHR '00'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_01
-              time 01:00
+              trigger :TIME >= 0100 and :TIME < 0700
               edit VHR '01'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_02
-              time 02:00
+              trigger :TIME >= 0200 and :TIME < 0800
               edit VHR '02'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_03
-              time 03:00
+              trigger :TIME >= 0300 and :TIME < 0900
               edit VHR '03'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_04
-              time 04:00
+              trigger :TIME >= 0400 and :TIME < 1000
               edit VHR '04'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_05
-              time 05:00
+              trigger :TIME >= 0500 and :TIME < 1100
               edit VHR '05'
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00
-              trigger :TIME >= 0545 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00
-              trigger :TIME >= 0545 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
           endfamily
         endfamily    # 00 stats
         family plots
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family rtofs
-            task jevs_plots_rtofs_aviso_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_plots_rtofs_ghrsst_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_plots_rtofs_osisaf_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_plots_rtofs_smap_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700
-            task jevs_plots_rtofs_smos_grid2grid_last60days
-              trigger :TIME >= 0300 and :TIME < 0700
             task jevs_plots_rtofs_argo_grid2obs_last60days
-              trigger :TIME >= 0300 and :TIME < 0700
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete
+            task jevs_plots_rtofs_aviso_grid2grid_last60days
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid == complete
+            task jevs_plots_rtofs_ghrsst_grid2grid_last60days
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete
+            task jevs_plots_rtofs_osisaf_grid2grid_last60days
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
+            task jevs_plots_rtofs_smap_grid2grid_last60days
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_smap_grid2grid == complete
+            task jevs_plots_rtofs_smos_grid2grid_last60days
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_smos_grid2grid == complete
             task jevs_plots_rtofs_ndbc_grid2obs_last60days
-              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete
             task jevs_plots_rtofs_headline_grid2grid_last90days
-              trigger :TIME >= 0300 and :TIME < 0700
+              trigger :TIME >= 0300 and :TIME < 0700 and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete and ../../../../../18/evs/v2.0/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
+          endfamily
+          family mesoscale
+            task jevs_plots_mesoscale_headline
+              trigger :TIME >= 0100 and :TIME < 0700
+              edit VHR '01'
           endfamily
           family cam
             task jevs_plots_cam_nam_firewxnest_grid2obs_last31days
-              time 00:30
+              trigger :TIME >= 0030 and :TIME < 0630 and ../../../../../18/evs/v2.0/stats/cam/jevs_stats_cam_nam_firewxnest_grid2obs_vhr_23 == complete and ../../../../../18/evs/v2.0/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../../../../18/evs/v2.0/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_21 == complete
           endfamily
           family global_chem
             task jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days
-              time 00:45
+              trigger :TIME >= 0045 and :TIME < 0645
             task jevs_plots_global_chem_atmos_grid2obs_airnow_last90days
-              time 00:45
+              trigger :TIME >= 0045 and :TIME < 0645
             task jevs_plots_global_chem_headline_grid2obs_last90days
-              time 00:45
+              trigger :TIME >= 0045 and :TIME < 0645
           endfamily
           family aqm
             task jevs_plots_aqm_atmos_grid2grid_hourly_last31days
-              time 05:20
+              trigger :TIME >= 0520 and :TIME < 1120
             task jevs_plots_aqm_atmos_grid2obs_daily_last90days
-              time 05:30
-            task jevs_plots_aqm_headline_grid2obs_last90days
-              time 05:45
+              trigger :TIME >= 0520 and :TIME < 1120 and jevs_plots_aqm_atmos_grid2grid_hourly_last31days == complete
             task jevs_plots_aqm_atmos_grid2obs_hourly_last31days
-              time 05:58
+              trigger :TIME >= 0520 and :TIME < 1120 and jevs_plots_aqm_atmos_grid2obs_daily_last90days == complete
+            task jevs_plots_aqm_headline_grid2obs_last90days
+              trigger :TIME >= 0520 and :TIME < 1120 and jevs_plots_aqm_atmos_grid2obs_hourly_last31days == complete
           endfamily
           family analyses
             task jevs_plots_analyses_grid2obs_last31days
-            time 00:30
+            trigger :TIME >= 0030 and :TIME < 0630 and ../../../../../18/evs/v2.0/stats/analyses/jevs_stats_analyses_rtma_grid2obs_vhr_23 == complete and ../../../../../18/evs/v2.0/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs_vhr_23 == complete and ../../../../../18/evs/v2.0/stats/analyses/jevs_stats_analyses_urma_grid2obs_vhr_23 == complete
           endfamily
         endfamily    # 00 plots
       endfamily  # evs

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -536,19 +536,19 @@ suite evs_nco
             task jevs_stats_global_ens_gefs_atmos_cnv
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_grid2grid
-              trigger :TIME >= 0830 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0830 and :TIME < 1430 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_grid2obs
               trigger :TIME >= 0945 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_precip
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_grid2grid
-              trigger :TIME >= 0930 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0930 and :TIME < 1530 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_grid2obs
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_precip
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_grid2grid
-              trigger :TIME >= 0900 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0900 and :TIME < 1500 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_grid2obs
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_precip
@@ -1545,68 +1545,67 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family global_det
             task jevs_prep_global_det_atmos
-              time 18:10
+              trigger :TIME >= 1810 or :TIME < 0010
           endfamily
           family cam
             task jevs_prep_cam_radar_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_prep_cam_radar_vhr_19
-              time 19:05
+              trigger :TIME >= 1905 or :TIME < 0105
               edit VHR '19'
             task jevs_prep_cam_radar_vhr_20
-              time 20:05
+              trigger :TIME >= 2005 or :TIME < 0205
               edit VHR '20'
             task jevs_prep_cam_radar_vhr_21
-              time 21:05
+              trigger :TIME >= 2105 or :TIME < 0305
               edit VHR '21'
             task jevs_prep_cam_radar_vhr_22
-              time 22:05
+              trigger :TIME >= 2205 or :TIME < 0405
               edit VHR '22'
             task jevs_prep_cam_radar_vhr_23
-              time 23:05
+              trigger :TIME >= 2305 or :TIME < 0505
               edit VHR '23'
-            task jevs_prep_cam_namnest_precip_vhr_18
-              time 18:15
-              edit VHR '18'
-            task jevs_prep_cam_hrrr_precip_vhr_18
-              time 18:15
-              edit VHR '18'
-            task jevs_prep_cam_hireswfv3_precip_vhr_18
-              time 18:15
-              edit VHR '18'
             task jevs_prep_cam_hireswarw_precip_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_18
-              time 18:15
+              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hireswarw_precip_vhr_18 == complete
+              edit VHR '18'
+            task jevs_prep_cam_hireswfv3_precip_vhr_18
+              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hireswarwmem2_precip_vhr_18 == complete
+              edit VHR '18'
+            task jevs_prep_cam_hrrr_precip_vhr_18
+              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hireswfv3_precip_vhr_18 == complete
+              edit VHR '18'
+            task jevs_prep_cam_namnest_precip_vhr_18
+              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hrrr_precip_vhr_18 == complete
               edit VHR '18'
             task jevs_prep_cam_hrrr_severe_vhr_18
-              time 18:15
+              trigger :TIME >= 1815 or :TIME < 0015
               edit VHR '18'
             task jevs_prep_cam_namnest_severe_vhr_18
-              time 18:15
+              trigger (:TIME >= 1815 or :TIME < 0015) and jevs_prep_cam_hrrr_severe_vhr_18 == complete
               edit VHR '18'
-
           endfamily
         endfamily   # 18 prep
         family stats
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family rtofs
             task jevs_stats_rtofs_ndbc_grid2obs
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
             task jevs_stats_rtofs_argo_grid2obs
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
             task jevs_stats_rtofs_aviso_grid2grid
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
             task jevs_stats_rtofs_ghrsst_grid2grid
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
             task jevs_stats_rtofs_osisaf_grid2grid
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
             task jevs_stats_rtofs_smap_grid2grid
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
             task jevs_stats_rtofs_smos_grid2grid
-              trigger :TIME >= 2200 and ../../../../06/evs/prep/rtofs == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../../../06/evs/prep/rtofs == complete
           endfamily
           family mesoscale
             task jevs_stats_mesoscale_nam_precip_vhr_18

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -80,7 +80,7 @@ suite evs_nco
               trigger :TIME >= 0000 and :TIME < 0600 and jevs_prep_cam_hrrr_severe_vhr_00 == complete
               edit VHR '00'
             task jevs_prep_cam_href_severe_vhr_00
-              trigger ./jevs_prep_cam_hireswarw_severe_vhr_00 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_00 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_00 == complete and ./jevs_prep_cam_hrrr_severe_vhr_00 == complete and ./jevs_prep_cam_namnest_severe_vhr_00 == complete
+              trigger :TIME >= 0020 and :TIME < 0620 and ./jevs_prep_cam_hireswarw_severe_vhr_00 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_00 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_00 == complete and ./jevs_prep_cam_hrrr_severe_vhr_00 == complete and ./jevs_prep_cam_namnest_severe_vhr_00 == complete
               edit VHR '00'
           endfamily
           family aqm
@@ -283,34 +283,34 @@ suite evs_nco
               trigger :TIME >= 0030 and :TIME < 0630
               edit VHR '00'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_02
-              trigger :TIME >= 0200 and :TIME < 0800
+              trigger :TIME >= 0230 and :TIME < 0830
               edit VHR '02'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_03
-              trigger :TIME >= 0300 and :TIME < 0900
+              trigger :TIME >= 0330 and :TIME < 0930
               edit VHR '03'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_02
-              trigger :TIME >= 0200 and :TIME < 0800
+              trigger :TIME >= 0230 and :TIME < 0830
               edit VHR '02'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_03
-               trigger :TIME >= 0300 and :TIME < 0900
+               trigger :TIME >= 0330 and :TIME < 0930
               edit VHR '03'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_02
-              trigger :TIME >= 0200 and :TIME < 0800
+              trigger :TIME >= 0230 and :TIME < 0830
               edit VHR '02'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_03
-              trigger :TIME >= 0300 and :TIME < 0900
+              trigger :TIME >= 0330 and :TIME < 0930
               edit VHR '03'
             task jevs_stats_cam_hrrr_grid2obs_vhr_02
-              trigger :TIME >= 0200 and :TIME < 0800
+              trigger :TIME >= 0230 and :TIME < 0830
               edit VHR '02'
             task jevs_stats_cam_hrrr_grid2obs_vhr_03
-              trigger :TIME >= 0300 and :TIME < 0900
+              trigger :TIME >= 0330 and :TIME < 0930
               edit VHR '03'
             task jevs_stats_cam_namnest_grid2obs_vhr_02
-              trigger :TIME >= 0200 and :TIME < 0800
+              trigger :TIME >= 0230 and :TIME < 0830
               edit VHR '02'
             task jevs_stats_cam_namnest_grid2obs_vhr_03
-              trigger :TIME >= 0300 and :TIME < 0900
+              trigger :TIME >= 0330 and :TIME < 0930
               edit VHR '03'
           endfamily
           family aqm
@@ -419,9 +419,12 @@ suite evs_nco
               trigger :TIME >= 0300 and :TIME < 0700 and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_argo_grid2obs == complete and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid == complete and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs == complete and ../../../../18/evs/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid == complete
           endfamily
           family mesoscale
-            task jevs_plots_mesoscale_headline
+            task jevs_plots_mesoscale_grid2obs_last90days
               trigger :TIME >= 0100 and :TIME < 0700
               edit VHR '01'
+            task jevs_plots_mesoscale_headline
+              trigger :TIME >= 0100 and :TIME < 0700
+              edit VHR '01' 
           endfamily
           family cam
             task jevs_plots_cam_nam_firewxnest_grid2obs_last31days
@@ -472,7 +475,7 @@ suite evs_nco
           endfamily
           family mesoscale
             task jevs_prep_mesoscale_grid2obs
-              trigger :TIME >= 0730 and :TIME < 1330
+              trigger :TIME >= 0700 and :TIME < 1300
               edit VHR '07'
           endfamily
           family cam
@@ -610,7 +613,7 @@ suite evs_nco
               trigger :TIME >= 1100 and :TIME < 1700
               edit VHR '11'
             task jevs_stats_mesoscale_nam_grid2obs
-              trigger :TIME >= 0700 and :TIME < 1300
+              trigger :TIME >= 0800 and :TIME < 1400
               edit VHR '08'
             task jevs_stats_mesoscale_rap_grid2obs
               trigger :TIME >= 0730 and :TIME < 1330
@@ -769,34 +772,34 @@ suite evs_nco
               trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_09
-              trigger :TIME >= 0900 and :TIME < 1500
+              trigger :TIME >= 0930 and :TIME < 1530
               edit VHR '09'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_09
-              trigger :TIME >= 0900 and :TIME < 1500
+              trigger :TIME >= 0930 and :TIME < 1530
               edit VHR '09'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_09
-              trigger :TIME >= 0900 and :TIME < 1500
+              trigger :TIME >= 0930 and :TIME < 1530
               edit VHR '09'
             task jevs_stats_cam_hrrr_grid2obs_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hrrr_grid2obs_vhr_09
-              trigger :TIME >= 0900 and :TIME < 1500
+              trigger :TIME >= 0930 and :TIME < 1530
               edit VHR '09'
             task jevs_stats_cam_namnest_grid2obs_vhr_06
-              trigger :TIME >= 0600 and :TIME < 1200
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_namnest_grid2obs_vhr_09
-              trigger :TIME >= 0900 and :TIME < 1500
+              trigger :TIME >= 0930 and :TIME < 1530
               edit VHR '09'
             task jevs_stats_cam_hrrr_severe
               trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_prep_cam_hrrr_severe_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_prep_cam_hrrr_severe_vhr_06 == complete
@@ -809,7 +812,7 @@ suite evs_nco
             task jevs_stats_cam_href_precip
               trigger :TIME >= 0830 and :TIME < 1430
             task jevs_stats_cam_href_snowfall
-              trigger :TIME >= 0900 and :TIME < 1500
+              trigger :TIME >= 0830 and :TIME < 1430
             task jevs_stats_cam_href_spcoutlook
               trigger :TIME >= 0830 and :TIME < 1430 and ../../prep/cam/jevs_prep_cam_severe == complete
           endfamily
@@ -930,32 +933,24 @@ suite evs_nco
               trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06
-              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete
+              trigger :TIME >= 0715 and :TIME < 1315 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete
               edit VHR '06'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09
-              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete
+              trigger :TIME >= 0730 and :TIME < 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03
               trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06
-              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete
+              trigger :TIME >= 0715 and :TIME < 1315 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete
               edit VHR '06'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09
-              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete
+              trigger :TIME >= 0730 and :TIME < 1330 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete
               edit VHR '09'
           endfamily
         endfamily    # 06 stats
         family plots
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
-          family mesoscale
-            task jevs_plots_mesoscale_grid2obs_last90days
-              trigger :TIME >= 0900 and :TIME < 1500
-              edit VHR '09'
-            task jevs_plots_mesoscale_headline
-              trigger :TIME >= 0900 and :TIME < 1500
-              edit VHR '09'
-          endfamily
           family global_ens
 	    task jevs_plots_global_ens_wave_gefs_grid2obs_last90days
               trigger :TIME >= 1100 and :TIME < 1700 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_wave_grid2obs == complete
@@ -1039,7 +1034,7 @@ suite evs_nco
               trigger :TIME >= 1200 and :TIME < 1800 and jevs_prep_cam_hrrr_severe_vhr_12 == complete
               edit VHR '12'
             task jevs_prep_cam_href_severe_vhr_12
-              trigger ./jevs_prep_cam_hireswarw_severe_vhr_12 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_12 == complete and ./jevs_prep_cam_hrrr_severe_vhr_12 == complete and ./jevs_prep_cam_namnest_severe_vhr_12 == complete
+              trigger :TIME >= 1220 and :TIME < 1220 and ./jevs_prep_cam_hireswarw_severe_vhr_12 == complete and ./jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete and ./jevs_prep_cam_hireswfv3_severe_vhr_12 == complete and ./jevs_prep_cam_hrrr_severe_vhr_12 == complete and ./jevs_prep_cam_namnest_severe_vhr_12 == complete
               edit VHR '12'
           endfamily
         endfamily   # 12 prep
@@ -1250,34 +1245,34 @@ suite evs_nco
               trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_12
-              trigger :TIME >= 1220 and :TIME < 1815
+              trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_15
-              trigger :TIME >= 1500 and :TIME < 2100
+              trigger :TIME >= 1530 and :TIME < 2130
               edit VHR '15'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12
-              trigger :TIME >= 1220 and :TIME < 1815
+              trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15
-              trigger :TIME >= 1500 and :TIME < 2100
+              trigger :TIME >= 1530 and :TIME < 2130
               edit VHR '15'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_12
-              trigger :TIME >= 1220 and :TIME < 1815
+              trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_15
-              trigger :TIME >= 1500 and :TIME < 2100
+              trigger :TIME >= 1530 and :TIME < 2130
               edit VHR '15'
             task jevs_stats_cam_hrrr_grid2obs_vhr_12
-              trigger :TIME >= 1220 and :TIME < 1815
+              trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_stats_cam_hrrr_grid2obs_vhr_15
-              trigger :TIME >= 1500 and :TIME < 2100
+              trigger :TIME >= 1530 and :TIME < 2130
               edit VHR '15'
             task jevs_stats_cam_namnest_grid2obs_vhr_12
-              trigger :TIME >= 1220 and :TIME < 1815
+              trigger :TIME >= 1230 and :TIME < 1830
               edit VHR '12'
             task jevs_stats_cam_namnest_grid2obs_vhr_15
-              trigger :TIME >= 1500 and :TIME < 2100
+              trigger :TIME >= 1530 and :TIME < 2130
               edit VHR '15'
             task jevs_stats_cam_hireswarwmem2_severe
               trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_12 == complete
@@ -1490,6 +1485,9 @@ suite evs_nco
 	      trigger :TIME >= 1500 and :TIME < 2100 and ../../stats/nfcens == complete
           endfamily
           family mesoscale
+            task jevs_plots_mesoscale_snowfall_last90days 
+              trigger :TIME >= 1300 and :TIME < 1900
+              edit VHR '13'
             task jevs_plots_mesoscale_sref_grid2obs_last90days
               trigger :TIME >= 1300 and :TIME < 1900 and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_sref_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_mesoscale_sref_precip_last90days
@@ -1896,34 +1894,34 @@ suite evs_nco
               trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_namnest_precip_prep_vhr_18 == complete and ./jevs_stats_cam_namnest_precip_vhr_19 == complete and ./jevs_stats_cam_namnest_precip_vhr_20 == complete and ./jevs_stats_cam_namnest_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_18
-              trigger :TIME >= 1815 or :TIME < 0015
+              trigger :TIME >= 1830 or :TIME < 0030
               edit VHR '18'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_21
               trigger :TIME >= 2100 and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_18
-              trigger :TIME >= 1815 or :TIME < 0015
+              trigger :TIME >= 1830 or :TIME < 0030
               edit VHR '18'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_21
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2130 or :TIME < 0330) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_18
-              trigger :TIME >= 1815 or :TIME < 0015
+              trigger :TIME >= 1830 or :TIME < 0030
               edit VHR '18'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_21
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2130 or :TIME < 0330) and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hrrr_grid2obs_vhr_18
-              trigger :TIME >= 1815 or :TIME < 0015
+              trigger :TIME >= 1830 or :TIME < 0030
               edit VHR '18'
             task jevs_stats_cam_hrrr_grid2obs_vhr_21
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2130 or :TIME < 0330) and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_namnest_grid2obs_vhr_18
-              trigger :TIME >= 1815 or :TIME < 0015
+              trigger :TIME >= 1830 or :TIME < 0030
               edit VHR '18'
             task jevs_stats_cam_namnest_grid2obs_vhr_21
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_18 == complete
+              trigger (:TIME >= 2130 or :TIME < 0330) and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_09 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_15 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_namnest_grid2obs_vhr_18 == complete
               edit VHR '21'
           endfamily
           family analyses
@@ -1998,11 +1996,6 @@ suite evs_nco
               trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
             task jevs_plots_subseasonal_grid2grid_temp_last90days
               trigger (:TIME >= 1900 or :TIME < 0100) and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid == complete and ../../../../12/evs/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid == complete
-          endfamily
-          family mesoscale
-            task jevs_plots_mesoscale_snowfall_last90days
-              trigger (:TIME >= 1830 or :TIME < 0030) and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_18 == complete and ../../../../06/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_06 == complete and ../../../../12/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_12 == complete and ../../../../18/evs/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_18 == complete
-              edit VHR '13'
           endfamily
           family global_det
             task jevs_plots_global_det_atmos_headline

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -85,9 +85,9 @@ suite evs_nco
           endfamily
           family aqm
             task jevs_prep_aqm_atmos_grid2obs
-              trigger :TIME >= 0000 and :TIME < 0600
+              trigger :TIME >= 0500 and :TIME < 1100
             task jevs_prep_aqm_atmos_grid2grid
-              trigger :TIME >= 0000 and :TIME < 0600
+              trigger :TIME >= 0515 and :TIME < 1115
           endfamily
           family global_chem
             task jevs_prep_global_chem_atmos_grid2obs
@@ -318,19 +318,19 @@ suite evs_nco
               trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2obs_vhr_01
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_00 == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2obs_vhr_02
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_01 == complete
               edit VHR '02'
             task jevs_stats_aqm_atmos_grid2grid_vhr_00
               trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '00'
             task jevs_stats_aqm_atmos_grid2grid_vhr_01
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_00 == complete
               edit VHR '01'
             task jevs_stats_aqm_atmos_grid2grid_vhr_02
-              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0530 and :TIME < 1130 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_01 == complete
               edit VHR '02'
           endfamily
           family analyses
@@ -391,10 +391,10 @@ suite evs_nco
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00
-              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../../00/evs/v2.0/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00
-              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0545 and :TIME < 1145 and ../../../../../00/evs/v2.0/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '00'
           endfamily
         endfamily    # 00 stats
@@ -464,59 +464,59 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/prep'
           family rtofs
             task jevs_prep_rtofs
-              time 07:00
+              trigger :TIME >= 0700 and :TIME < 1300
           endfamily
           family global_ens
             task jevs_prep_global_ens_wave
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
           endfamily
           family mesoscale
             task jevs_prep_mesoscale_grid2obs
-              time 07:30
+              trigger :TIME >= 0730 and :TIME < 1330
               edit VHR '07'
           endfamily
           family cam
             task jevs_prep_cam_radar_vhr_06
-              time 06:05
+              trigger :TIME >= 0605 and :TIME < 1205
               edit VHR '06'
             task jevs_prep_cam_radar_vhr_07
-              time 07:05
+              trigger :TIME >= 0705 and :TIME < 1305
               edit VHR '07'
             task jevs_prep_cam_radar_vhr_08
-              time 08:05
+              trigger :TIME >= 0805 and :TIME < 1405
               edit VHR '08'
             task jevs_prep_cam_radar_vhr_09
-              time 09:05
+              trigger :TIME >= 0905 and :TIME < 1505
               edit VHR '09'
             task jevs_prep_cam_radar_vhr_10
-              time 10:05
+              trigger :TIME >= 1005 and :TIME < 1605
               edit VHR '10'
             task jevs_prep_cam_radar_vhr_11
-              time 11:05
+              trigger :TIME >= 1105 and :TIME < 1705
               edit VHR '11'
-            task jevs_prep_cam_namnest_precip_vhr_06
-              time 06:00
-              edit VHR '06'
-            task jevs_prep_cam_hrrr_precip_vhr_06
-              time 06:00
-              edit VHR '06'
-            task jevs_prep_cam_hireswfv3_precip_vhr_06
-              time 06:00
-              edit VHR '06'
             task jevs_prep_cam_hireswarw_precip_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_prep_cam_hireswarwmem2_precip_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hireswarw_precip_vhr_06 == complete
+              edit VHR '06'
+            task jevs_prep_cam_hireswfv3_precip_vhr_06
+              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hireswarwmem2_precip_vhr_06 == complete
+              edit VHR '06'
+            task jevs_prep_cam_hrrr_precip_vhr_06
+              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hireswfv3_precip_vhr_06 == complete
+              edit VHR '06'
+            task jevs_prep_cam_namnest_precip_vhr_06
+              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hrrr_precip_vhr_06 == complete
               edit VHR '06'
             task jevs_prep_cam_hrrr_severe_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_prep_cam_namnest_severe_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200 and jevs_prep_cam_hrrr_severe_vhr_06 == complete
               edit VHR '06'
             task jevs_prep_cam_severe
-              time 07:30
+              trigger :TIME >= 0730 and :TIME < 1330
               edit VHR '07'
           endfamily
         endfamily    # 06 prep
@@ -524,455 +524,425 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family global_ens
             task jevs_stats_global_ens_gefs_atmos_snowfall
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_snowfall
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_snowfall
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_sst
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_sea_ice
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_cnv
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_grid2grid
-              trigger :TIME >= 0830 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete    # walltime=03:30:00
+              trigger :TIME >= 0830 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_grid2obs
-              trigger :TIME >= 0945 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 0945 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_gefs_atmos_precip
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_grid2grid
-              trigger :TIME >= 0930 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete    # walltime=02:30:00
+              trigger :TIME >= 0930 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_grid2obs
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_cmce_atmos_precip
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_grid2grid
-              trigger :TIME >= 0900 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete    # walltime=03:00:00
+              trigger :TIME >= 0900 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_grid2obs
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_ecme_atmos_precip
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_naefs_atmos_grid2grid
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
             task jevs_stats_global_ens_naefs_atmos_grid2obs
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_atmos == complete
             task jevs_stats_global_ens_naefs_atmos_precip
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_naefs_atmos == complete
             task jevs_stats_global_ens_gfs_headline_grid2grid
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_headline == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_headline == complete
             task jevs_stats_global_ens_gefs_headline_grid2grid
-              trigger :TIME >= 1000 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_headline == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_headline == complete
             task jevs_stats_global_ens_naefs_headline_grid2grid
-              trigger :TIME >= 1100 and ../../../../00/evs/prep/global_ens/jevs_prep_global_ens_headline == complete
+              trigger :TIME >= 1100 and :TIME < 1700 and ../../../../../00/evs/v2.0/prep/global_ens/jevs_prep_global_ens_headline == complete
             task jevs_stats_global_ens_gefs_wave_grid2obs
-              trigger :TIME >= 1000 and ../../../../06/evs/prep/global_ens/jevs_prep_global_ens_wave == complete
+              trigger :TIME >= 1000 and :TIME < 1600 and ../../../../../06/evs/v2.0/prep/global_ens/jevs_prep_global_ens_wave == complete
           endfamily
           family wafs
             task jevs_stats_wafs_atmos
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
           endfamily
           family mesoscale
             task jevs_stats_mesoscale_nam_precip_vhr_06
-              time 06:10
+              trigger :TIME >= 0610 and :TIME < 1210
               edit VHR '06'
             task jevs_stats_mesoscale_nam_precip_vhr_07
-              time 07:10
+              trigger :TIME >= 0710 and :TIME < 1310
               edit VHR '07'
             task jevs_stats_mesoscale_nam_precip_vhr_08
-              time 08:10
+              trigger :TIME >= 0810 and :TIME < 1410
               edit VHR '08'
             task jevs_stats_mesoscale_nam_precip_vhr_09
-              time 09:10
+              trigger :TIME >= 0910 and :TIME < 1510
               edit VHR '09'
             task jevs_stats_mesoscale_nam_precip_vhr_10
-              time 10:10
+              trigger :TIME >= 1010 and :TIME < 1610
               edit VHR '10'
             task jevs_stats_mesoscale_nam_precip_vhr_11
-              time 11:00
+              trigger :TIME >= 1100 and :TIME < 1700
               edit VHR '11'
             task jevs_stats_mesoscale_rap_precip_vhr_06
-              time 06:10
+              trigger :TIME >= 0610 and :TIME < 1210
               edit VHR '06'
             task jevs_stats_mesoscale_rap_precip_vhr_07
-              time 07:10
+              trigger :TIME >= 0710 and :TIME < 1310
               edit VHR '07'
             task jevs_stats_mesoscale_rap_precip_vhr_08
-              time 08:10
+              trigger :TIME >= 0810 and :TIME < 1410
               edit VHR '08'
             task jevs_stats_mesoscale_rap_precip_vhr_09
-              time 09:10
+              trigger :TIME >= 0910 and :TIME < 1510
               edit VHR '09'
             task jevs_stats_mesoscale_rap_precip_vhr_10
-              time 10:10
+              trigger :TIME >= 1010 and :TIME < 1610
               edit VHR '10'
             task jevs_stats_mesoscale_rap_precip_vhr_11
-              time 11:00
+              trigger :TIME >= 1100 and :TIME < 1700
               edit VHR '11'
             task jevs_stats_mesoscale_nam_grid2obs
-              trigger :TIME >= 0800 and ../../prep/mesoscale/jevs_prep_mesoscale_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1300
               edit VHR '08'
             task jevs_stats_mesoscale_rap_grid2obs
-              trigger :TIME >= 0830 and ../../prep/mesoscale/jevs_prep_mesoscale_grid2obs == complete
+              trigger :TIME >= 0730 and :TIME < 1330
               edit VHR '08'
             task jevs_stats_mesoscale_nam_snowfall_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_mesoscale_rap_snowfall_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_mesoscale_sref_precip
-              time 09:30
+              trigger :TIME >= 0930 and :TIME < 1530
             task jevs_stats_mesoscale_sref_grid2obs
-              time 09:30
+              trigger :TIME >= 0930 and :TIME < 1530
           endfamily
           family cam
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_07
-              time 07:00
+              trigger :TIME >= 0700 and :TIME < 1300
               edit VHR '07'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_08
-              time 08:00
+              trigger :TIME >= 0800 and :TIME < 1400
               edit VHR '08'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_10
-              time 10:00
+              trigger :TIME >= 1000 and :TIME < 1600
               edit VHR '10'
-            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_11    # walltime=02:00:00
-              time 10:10
+            task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_11
+              trigger :TIME >= 1010 and :TIME < 1610
               edit VHR '11'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_06
-              time 06:40
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '06'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_07
-              time 07:40
+              trigger :TIME >= 0740 and :TIME < 1340 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_08
-              time 08:40
+              trigger :TIME >= 0840 and :TIME < 1440 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_09
-              time 09:40
+              trigger :TIME >= 0940 and :TIME < 1540 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_10
-              time 10:40
+              trigger :TIME >= 1040 and :TIME < 1640 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '10'
             task jevs_stats_cam_hireswarwmem2_radar_vhr_11
-              time 11:40
+              trigger :TIME >= 1140 and :TIME < 1740 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '11'
             task jevs_stats_cam_hireswarw_radar_vhr_06
-              time 06:40
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '06'
             task jevs_stats_cam_hireswarw_radar_vhr_07
-              time 07:40
+              trigger :TIME >= 0740 and :TIME < 1340 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_cam_hireswarw_radar_vhr_08
-              time 08:40
+              trigger :TIME >= 0840 and :TIME < 1440 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_hireswarw_radar_vhr_09
-              time 09:40
+              trigger :TIME >= 0940 and :TIME < 1540 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_cam_hireswarw_radar_vhr_10
-              time 10:40
+              trigger :TIME >= 1040 and :TIME < 1640 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '10'
             task jevs_stats_cam_hireswarw_radar_vhr_11
-              time 11:40
+              trigger :TIME >= 1140 and :TIME < 1740 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '11'
             task jevs_stats_cam_hireswfv3_radar_vhr_06
-              time 06:40
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '06'
             task jevs_stats_cam_hireswfv3_radar_vhr_07
-              time 07:40
+              trigger :TIME >= 0740 and :TIME < 1340 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_cam_hireswfv3_radar_vhr_08
-              time 08:40
+              trigger :TIME >= 0840 and :TIME < 1440 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_hireswfv3_radar_vhr_09
-              time 09:40
+              trigger :TIME >= 0940 and :TIME < 1540 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_cam_hireswfv3_radar_vhr_10
-              time 10:40
+              trigger :TIME >= 1040 and :TIME < 1640 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '10'
             task jevs_stats_cam_hireswfv3_radar_vhr_11
-              time 11:40
+              trigger :TIME >= 1140 and :TIME < 1740 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '11'
             task jevs_stats_cam_href_radar_vhr_06
-              time 06:40
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '06'
             task jevs_stats_cam_href_radar_vhr_07
-              time 07:40
+              trigger :TIME >= 0740 and :TIME < 1340 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_cam_href_radar_vhr_08
-              time 08:40
+              trigger :TIME >= 0840 and :TIME < 1440 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_href_radar_vhr_09
-              time 09:40
+              trigger :TIME >= 0940 and :TIME < 1540 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_cam_href_radar_vhr_10
-              time 10:40
+              trigger :TIME >= 1040 and :TIME < 1640 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '10'
             task jevs_stats_cam_href_radar_vhr_11
-              time 11:40
+              trigger :TIME >= 1140 and :TIME < 1740 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '11'
             task jevs_stats_cam_hrrr_radar_vhr_06
-              time 06:40
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '06'
             task jevs_stats_cam_hrrr_radar_vhr_07
-              time 07:40
+              trigger :TIME >= 0740 and :TIME < 1340 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_cam_hrrr_radar_vhr_08
-              time 08:40
+              trigger :TIME >= 0840 and :TIME < 1440 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_hrrr_radar_vhr_09
-              time 09:40
+              trigger :TIME >= 0940 and :TIME < 1540 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_cam_hrrr_radar_vhr_10
-              time 10:40
+              trigger :TIME >= 1040 and :TIME < 1640 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '10'
             task jevs_stats_cam_hrrr_radar_vhr_11
-              time 11:40
+              trigger :TIME >= 1140 and :TIME < 1740 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '11'
             task jevs_stats_cam_namnest_radar_vhr_06
-              time 06:40
+              trigger :TIME >= 0640 and :TIME < 1240 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '06'
             task jevs_stats_cam_namnest_radar_vhr_07
-              time 07:40
+              trigger :TIME >= 0740 and :TIME < 1340 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_cam_namnest_radar_vhr_08
-              time 08:40
+              trigger :TIME >= 0840 and :TIME < 1440 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_namnest_radar_vhr_09
-              time 09:40
+              trigger :TIME >= 0940 and :TIME < 1540 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '09'
             task jevs_stats_cam_namnest_radar_vhr_10
-              time 10:40
+              trigger :TIME >= 1040 and :TIME < 1640 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '10'
             task jevs_stats_cam_namnest_radar_vhr_11
-              time 11:40
+              trigger :TIME >= 1140 and :TIME < 1740 and ../../prep/cam/jevs_prep_cam_radar_vhr_06 == complete
               edit VHR '11'
             task jevs_stats_cam_hireswarw_snowfall_vhr_06
-              time 06:30
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswarwmem2_snowfall_vhr_06
-              time 06:30
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswfv3_snowfall_vhr_06
-              time 06:30
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hrrr_snowfall_vhr_06
-              time 06:30
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_namnest_snowfall_vhr_06
-              time 06:30
+              trigger :TIME >= 0630 and :TIME < 1230
               edit VHR '06'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_cam_hireswarw_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_cam_hireswarwmem2_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_cam_hireswfv3_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_hrrr_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_cam_hrrr_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_namnest_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_cam_namnest_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
-            task jevs_stats_cam_hireswarwmem2_severe
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/cam/jevs_prep_cam_hireswarwmem2_severe_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_prep_cam_hireswarwmem2_severe_vhr_12 == complete
-              edit VHR '08'
-            task jevs_stats_cam_hireswarw_severe
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/cam/jevs_prep_cam_hireswarw_severe_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_prep_cam_hireswarw_severe_vhr_12 == complete
-              edit VHR '08'
-            task jevs_stats_cam_hireswfv3_severe
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/cam/jevs_prep_cam_hireswfv3_severe_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_prep_cam_hireswfv3_severe_vhr_12 == complete
-              edit VHR '08'
-            task jevs_stats_cam_href_severe
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/cam/jevs_prep_cam_href_severe_vhr_00 == complete and ../../../../12/evs/prep/cam/jevs_prep_cam_href_severe_vhr_12 == complete
-              edit VHR '08'
             task jevs_stats_cam_hrrr_severe
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/cam/jevs_prep_cam_hrrr_severe_prep_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_prep_cam_hrrr_severe_vhr_06 == complete
+              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hrrr_severe_prep_vhr_00 == complete and ../../../../../06/evs/v2.0/prep/cam/jevs_cam_hrrr_severe_prep_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_namnest_severe
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/cam/jevs_prep_cam_namnest_severe_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_prep_cam_namnest_severe_vhr_06 == complete
+              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_namnest_severe_prep_vhr_00 == complete and ../../../../../06/evs/v2.0/prep/cam/jevs_cam_namnest_severe_prep_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_href_grid2obs
-              time 07:30
+              trigger :TIME >= 0730 and :TIME < 1330
             task jevs_stats_cam_href_precip
-              time 08:30
+              trigger :TIME >= 0830 and :TIME < 1430
             task jevs_stats_cam_href_snowfall
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
             task jevs_stats_cam_href_spcoutlook
-              trigger :TIME >= 0830 and ../../prep/cam/jevs_prep_cam_severe == complete
+              trigger :TIME >= 0830 and :TIME < 1430 and ../../prep/cam/jevs_prep_cam_severe == complete
           endfamily
           family aqm
             task jevs_stats_aqm_atmos_grid2obs_vhr_03
-              trigger :TIME >= 0600 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_aqm_atmos_grid2obs_vhr_04
-              trigger :TIME >= 0610 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_03 == complete
               edit VHR '04'
             task jevs_stats_aqm_atmos_grid2obs_vhr_05
-              trigger :TIME >= 0620 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_04 == complete
               edit VHR '05'
             task jevs_stats_aqm_atmos_grid2obs_vhr_06
-              trigger :TIME >= 0630 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_05 == complete
               edit VHR '06'
             task jevs_stats_aqm_atmos_grid2obs_vhr_07
-              trigger :TIME >= 0730 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_aqm_atmos_grid2obs_vhr_08
-              trigger :TIME >= 0740 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_07 == complete
               edit VHR '08'
             task jevs_stats_aqm_atmos_grid2obs_vhr_09
-              trigger :TIME >= 0750 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_08 == complete
               edit VHR '09'
             task jevs_stats_aqm_atmos_grid2obs_vhr_10
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_09 == complete
               edit VHR '10'
             task jevs_stats_aqm_atmos_grid2obs_vhr_11
-              trigger :TIME >= 0810 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_10 == complete
               edit VHR '11'
-            task jevs_stats_aqm_atmos_grid2obs_vhr_12
-              trigger :TIME >= 1135 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
-              edit VHR '12'
-            task jevs_stats_aqm_atmos_grid2obs_vhr_13
-              trigger :TIME >= 1145 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
-              edit VHR '13'
-            task jevs_stats_aqm_atmos_grid2obs_vhr_14
-              trigger :TIME >= 1155 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
-              edit VHR '14'
             task jevs_stats_aqm_atmos_grid2grid_vhr_03
-              trigger :TIME >= 0600 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '03'
             task jevs_stats_aqm_atmos_grid2grid_vhr_04
-              trigger :TIME >= 0610 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_03 == complete
               edit VHR '04'
             task jevs_stats_aqm_atmos_grid2grid_vhr_05
-              trigger :TIME >= 0620 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_04 == complete
               edit VHR '05'
             task jevs_stats_aqm_atmos_grid2grid_vhr_06
-              trigger :TIME >= 0630 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_05 == complete
               edit VHR '06'
             task jevs_stats_aqm_atmos_grid2grid_vhr_07
-              trigger :TIME >= 0730 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_06 == complete
               edit VHR '07'
             task jevs_stats_aqm_atmos_grid2grid_vhr_08
-              trigger :TIME >= 0740 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_07 == complete
               edit VHR '08'
             task jevs_stats_aqm_atmos_grid2grid_vhr_09
-              trigger :TIME >= 0750 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_08 == complete
               edit VHR '09'
             task jevs_stats_aqm_atmos_grid2grid_vhr_10
-              trigger :TIME >= 0800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_09 == complete
               edit VHR '10'
             task jevs_stats_aqm_atmos_grid2grid_vhr_11
-              trigger :TIME >= 0810 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              trigger :TIME >= 0600 and :TIME < 1200 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_10 == complete
               edit VHR '11'
-            task jevs_stats_aqm_atmos_grid2grid_vhr_12
-              trigger :TIME >= 1135 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
-              edit VHR '12'
-            task jevs_stats_aqm_atmos_grid2grid_vhr_13
-              trigger :TIME >= 1145 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
-              edit VHR '13'
-            task jevs_stats_aqm_atmos_grid2grid_vhr_14
-              trigger :TIME >= 1155 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
-              edit VHR '14'
           endfamily
           family analyses
             task jevs_stats_analyses_urma_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_analyses_urma_grid2obs_vhr_07
-              time 07:00
+              trigger :TIME >= 0700 and :TIME < 1300
               edit VHR '07'
             task jevs_stats_analyses_urma_grid2obs_vhr_08
-              time 08:00
+              trigger :TIME >= 0800 and :TIME < 1400
               edit VHR '08'
             task jevs_stats_analyses_urma_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_analyses_urma_grid2obs_vhr_10
-              time 10:00
+              trigger :TIME >= 1000 and :TIME < 1600
               edit VHR '10'
             task jevs_stats_analyses_urma_grid2obs_vhr_11
-              time 11:00
+              trigger :TIME >= 1100 and :TIME < 1700
               edit VHR '11'
             task jevs_stats_analyses_rtma_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_analyses_rtma_grid2obs_vhr_07
-              time 07:00
+              trigger :TIME >= 0700 and :TIME < 1300
               edit VHR '07'
             task jevs_stats_analyses_rtma_grid2obs_vhr_08
-              time 08:00
+              trigger :TIME >= 0800 and :TIME < 1400
               edit VHR '08'
             task jevs_stats_analyses_rtma_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_analyses_rtma_grid2obs_vhr_10
-              time 10:00
+              trigger :TIME >= 1000 and :TIME < 1600
               edit VHR '10'
             task jevs_stats_analyses_rtma_grid2obs_vhr_11
-              time 11:00
+              trigger :TIME >= 1100 and :TIME < 1700
               edit VHR '11'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_06
-              time 06:00
+              trigger :TIME >= 0600 and :TIME < 1200
               edit VHR '06'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_07
-              time 07:00
+              trigger :TIME >= 0700 and :TIME < 1300
               edit VHR '07'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_08
-              time 08:00
+              trigger :TIME >= 0800 and :TIME < 1400
               edit VHR '08'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_09
-              time 09:00
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_10
-              time 10:00
+              trigger :TIME >= 1000 and :TIME < 1600
               edit VHR '10'
             task jevs_stats_analyses_rtma_ru_grid2obs_vhr_11
-              time 11:00
+              trigger :TIME >= 1100 and :TIME < 1700
               edit VHR '11'
           endfamily
           family global_chem
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03
-              trigger :TIME >= 0615 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
-              edit VHR '03'
-            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03
-              trigger :TIME >= 0615 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
               edit VHR '03'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06
-              trigger :TIME >= 0705 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
-              edit VHR '06'
-            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06
-              trigger :TIME >= 0705 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_03 == complete
               edit VHR '06'
             task jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_09
-              trigger :TIME >= 0730 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_06 == complete
               edit VHR '09'
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03
+              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              edit VHR '03'
+            task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06
+              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_03 == complete
+              edit VHR '06'
             task jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_09
-              trigger :TIME >= 0730 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete
+              trigger :TIME >= 0700 and :TIME < 1300 and ../../../../00/evs/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs == complete and ./jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_06 == complete
               edit VHR '09'
           endfamily
         endfamily    # 06 stats
@@ -980,15 +950,15 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family mesoscale
             task jevs_plots_mesoscale_grid2obs_last90days
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
-              time 09:00
             task jevs_plots_mesoscale_headline
+              trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
-              time 09:00
           endfamily
           family global_ens
 	    task jevs_plots_global_ens_wave_gefs_grid2obs_last90days
-              trigger :TIME >= 1135 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_wave_grid2obs == complete
+              trigger :TIME >= 1100 and :TIME < 1700 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_wave_grid2obs == complete
           endfamily
         endfamily    # 06 plots
       endfamily  # evs
@@ -1138,6 +1108,18 @@ suite evs_nco
               trigger :TIME >= 1325 and ../../prep/global_det/jevs_prep_global_det_wave == complete
           endfamily
           family cam
+            task jevs_stats_cam_hireswarwmem2_severe
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_hireswarwmem2_severe_prep_vhr_12 == complete
+              edit VHR '08'
+            task jevs_stats_cam_hireswarw_severe
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hireswarw_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_hireswarw_severe_prep_vhr_12 == complete
+              edit VHR '08'
+            task jevs_stats_cam_hireswfv3_severe
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_hireswfv3_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_hireswfv3_severe_prep_vhr_12 == complete
+              edit VHR '08'
+            task jevs_stats_cam_href_severe
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../../00/evs/v2.0/prep/cam/jevs_cam_href_severe_prep_vhr_00 == complete and ../../../../../12/evs/v2.0/prep/cam/jevs_cam_href_severe_prep_vhr_12 == complete
+              edit VHR '08'
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_12
               time 12:15
               edit VHR '12'
@@ -1311,6 +1293,15 @@ suite evs_nco
               edit VHR '15'
           endfamily
           family aqm
+            task jevs_stats_aqm_atmos_grid2obs_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
+              edit VHR '12'
+            task jevs_stats_aqm_atmos_grid2obs_vhr_13
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete
+              edit VHR '13'
+            task jevs_stats_aqm_atmos_grid2obs_vhr_14
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete and ./jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete
+              edit VHR '14'
             task jevs_stats_aqm_atmos_grid2obs_vhr_15
               trigger :TIME >= 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2obs == complete
               edit VHR '15'
@@ -1337,6 +1328,16 @@ suite evs_nco
               edit VHR '22'
             task jevs_stats_aqm_atmos_grid2obs_vhr_23
               trigger :TIME >= 1330 and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_00 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_01 == complete and ../../../../00/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_02 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_03 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_04 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_05 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_11 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_12 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_13 == complete and ../../../../06/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_17 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_18 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_19 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_20 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_21 == complete and ../../../../12/evs/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_22 == complete
+              edit VHR '23'
+            task jevs_stats_aqm_atmos_grid2grid_vhr_12
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
+              edit VHR '12'
+            task jevs_stats_aqm_atmos_grid2grid_vhr_13
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_12 == complete
+              edit VHR '13'
+            task jevs_stats_aqm_atmos_grid2grid_vhr_14
+              trigger :TIME >= 1200 and :TIME < 1800 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete and ./jevs_stats_aqm_atmos_grid2grid_vhr_13 == complete
+              edit VHR '14'
             task jevs_stats_aqm_atmos_grid2grid_vhr_15
               trigger :TIME >= 1205 and ../../../../00/evs/prep/aqm/jevs_prep_aqm_atmos_grid2grid == complete
               edit VHR '15'

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -799,10 +799,10 @@ suite evs_nco
               trigger :TIME >= 0900 and :TIME < 1500
               edit VHR '09'
             task jevs_stats_cam_hrrr_severe
-              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_cam_hrrr_severe_prep_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_cam_hrrr_severe_prep_vhr_06 == complete
+              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_prep_cam_hrrr_severe_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_prep_cam_hrrr_severe_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_namnest_severe
-              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_cam_namnest_severe_prep_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_cam_namnest_severe_prep_vhr_06 == complete
+              trigger :TIME >= 0800 and :TIME < 1400 and ../../../../00/evs/prep/cam/jevs_prep_cam_namnest_severe_vhr_00 == complete and ../../../../06/evs/prep/cam/jevs_prep_cam_namnest_severe_vhr_06 == complete
               edit VHR '08'
             task jevs_stats_cam_href_grid2obs
               trigger :TIME >= 0730 and :TIME < 1330


### PR DESCRIPTION
## Description of Changes

**Summary: This PR only updates ecf/defs/evs-nco.def.** 
The EVS v2.0 evs-nco.def file was incredibly out of date. It did not match our EVS v2.0 parallel perfectly and didn't use the best ecflow practices of EVS v1.0 in ops. I've updated the EVS v2.0 evs-nco.def file to incorporate the best preactices of the ops EVS v1.0 NCO defs file (like using a 6-hour span for jobs to get triggered and not just one start time), as well as the timings from our EVS v2.0 parallel cronjobs. At times, I updated the emc.vpppg parallel to be more consistent with current ops EVS when the change was not dramatic. For example, almost no ops EVS v1.0 jobs run between 18:00Z and 18:15Z, which I think is intentional so that NCO can switch EVS versions during that timeframe. The High Water Mark chart will update over the next few days with these small adjustments. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes

* Do you have any planned upcoming annual leave/PTO?
Yes (Nov 25th–Dec 2nd)

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
Yes, but I've already made those changes in the emc.vpppg EVS v2.0 parallel. 
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

This PR does not need to be tested, but it would be helpful is all developers (and at least 2 code managers) took a look at the changes in evs-nco.def. Also, [here is a spreadsheet](https://docs.google.com/spreadsheets/d/1-gIVf7bXsSZDDye82gSboD2tjJaarqZaKaxV6mSGak4/edit?gid=606824942#gid=606824942) of how the EVS v2.0 defs file differs from the EVS v1.0 ops defs file. If the EVS v2.0 start time colomn is blue, it means that job's start time changed in EVS v2.0. If your component has any blue rows, please confirm that you don't see any issues with the new start time. Thank you!

@AndrewBenjamin-NOAA @ShannonShields-NOAA @MarcelCaron-NOAA @Ho-ChunHuang-NOAA @GwenChen-NOAA @QiShi-NOAA @SamiraArdani-NOAA
