### PR TITLE
Remove imd from prep driver script and plot evs_config files

### DIFF
--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
@@ -42,7 +42,7 @@ export TMPDIR=$DATAROOT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT/$RUN
 
-export MODELNAME="cfs cmc cmc_regional dwd fnmoc gfs imd jma metfra ukmet ecmwf"
+export MODELNAME="cfs cmc cmc_regional dwd fnmoc gfs jma metfra ukmet ecmwf"
 export OBSNAME="osi_saf ghrsst_ospo ccpa_accum24hr prepbufr_gdas prepbufr_nam"
 
 # CALL executable job script here

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1660,10 +1660,6 @@ suite evs_nco
               trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_jma_atmos_grid2grid
               trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
-            task jevs_stats_global_det_imd_atmos_grid2obs
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
-            task jevs_stats_global_det_imd_atmos_grid2grid
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_grid2obs
               trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_grid2grid
@@ -2005,15 +2001,15 @@ suite evs_nco
             task jevs_plots_global_det_atmos_grid2obs_ptype_last90days
               trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_grid2obs_pres_levs_last90days
-              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_grid2grid_sst_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_snow_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_sea_ice_last90days
               trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_pres_levs_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
+              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_precip_last90days
               trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid == complete
           endfamily

--- a/ecf/scripts/prep/global_det/jevs_prep_global_det_atmos.ecf
+++ b/ecf/scripts/prep/global_det/jevs_prep_global_det_atmos.ecf
@@ -49,7 +49,7 @@ else
 fi
 export NET=evs
 export RUN=atmos
-export MODELNAME="cfs cmc cmc_regional dwd ecmwf fnmoc imd jma metfra ukmet"
+export MODELNAME="cfs cmc cmc_regional dwd ecmwf fnmoc jma metfra ukmet"
 export OBSNAME="osi_saf ghrsst_ospo"
 
 ############################################################

--- a/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.pres_levs
+++ b/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.pres_levs
@@ -30,7 +30,7 @@ export RUN_GRID2OBS_PLOTS="NO"
 #model_evs_data_dir_list:    base path to "evs_data" directory
 #model_file_format_list:     file format of model files
 export model_list="gfs ecmwf cmc ukmet jma fnmoc cfs"
-export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/cmc $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/fnmoc $COMIN/stats/$COMPONENT/cfs"
+export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/cmc $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/jma $COMIN/stats/$COMPONENT/fnmoc $COMIN/stats/$COMPONENT/cfs"
 export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cmc/cmc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/jma/jma.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/fnmoc/fnmoc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cfs/cfs.t{init?fmt=%H}z.f{lead?fmt=%3H}"
 ## OUTPUT DATA SETTINGS
 #OUTPUTROOT: base output directory

--- a/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.pres_levs
+++ b/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.pres_levs
@@ -29,9 +29,9 @@ export RUN_GRID2OBS_PLOTS="NO"
 #model_list:                 model names
 #model_evs_data_dir_list:    base path to "evs_data" directory
 #model_file_format_list:     file format of model files
-export model_list="gfs ecmwf cmc ukmet jma imd fnmoc cfs"
-export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/cmc $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/jma $COMIN/stats/$COMPONENT/imd $COMIN/stats/$COMPONENT/fnmoc $COMIN/stats/$COMPONENT/cfs"
-export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cmc/cmc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/jma/jma.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/imd/imd.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/fnmoc/fnmoc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cfs/cfs.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+export model_list="gfs ecmwf cmc ukmet jma fnmoc cfs"
+export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/cmc $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/fnmoc $COMIN/stats/$COMPONENT/cfs"
+export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cmc/cmc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/jma/jma.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/fnmoc/fnmoc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cfs/cfs.t{init?fmt=%H}z.f{lead?fmt=%3H}"
 ## OUTPUT DATA SETTINGS
 #OUTPUTROOT: base output directory
 export OUTPUTROOT="$DATAROOT"
@@ -58,10 +58,10 @@ if [ $RUN_GRID2GRID_PLOTS = YES ]; then
     #    g2gp_*_fhr_min: forecast hour to start verification: HH[H]
     #    g2gp_*_fhr_max: forecast hour to end verification: HH[H]
     #    g2gp_*_fhr_inc: frequency to verify forecast hours: HH[H]
-    export g2gp_model_plot_name_list="gfs ecmwf cmc ukmet jma imd fnmoc cfs"
+    export g2gp_model_plot_name_list="gfs ecmwf cmc ukmet jma fnmoc cfs"
     export g2gp_type_list="pres_levs"
     export g2gp_event_equalization="NO"
-    export g2gp_pres_levs_truth_name_list="gfs_anl ecmwf_anl cmc_anl ukmet_anl jma_anl imd_anl fnmoc_anl gfs_anl"
+    export g2gp_pres_levs_truth_name_list="gfs_anl ecmwf_anl cmc_anl ukmet_anl jma_anl fnmoc_anl gfs_anl"
     export g2gp_pres_levs_init_hr_list="00 12"
     export g2gp_pres_levs_valid_hr_list="00 12"
     export g2gp_pres_levs_fhr_list="0 24 72 120 168 240 312 384"

--- a/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.snow
+++ b/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.snow
@@ -29,9 +29,9 @@ export RUN_GRID2OBS_PLOTS="NO"
 #model_list:                 model names
 #model_evs_data_dir_list:    base path to "evs_data" directory
 #model_file_format_list:     file format of model files
-export model_list="gfs ecmwf imd"
-export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/imd"
-export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/imd/imd.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+export model_list="gfs ecmwf"
+export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf"
+export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H}"
 ## OUTPUT DATA SETTINGS
 #OUTPUTROOT: base output directory
 export OUTPUTROOT="$DATAROOT"
