### PR TITLE
Feature/ecf and dev driver consistency update

### DIFF
--- a/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sea_ice_last31days.sh
+++ b/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sea_ice_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=22:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=22:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sea_ice_last90days.sh
+++ b/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sea_ice_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=22:ompthreads=1:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=22:ompthreads=1:mem=50GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_precip_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_precip_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=2:ncpus=70:mem=100GB
+#PBS -l place=vscatter:shared,select=2:ncpus=70:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_precip_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_precip_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=2:ncpus=70:mem=300GB
+#PBS -l place=vscatter:shared,select=2:ncpus=70:mem=300GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_sea_ice_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_sea_ice_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=29:mem=10GB
+#PBS -l place=vscatter:shared,select=1:ncpus=29:mem=10GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_sea_ice_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_sea_ice_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=29:mem=10GB
+#PBS -l place=vscatter:shared,select=1:ncpus=29:mem=10GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_snowfall_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_snowfall_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=2:ncpus=95:mem=60GB
+#PBS -l place=vscatter:shared,select=2:ncpus=95:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_snowfall_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_snowfall_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=2:ncpus=95:mem=100GB
+#PBS -l place=vscatter:shared,select=2:ncpus=95:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_grid2grid_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_grid2grid_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=24:mem=15GB
+#PBS -l place=vscatter:shared,select=1:ncpus=24:mem=15GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_grid2grid_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_grid2grid_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=24:mem=15GB
+#PBS -l place=vscatter:shared,select=1:ncpus=24:mem=15GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_precip_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_precip_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=28:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=28:mem=50GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_precip_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_atmos_naefs_precip_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=28:mem=100GB
+#PBS -l place=vscatter:shared,select=1:ncpus=28:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_wave_gefs_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_wave_gefs_grid2obs_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=108:mem=110G
+#PBS -l place=vscatter:exclhost,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_wave_gefs_grid2obs_last90days.sh
+++ b/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_wave_gefs_grid2obs_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=108:mem=110G
+#PBS -l place=vscatter:exclhost,select=1:ncpus=108:mem=110G
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
+++ b/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
@@ -5,7 +5,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=1:ompthreads=1:mem=128GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=128GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
+++ b/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_prep_analyses_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hireswarwmem2_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hireswarwmem2_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_prep_cam_hireswarwmem2_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hireswfv3_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hireswfv3_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_prep_cam_hireswfv3_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_prep_cam_hrrr_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_namnest_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_namnest_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_prep_cam_namnest_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:45:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=100GB
+#PBS -l place=shared,select=1:ncpus=1:mem=100GB
 #PBS -l debug=true
 
 set -x 

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_headline.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_headline.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_naefs_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_naefs_atmos.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=34:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=34:mem=50GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=02:30:00
-#PBS -l place=vscatter,select=1:ncpus=1:ompthreads=1:mem=300GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=300GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_analyses_ccpa_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_analyses_rtma_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_analyses_rtma_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_analyses_rtma_ru_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_analyses_urma_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_analyses_urma_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_grid2obs.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hireswarw_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hireswarw_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_severe.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=500MB
+#PBS -l place=shared,select=1:ncpus=1:mem=500MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarw_snowfall.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #PBS -N jevs_stats_cam_hireswarw_snowfall
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hireswarwmem2_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hireswarwmem2_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_severe.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=500MB
+#PBS -l place=shared,select=1:ncpus=1:mem=500MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswfv3_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswfv3_grid2obs.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hireswfv3_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswfv3_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswfv3_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hireswfv3_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswfv3_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hireswfv3_severe.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=500MB
+#PBS -l place=shared,select=1:ncpus=1:mem=500MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_href_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_href_severe.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=500MB
+#PBS -l place=shared,select=1:ncpus=1:mem=500MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_grid2obs.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hrrr_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_hrrr_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_severe.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=500MB
+#PBS -l place=shared,select=1:ncpus=1:mem=500MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_namnest_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_namnest_grid2obs.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_namnest_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_namnest_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_namnest_precip.sh
@@ -1,4 +1,3 @@
-#PBS -S /bin/bash
 #PBS -N jevs_stats_cam_namnest_precip
 #PBS -j oe
 #PBS -S /bin/bash

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_namnest_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_namnest_severe.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=exclhost,select=1:ncpus=1:mem=500MB
+#PBS -l place=shared,select=1:ncpus=1:mem=500MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:05:00
-#PBS -l place=vscatter,select=1:ncpus=40:ompthreads=1:mem=75GB
+#PBS -l place=vscatter:shared,select=1:ncpus=40:ompthreads=1:mem=75GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter,select=1:ncpus=28:ompthreads=1:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=28:ompthreads=1:mem=50GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=31:ompthreads=1:mem=35GB
+#PBS -l place=vscatter:shared,select=1:ncpus=31:ompthreads=1:mem=35GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=1:ncpus=14:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=14:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=11:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=11:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=11:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=11:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=53:ompthreads=1:mem=60GB
+#PBS -l place=vscatter:shared,select=1:ncpus=53:ompthreads=1:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=14:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=14:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=20:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=20:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=14:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=14:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=1:ncpus=25:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=25:mem=50GB
 #PBS -l debug=true
 
 set -x 

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=43:ompthreads=1:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=43:ompthreads=1:mem=50GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=14:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=14:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=31:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=31:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=14:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=14:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=11:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=11:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=32:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=32:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=14:ompthreads=1:mem=25GB
+#PBS -l place=vscatter:shared,select=1:ncpus=14:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:10:00
-#PBS -l place=vscatter,select=1:ncpus=2:mem=50GB
+#PBS -l place=vscatter:shared,select=1:ncpus=2:mem=50GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:30:00
-#PBS -l place=vscatter,select=1:ncpus=24:mem=10GB
+#PBS -l place=vscatter:shared,select=1:ncpus=24:mem=10GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=5GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=5GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_wmo_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_wmo_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter,select=1:ncpus=2:mem=100GB
+#PBS -l place=vscatter:shared,select=1:ncpus=2:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:50:00
-#PBS -l place=vscatter,select=1:ncpus=2:mem=100GB
+#PBS -l place=vscatter:shared,select=1:ncpus=2:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=02:00:00
-#PBS -l place=vscatter,select=1:ncpus=24:mem=80GB
+#PBS -l place=vscatter:shared,select=1:ncpus=24:mem=80GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=5GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=5GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=28:mem=15GB
+#PBS -l place=vscatter:shared,select=1:ncpus=28:mem=15GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=02:00:00
-#PBS -l place=vscatter,select=1:ncpus=4:mem=120GB
+#PBS -l place=vscatter:shared,select=1:ncpus=4:mem=120GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=02:30:00
-#PBS -l place=vscatter,select=1:ncpus=60:mem=60GB
+#PBS -l place=vscatter:shared,select=1:ncpus=60:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=5:mem=30GB
+#PBS -l place=vscatter:shared,select=1:ncpus=5:mem=30GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=4GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=4GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=2GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=2GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_headline_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wave_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wave_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=36:mem=50G
+#PBS -l place=vscatter:shared,select=1:ncpus=36:mem=50G
 #PBS -l debug=true
 
 set -x 

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wmo_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wmo_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter,select=1:ncpus=2:mem=100GB
+#PBS -l place=vscatter:shared,select=1:ncpus=2:mem=100GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gfs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gfs_headline_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:45:00
-#PBS -l place=vscatter,select=1:ncpus=2:mem=20GB
+#PBS -l place=vscatter:shared,select=1:ncpus=2:mem=20GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:45:00
-#PBS -l place=vscatter,select=1:ncpus=12:mem=6GB
+#PBS -l place=vscatter:shared,select=1:ncpus=12:mem=6GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=4GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=4GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_headline_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=1:mem=1GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:mem=1GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/nfcens/jevs_stats_nfcens_wave_grid2obs.sh
+++ b/dev/drivers/scripts/stats/nfcens/jevs_stats_nfcens_wave_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=36:mem=50G
+#PBS -l place=vscatter:shared,select=1:ncpus=36:mem=50G
 #PBS -l debug=true
 
 set -x 

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=66:ompthreads=1:mem=70GB
+#PBS -l place=vscatter:shared,select=1:ncpus=66:ompthreads=1:mem=70GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=8:ompthreads=1:mem=60GB
+#PBS -l place=vscatter:shared,select=1:ncpus=8:ompthreads=1:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2grid.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=1:ncpus=66:ompthreads=1:mem=70GB
+#PBS -l place=vscatter:shared,select=1:ncpus=66:ompthreads=1:mem=70GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_gefs_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter,select=1:ncpus=8:ompthreads=1:mem=60GB
+#PBS -l place=vscatter:shared,select=1:ncpus=8:ompthreads=1:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_means_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_means_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_means_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_means_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_precip_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_precip_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_precip_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_precip_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_pres_levs_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_pres_levs_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_pres_levs_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_pres_levs_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_snow_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_snow_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_snow_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_snow_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sst_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sst_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:shared,select=1:ncpus=32:ompthreads=1:mem=32GB
+#PBS -l place=vscatter,select=1:ncpus=32:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sst_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sst_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:shared,select=1:ncpus=32:ompthreads=1:mem=50GB
+#PBS -l place=vscatter,select=1:ncpus=32:ompthreads=1:mem=50GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_pres_levs_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_pres_levs_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:45:00
-#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=250GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_pres_levs_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_pres_levs_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=375GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_ptype_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_ptype_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_ptype_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_ptype_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_sfc_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_sfc_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=275GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_sfc_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_sfc_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=325GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_wave_grid2obs_last31days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_wave_grid2obs_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:25:00
-#PBS -l place=vscatter:shared,select=1:ncpus=15:mem=35GB
+#PBS -l place=vscatter,select=1:ncpus=15:mem=35GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_wave_grid2obs_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_wave_grid2obs_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=vscatter:shared,select=1:ncpus=15:mem=75GB
+#PBS -l place=vscatter,select=1:ncpus=15:mem=75GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_precip_spatial.ecf
+++ b/ecf/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_precip_spatial.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:25:00
+#PBS -l walltime=00:30:00
 #PBS -l place=shared,select=1:ncpus=1:mem=5GB
 #PBS -l debug=true
 

