### PR TITLE
feature/Remove SENDDBN_NTC lines

### DIFF
--- a/jobs/JEVS_PLOTS_MESOSCALE
+++ b/jobs/JEVS_PLOTS_MESOSCALE
@@ -51,7 +51,6 @@ export USHevs=${USHevs:-$HOMEevs/ush}
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export SENDECF=${SENDECF:-YES}
-export SENDDBN_NTC=${SENDDBN_NTC:-NO}
 export SENDMAIL=${SENDMAIL:-NO}
 
 

--- a/jobs/JEVS_PLOTS_SUBSEASONAL
+++ b/jobs/JEVS_PLOTS_SUBSEASONAL
@@ -33,7 +33,6 @@ export machine=${machine:-WCOSS2}
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}       # need to set to NO for testing
 export SENDECF=${SENDECF:-YES}
-export SENDDBN_NTC=${SENDDBN_NTC:-NO}
 
 ################################################################
 # Set EVS directories

--- a/jobs/JEVS_PREP_SUBSEASONAL
+++ b/jobs/JEVS_PREP_SUBSEASONAL
@@ -35,7 +35,6 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDMAIL=${SENDMAIL:-NO}
 export SENDDBN=${SENDDBN:-YES}       # need to set to NO for testing
 export SENDECF=${SENDECF:-YES}
-export SENDDBN_NTC=${SENDDBN_NTC:-NO}
 
 ################################################################
 # Set EVS directories

--- a/jobs/JEVS_STATS_SUBSEASONAL
+++ b/jobs/JEVS_STATS_SUBSEASONAL
@@ -33,7 +33,6 @@ export machine=${machine:-WCOSS2}
 export SENDCOM=${SENDCOM:-YES}
 export SENDDBN=${SENDDBN:-YES}       # need to set to NO for testing
 export SENDECF=${SENDECF:-YES}
-export SENDDBN_NTC=${SENDDBN_NTC:-NO}
 
 ################################################################
 # Set EVS directories


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
At the request of NCO and Alicia, the following lines were removed:
jobs/JEVS_STATS_SUBSEASONAL:export SENDDBN_NTC=${SENDDBN_NTC:-NO}
jobs/JEVS_PLOTS_MESOSCALE:export SENDDBN_NTC=${SENDDBN_NTC:-NO}
jobs/JEVS_PLOTS_SUBSEASONAL:export SENDDBN_NTC=${SENDDBN_NTC:-NO}
jobs/JEVS_PREP_SUBSEASONAL:export SENDDBN_NTC=${SENDDBN_NTC:-NO}
Testing of subseasonal jobs were successful.
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
* Yes, code delivery is end of week.
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Set up your test directory and clone branch (git clone https://github.com/ShannonShields-NOAA/EVS.git)
cd EVS
git checkout feature/remove_SENDDBN_NTC
Link EVSfix directory and run sorc/build.sh
For each dev/driver script:
Change HOMEevs to your test directory (pr###test)
Change COMIN to point to emc.vpppg
Set export KEEPDATA=YES and export SENDMAIL=NO
Test the following:
dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
dev/drivers/scripts/stats/subseasonal/jevs_stats_subseasonal_cfs_grid2grid.sh
dev/drivers/scripts/plots/subseasonal/jevs_plots_subseasonal_grid2grid_temp_last90days.sh