@@ -58,7 +58,7 @@ if [ $RUN_GRID2GRID_PLOTS = YES ]; then
     #    g2gp_*_fhr_min: forecast hour to start verification: HH[H]
     #    g2gp_*_fhr_max: forecast hour to end verification: HH[H]
     #    g2gp_*_fhr_inc: frequency to verify forecast hours: HH[H]
-    export g2gp_model_plot_name_list="gfs ecmwf imd"
+    export g2gp_model_plot_name_list="gfs ecmwf"
     export g2gp_type_list="snow"
     export g2gp_event_equalization="NO"
     export g2gp_snow_init_hr_list="12"

--- a/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.sst
+++ b/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2grid.sst
@@ -29,9 +29,9 @@ export RUN_GRID2OBS_PLOTS="NO"
 #model_list:                 model names
 #model_evs_data_dir_list:    base path to "evs_data" directory
 #model_file_format_list:     file format of model files
-export model_list="gfs ukmet imd"
-export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/imd"
-export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/imd/imd.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+export model_list="gfs ukmet"
+export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ukmet"
+export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H}"
 ## OUTPUT DATA SETTINGS
 #OUTPUTROOT: base output directory
 export OUTPUTROOT="$DATAROOT"
@@ -58,7 +58,7 @@ if [ $RUN_GRID2GRID_PLOTS = YES ]; then
     #    g2gp_*_fhr_min: forecast hour to start verification: HH[H]
     #    g2gp_*_fhr_max: forecast hour to end verification: HH[H]
     #    g2gp_*_fhr_inc: frequency to verify forecast hours: HH[H]
-    export g2gp_model_plot_name_list="gfs ukmet imd"
+    export g2gp_model_plot_name_list="gfs ukmet"
     export g2gp_type_list="sst"
     export g2gp_event_equalization="NO"
     export g2gp_sst_init_hr_list="00"

--- a/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2obs.pres_levs
+++ b/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.grid2obs.pres_levs
@@ -29,9 +29,9 @@ export RUN_GRID2OBS_PLOTS="YES"
 #model_list:                 model names
 #model_evs_data_dir_list:    base path to "evs_data" directory
 #model_file_format_list:     file format of model files
-export model_list="gfs ecmwf cmc ukmet jma imd fnmoc cfs"
-export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/cmc $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/jma $COMIN/stats/$COMPONENT/imd $COMIN/stats/$COMPONENT/fnmoc $COMIN/stats/$COMPONENT/cfs"
-export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cmc/cmc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/jma/jma.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/imd/imd.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/fnmoc/fnmoc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cfs/cfs.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+export model_list="gfs ecmwf cmc ukmet jma fnmoc cfs"
+export model_evs_data_dir_list="$COMIN/stats/$COMPONENT/gfs $COMIN/stats/$COMPONENT/ecmwf $COMIN/stats/$COMPONENT/cmc $COMIN/stats/$COMPONENT/ukmet $COMIN/stats/$COMPONENT/jma $COMIN/stats/$COMPONENT/fnmoc $COMIN/stats/$COMPONENT/cfs"
+export model_file_format_list="$COMROOT/gfs/${gfs_ver}/gfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/atmos/gfs.t{init?fmt=%2H}z.pgrb2.0p25.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ecmwf/ecmwf.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cmc/cmc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/ukmet/ukmet.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/jma/jma.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/fnmoc/fnmoc.t{init?fmt=%H}z.f{lead?fmt=%3H} ${COMIN}/prep/global_det/atmos.{init?fmt=%Y%m%d}/cfs/cfs.t{init?fmt=%H}z.f{lead?fmt=%3H}"
 ## OUTPUT DATA SETTINGS
 #OUTPUTROOT: base output directory
 export OUTPUTROOT="$DATAROOT"
@@ -56,7 +56,7 @@ if [ $RUN_GRID2OBS_PLOTS = YES ]; then
     #    g2op_*_fhr_min: forecast hour to start verification: HH[H]
     #    g2op_*_fhr_max: forecast hour to end verification: HH[H]
     #    g2op_*_fhr_inc: frequency to verify forecast hours: at HH[H]
-    export g2op_model_plot_name_list="gfs ecmwf cmc ukmet jma imd fnmoc cfs"
+    export g2op_model_plot_name_list="gfs ecmwf cmc ukmet jma fnmoc cfs"
     export g2op_type_list="pres_levs"
     export g2op_event_equalization="NO"
     export g2op_pres_levs_init_hr_list="00 06 12 18"


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

- Remove imd from dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
- Remove imd from plot scripts in the  folder parm/evs_config/global_det:
   config.evs.prod.plots.global_det.atmos.grid2grid.pres_levs 
   config.evs.prod.plots.global_det.atmos.grid2grid.sst
   config.evs.prod.plots.global_det.atmos.grid2grid.snow  
   config.evs.prod.plots.global_det.atmos.grid2obs.pres_levs 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? NO
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

To test this PR, please test the following driver scripts:
prep step: $HOMEevs/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
plots step: $HOMEevs/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_pres_levs_last90days.sh

$HOMEevs/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_snow_last90days.sh
                  $HOMEevs/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2grid_sst_last90days.sh  
                 $HOMEevs/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_grid2obs_pres_levs_last90days.sh

Clone my fork in your local and checkout branch feature/remove_imd
ln -sf fix directory.
cd sorc/ and then ./build.sh

for the driver scripts listed above for testing,
1- set the HOMEevs to your test directory.
2- set KEEPDATA to YES
3- set SENDMAIL to NO


4- To test the plots step:

export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d