--- a/ecf/scripts/prep/analyses/jevs_prep_analyses_precip_vhr_master.ecf
+++ b/ecf/scripts/prep/analyses/jevs_prep_analyses_precip_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=3:ompthreads=1:mem=128GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=128GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_stats_cam_hireswarw_grid2obs_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:10:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_stats_cam_hireswarwmem2_grid2obs_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:10:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_stats_cam_hireswfv3_grid2obs_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:00:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=128GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ecf/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.ecf
+++ b/ecf/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:25:00
+#PBS -l walltime=00:20:00
 #PBS -l place=vscatter:shared,select=1:ncpus=25:mem=50GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:shared,select=1:ncpus=32:ompthreads=1:mem=35GB
+#PBS -l place=vscatter:shared,select=1:ncpus=32:ompthreads=1:mem=25GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=02:30:00
-#PBS -l place=vscatter,select=1:ncpus=60:mem=60GB
+#PBS -l place=vscatter:shared,select=1:ncpus=60:mem=60GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_master.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_nam_precip_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_master.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_nam_snowfall_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_master.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_rap_precip_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_master.ecf
+++ b/ecf/scripts/stats/mesoscale/jevs_stats_mesoscale_rap_snowfall_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=500GB
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=150GB
 #PBS -l debug=true
 
 export model=evs


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

