### PR TITLE
Updated README.md and two global_ens start times in evs-nco.def

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-A description of the EMC Verification System (EVS) will go here. 
+The EMC Verification System (EVS) is a software system used to assess operational NCEP model performance. EVS routinely creates verification 1) statistics and 2) graphics in NCEP Operations, allowing EMC to monitor operational NCEP model performance in near real time. EVS is written using a combination of MET/METplus and Python and runs on WCOSS2. 
+
+EVS v1.0 (MET-11.0.2/METplus-5.0.1/Python 3.10) became operational on 3/26/24. 
+EVS v2.0 (MET-12.0.1/METplus-6.0.0/Python 3.10) will become operational during winter 2025-2026.
+
+EVS v2.0 Release Notes: https://docs.google.com/document/d/1cwVvNDxwDadHOL5IgEKZ2EkPYqj0vGTMdPqa79UnYs8/edit?usp=sharing

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1474,9 +1474,9 @@ suite evs_nco
             task jevs_plots_global_ens_atmos_gefs_precip_last90days
               trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip == complete
             task jevs_plots_global_ens_atmos_gefs_grid2obs_last90days
-              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1415 and :TIME < 2015 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_grid2obs_separate_last90days
-              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
+              trigger :TIME >= 1415 and :TIME < 2015 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs == complete
             task jevs_plots_global_ens_atmos_gefs_grid2grid_last90days
               trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid == complete and ../../../../06/evs/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid == complete
           endfamily


### PR DESCRIPTION
## Description of Changes

The EVS v2.0 description in the README.md file was very out of date. It has been updated in this PR. Additionally, adding the global_ens "separate" last90days stats job back into the emc.vpppg parallel caused us to go over our HPCRAC node allocation (50 nodes) at 14:00Z. The two global_ens plots jobs with the largest node usage (10 and 9 nodes) have been pushed back 15 minutes in order to not add to the 14Z node usage of the other global_ens plots, subseasonal prep, and aqm global_chem stats.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES, ASAP (no testing needed)

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
YES, but they have already been changed in the emc.vpppg parallel and this PR does the rest. 
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

No testing is needed, but two code managers should look at the two files that were changed and make sure there are no typos before merging. Thanks!