### PR TITLE
remove dbnroot from ecf scripts in global_chem plots steps

### DIFF
--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.ecf
@@ -38,7 +38,6 @@ module load met/${met_ver}
 module load metplus/${metplus_ver}
 
 export SIPHONROOT=${UTILROOT}/fakedbn
-export DBNROOT=$SIPHONROOT
 
 module list
 

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.ecf
@@ -37,8 +37,6 @@ module load imagemagick/${imagemagick_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
 
-export SIPHONROOT=${UTILROOT}/fakedbn
-
 module list
 
 ############################################################

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.ecf
@@ -38,7 +38,6 @@ module load met/${met_ver}
 module load metplus/${metplus_ver}
 
 export SIPHONROOT=${UTILROOT}/fakedbn
-export DBNROOT=$SIPHONROOT
 
 module list
 

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.ecf
@@ -37,8 +37,6 @@ module load imagemagick/${imagemagick_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
 
-export SIPHONROOT=${UTILROOT}/fakedbn
-
 module list
 
 ############################################################

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.ecf
@@ -38,7 +38,6 @@ module load met/${met_ver}
 module load metplus/${metplus_ver}
 
 export SIPHONROOT=${UTILROOT}/fakedbn
-export DBNROOT=$SIPHONROOT
 
 module list
 

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.ecf
@@ -37,8 +37,6 @@ module load imagemagick/${imagemagick_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
 
-export SIPHONROOT=${UTILROOT}/fakedbn
-
 module list
 
 ############################################################

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
@@ -38,7 +38,6 @@ module load met/${met_ver}
 module load metplus/${metplus_ver}
 
 export SIPHONROOT=${UTILROOT}/fakedbn
-export DBNROOT=$SIPHONROOT
 
 module list
 

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
@@ -37,8 +37,6 @@ module load imagemagick/${imagemagick_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
 
-export SIPHONROOT=${UTILROOT}/fakedbn
-
 module list
 
 ############################################################

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.ecf
@@ -38,7 +38,6 @@ module load met/${met_ver}
 module load metplus/${metplus_ver}
 
 export SIPHONROOT=${UTILROOT}/fakedbn
-export DBNROOT=$SIPHONROOT
 
 module list
 

--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.ecf
@@ -37,8 +37,6 @@ module load imagemagick/${imagemagick_ver}
 module load met/${met_ver}
 module load metplus/${metplus_ver}
 
-export SIPHONROOT=${UTILROOT}/fakedbn
-
 module list
 
 ############################################################


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
Instructed by Alicia, removing "export DBNROOT=$SIPHONROOT" from all ecf plots global_chem scripts, as it is included in ecf/include/envir-p1.h.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES, by 12/10/2025

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 NO
 
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Code review, as no ecf test can be made.