This PR updates .ecf resources so that they match the dev drivers that have been updated for v2.0.
In addition, several dev drivers had `vscatter:shared` removed. NCO prefers shared node usage, so "shared" was added back to the dev drivers to match operational EVS. This is where the bulk of the testing will need to take place.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
* Do you have any planned upcoming annual leave/PTO?
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AndrewBenjamin-NOAA/EVS.git
cd EVS/
git checkout feature/ecf_script-update
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh

Please edit and test all of the global_ens stats dev drivers. Things to change in dev drivers:
-HOMEevs to the directory that you are currently in (e.g., add /pr###test)
-COMIN from $USER to emc.vpppg
-KEEPDATA to YES
-SENDMAIL to NO

Drivers to test
**Prep**
- jevs_prep_analyses_precip.sh‎  (vhr= 00, 06,12 or 18)
- jevs_prep_global_det_atmos.sh‎
- jevs_prep_global_ens_headline.sh
- jevs_prep_global_ens_naefs_atmos.sh
- jevs_prep_subseasonal_gefs.sh

**Stats**
 (qsub -v vhr=08 $driver, @MarcelCaron-NOAA please confirm vhr for testing)
- jevs_stats_cam_hireswarw_severe.sh
- jevs_stats_cam_hireswarwmem2_severe.sh
- jevs_stats_cam_hireswfv3_severe.sh
- jevs_stats_cam_href_severe.sh
- jevs_stats_cam_hrrr_severe.sh
- jevs_stats_cam_namnest_severe.sh

- jevs_stats_global_det_cfs_atmos_grid2grid.sh
- jevs_stats_global_det_cfs_atmos_grid2obs.sh
- jevs_stats_global_det_cmc_atmos_grid2grid.sh
- jevs_stats_global_det_cmc_atmos_grid2obs.sh
- jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
- jevs_stats_global_det_dwd_atmos_grid2grid.sh
- jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
- jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
- jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
- jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
- jevs_stats_global_det_gfs_wave_grid2obs.sh
- jevs_stats_global_det_imd_atmos_grid2grid.sh
- jevs_stats_global_det_imd_atmos_grid2obs.sh
- jevs_stats_global_det_jma_atmos_grid2grid.sh
- jevs_stats_global_det_jma_atmos_grid2obs.sh
- jevs_stats_global_det_metfra_atmos_grid2grid.sh
- jevs_stats_global_det_ukmet_atmos_grid2grid.sh
- jevs_stats_global_det_ukmet_atmos_grid2obs.sh

- jevs_stats_global_ens_cmce_atmos_grid2grid.sh
- jevs_stats_global_ens_cmce_atmos_grid2obs.sh
- jevs_stats_global_ens_cmce_atmos_precip.sh
- jevs_stats_global_ens_cmce_atmos_snowfall.sh
- jevs_stats_global_ens_cmce_atmos_snowfall.sh
- jevs_stats_global_ens_cmce_wmo_grid2grid.sh
- jevs_stats_global_ens_ecme_atmos_grid2grid.sh
- jevs_stats_global_ens_ecme_atmos_grid2obs.sh
- jevs_stats_global_ens_ecme_atmos_precip.sh
- jevs_stats_global_ens_ecme_atmos_snowfall.sh
- jevs_stats_global_ens_gefs_atmos_cnv.sh
- jevs_stats_global_ens_gefs_atmos_grid2grid.sh
- jevs_stats_global_ens_gefs_atmos_grid2obs.sh
- jevs_stats_global_ens_gefs_atmos_precip.sh
- jevs_stats_global_ens_gefs_atmos_sea_ice.sh
- jevs_stats_global_ens_gefs_atmos_snowfall.sh
- jevs_stats_global_ens_gefs_atmos_sst.sh
- jevs_stats_global_ens_gefs_headline_grid2grid.sh
- jevs_stats_global_ens_gefs_wave_grid2obs.sh
- jevs_stats_global_ens_gefs_wmo_grid2grid.sh
- jevs_stats_global_ens_gfs_headline_grid2grid.sh
- jevs_stats_global_ens_naefs_atmos_grid2grid.sh
- jevs_stats_global_ens_naefs_atmos_grid2obs.sh
- jevs_stats_global_ens_naefs_atmos_precip.sh
- jevs_stats_global_ens_naefs_headline_grid2grid.sh

- jevs_stats_nfcens_wave_grid2obs.sh
- jevs_stats_subseasonal_cfs_grid2grid.sh
- jevs_stats_subseasonal_cfs_grid2obs.sh
- jevs_stats_subseasonal_gefs_grid2grid.sh
- jevs_stats_subseasonal_gefs_grid2obs.sh

**Plots**
- jevs_plots_global_det_atmos_grid2grid_sea_ice_last31days.sh
- jevs_plots_global_det_atmos_grid2grid_sea_ice_last90days.sh
- jevs_plots_global_ens_atmos_gefs_precip_last31days.sh
- jevs_plots_global_ens_atmos_gefs_precip_last90days.sh
- jevs_plots_global_ens_atmos_gefs_sea_ice_last31days.sh
- jevs_plots_global_ens_atmos_gefs_sea_ice_last90days.sh
- jevs_plots_global_ens_atmos_gefs_snowfall_last31days.sh
- jevs_plots_global_ens_atmos_gefs_snowfall_last90days.sh
- jevs_plots_global_ens_atmos_naefs_grid2grid_last31days.sh
- jevs_plots_global_ens_atmos_naefs_grid2grid_last90days.sh
- jevs_plots_global_ens_atmos_naefs_precip_last31days.sh
- jevs_plots_global_ens_atmos_naefs_precip_last90days.sh
- jevs_plots_global_ens_wave_gefs_grid2obs_last31days.sh
- jevs_plots_global_ens_wave_gefs_grid2obs_last90days.sh

Also, a number dev drivers in cam and analyses had a duplicate `#PBS -S /bin/bash` line that was also removed, but I am not sure if they need to be tested again, my initial tests were successful with removing the line. They include:
- jevs_prep_cam_hireswarwmem2_precip.sh
- jevs_prep_cam_hireswfv3_precip.sh‎
- jevs_prep_cam_hrrr_precip.sh
- jevs_prep_cam_namnest_precip.sh

- jevs_stats_analyses_ccpa_precip.sh
- jevs_stats_analyses_rtma_grid2obs.sh
- jevs_stats_analyses_rtma_grid2obs.sh
- jevs_stats_analyses_rtma_precip.sh
- jevs_stats_analyses_rtma_ru_grid2obs.sh
- jevs_stats_analyses_urma_grid2obs.sh
- jevs_stats_analyses_urma_precip.sh

- jevs_stats_cam_hireswarw_grid2obs.sh
- jevs_stats_cam_hireswarw_precip.sh
- jevs_stats_cam_hireswarw_snowfall.sh
- jevs_stats_cam_hireswarwmem2_grid2obs.sh
- jevs_stats_cam_hireswarwmem2_precip.sh
- jevs_stats_cam_hireswfv3_grid2obs.sh
- jevs_stats_cam_hireswfv3_precip.sh
- jevs_stats_cam_hrrr_grid2obs.sh
- jevs_stats_cam_hrrr_precip.sh
- jevs_stats_cam_namnest_grid2obs.sh
- jevs_stats_cam_namnest_precip.sh

