### PR TITLE
Remove 06Z and 18Z cycle hours processing in component global_chem

### DIFF
--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:25:00
+#PBS -l walltime=00:15:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 

--- a/ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_master.ecf
+++ b/ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_master.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:25:00
+#PBS -l walltime=00:15:00
 #PBS -l place=shared,select=1:ncpus=1:mem=10GB
 #PBS -l debug=true
 

--- a/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.aeronet
+++ b/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.aeronet
@@ -7,6 +7,7 @@
 ## CONTRIBUTORS: Ho-Chun Huang, ho-chun.huang@noaa.gov, NOAA/NWS/NCEP/EMC-VPPPGB
 ## PURPOSE: Set up configurations to run EVS Global Chemistry standalone
 ##---------------------------------------------------------------------------
+##   01/06/2026   Ho-Chun Huang  remove init cycle 06Z and 18Z
 ##--------------------------------------------------------------------------
 
 set -x

--- a/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.aeronet
+++ b/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.aeronet
@@ -64,7 +64,7 @@ if [ $RUN_GRID2OBS_PLOTS = YES ]; then
     export g2op_type_list="aeronet"
     export g2op_obsvar_list="aod"
     export g2op_event_equalization="YES"
-    export g2op_aeronet_init_hr_list="00 06 12 18"
+    export g2op_aeronet_init_hr_list="00 12"
     export g2op_aeronet_valid_hr_list="00 06 12 18"
     export g2op_aeronet_fhr_list="6 12 18 24 30 36 42 48 54 60 66 72 78 84 90 96 102 108 114 120"
 fi

--- a/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.airnow
+++ b/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.airnow
@@ -64,7 +64,7 @@ if [ $RUN_GRID2OBS_PLOTS = YES ]; then
     export g2op_type_list="airnow"
     export g2op_obsvar_list="pm25"
     export g2op_event_equalization="YES"
-    export g2op_airnow_init_hr_list="00 06 12 18"
+    export g2op_airnow_init_hr_list="00 12"
     export g2op_airnow_valid_hr_list="00 06 12 18"
     export g2op_airnow_fhr_list="6 12 18 24 30 36 42 48 54 60 66 72 78 84 90 96 102 108 114 120"
 fi

--- a/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.airnow
+++ b/parm/evs_config/global_chem/config.evs.prod.plots.global_chem.atmos.grid2obs.airnow
@@ -7,6 +7,7 @@
 ## CONTRIBUTORS: Ho-Chun Huang, ho-chun.huang@noaa.gov, NOAA/NWS/NCEP/EMC-VPPPGB
 ## PURPOSE: Set up configurations to run EVS Global Chemistry standalone
 ##---------------------------------------------------------------------------
+##   01/06/2026   Ho-Chun Huang  remove init cycle 06Z and 18Z
 ##--------------------------------------------------------------------------
 
 set -x

--- a/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
+++ b/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
@@ -12,6 +12,7 @@
 ###   01/30/2024   Ho-Chun Huang  for a single email of missing files of both OBS and FCST
 ###   05/01/2025   Ho-Chun Huang  Remove email function for missing model forecast output
 ###   05/22/2025   Ho-Chun Huang  Move from global_ens chem to global_chem
+###   01/06/2026   Ho-Chun Huang  remove init cycle 06Z and 18Z
 ###
 ########################################################################
 #

--- a/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
+++ b/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
@@ -155,7 +155,7 @@ match_aod_4="aerosol_wavelength >=5.45e-07,<=5.65e-07"
 match_pm25_1="PMTF"
 match_pm25_2="aerosol=Total Aerosol"
 match_pm25_3="aerosol_size <2.5e-06"
-declare -a cyc_opt=( 00 06 12 18 )
+declare -a cyc_opt=( 00 12 )
 let inc=3
 for mdl_cyc in "${cyc_opt[@]}"; do
     com_gc_mdl=${COMINgefs}/${MODELNAME}.${INITDATE}/${mdl_cyc}/chem/pgrb2ap25   ## FOR GEFS-chem

--- a/scripts/stats/global_chem/exevs_stats_global_chem_atmos_grid2obs.sh
+++ b/scripts/stats/global_chem/exevs_stats_global_chem_atmos_grid2obs.sh
@@ -37,7 +37,7 @@ export METPLUS_PATH
 
 grid2obs_list="${DATA_TYPE}"
 
-export init_cyc="00 06 12 18"
+export init_cyc="00 12"
 
 for ObsType in ${grid2obs_list}; do
     export ObsType

--- a/scripts/stats/global_chem/exevs_stats_global_chem_atmos_grid2obs.sh
+++ b/scripts/stats/global_chem/exevs_stats_global_chem_atmos_grid2obs.sh
@@ -13,6 +13,7 @@
 ###                               pre-processed forecast output
 ###   06/04/2025   Ho-Chun Huang  mv from global_ens to global_chem
 ###   12/05/2025   Ho-Chun Huang  add restart function and non-zero size copying
+###   01/06/2026   Ho-Chun Huang  remove init cycle 06Z and 18Z
 ###
 ########################################################################
 set -x

--- a/ush/global_chem/global_chem_atmos_plots_lead_average.py
+++ b/ush/global_chem/global_chem_atmos_plots_lead_average.py
@@ -368,8 +368,8 @@ class LeadAverage:
                               +f"{model_num_plot_name}]")
             if model_num_npts != 0:
                 ax1.plot(
-                    masked_forecast_hours,
-                    masked_model_num_data,
+                    np.ma.compressed(masked_forecast_hours),
+                    np.ma.compressed(masked_model_num_data),
                     color = model_num_plot_settings_dict['color'],
                     linestyle = model_num_plot_settings_dict['linestyle'],
                     linewidth = model_num_plot_settings_dict['linewidth'],
@@ -411,8 +411,8 @@ class LeadAverage:
                               +f"{model1_plot_name}]")
             if model_num_diff_npts != 0:
                 ax2.plot(
-                    masked_diff_forecast_hours,
-                    masked_model_num_model1_diff_data,
+                    np.ma.compressed(masked_diff_forecast_hours),
+                    np.ma.compressed(masked_model_num_model1_diff_data),
                     color = model_num_plot_settings_dict['color'],
                     linestyle = model_num_plot_settings_dict['linestyle'],
                     linewidth = model_num_plot_settings_dict['linewidth'],
@@ -480,15 +480,23 @@ class LeadAverage:
                             or np.ma.is_masked(stat_min_max_dict['ax2_stat_max']):
                         if not np.ma.is_masked(ci_max):
                             stat_min_max_dict['ax2_stat_max'] = ci_max
-                    cmasked_ci_forecast_hours = masked_ci_forecast_hours
-                    cmasked_model_num_model1_diff_ci_data = masked_model_num_model1_diff_ci_data
-                    cmasked_ci_bar_max_widths = np.ma.masked_where(
-                            np.ma.getmask(masked_model_num_model1_diff_ci_data),
-                            ci_bar_max_widths
+                    cmasked_ci_forecast_hours = np.ma.compressed(
+                            masked_ci_forecast_hoursi
                     )
-                    cmasked_ci_bar_intvl_widths = np.ma.masked_where(
-                            np.ma.getmask(masked_model_num_model1_diff_ci_data),
-                            ci_bar_intvl_widths
+                    cmasked_model_num_model1_diff_ci_data = np.ma.compressed(
+                            masked_model_num_model1_diff_ci_data
+                    )
+                    cmasked_ci_bar_max_widths = np.ma.compressed(
+                            np.ma.masked_where(
+                                np.ma.getmask(masked_model_num_model1_diff_ci_data),
+                                ci_bar_max_widths
+                            )
+                    )
+                    cmasked_ci_bar_intvl_widths = np.ma.compressed(
+                            np.ma.masked_where(
+                                np.ma.getmask(masked_model_num_model1_diff_ci_data),
+                                ci_bar_intvl_widths
+                            )
                     )
                     for fhr_idx in range(len(cmasked_ci_forecast_hours)):
                         fhr = cmasked_ci_forecast_hours[fhr_idx]


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Remove GEFSv12-aerosol cycle hour 06Z and 18Z  from EVSv2.0 verification for component global_chem, per pending PNS

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES.  ASAP.

* Do you have any planned upcoming annual leave/PTO?
YES, 01/14/2026-02/01/2026

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 NO
 
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Create local working directory for this PR test, modify HOMEevs=, COMIN, and COMOUT accordingly.

(1) Prep
run today's pre job [default to 20260103]
/lfs/h2/emc/vpppg/noscrub/ho-chun.huang/gcgefs/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh

check output directory for only 00Z and 12Z

(2) Stats 
Copy prep output in emc.parallel [/lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/global_chem] from 20251225-20260102, stats needs at least 6 days of prep output.

run today's stats job [default to 20260103]
(a) submit job ~/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
Submit vhr=00, 03, 06, 09, 12, and 18 together. After all jobs finnished, submit vhr=21.
(b) submit job ~/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
Submit vhr=00, 03, 06, 09, 12, and 18 together. After all jobs finnished, submit vhr=21.

Check stats files for only 00Z and 12Z

(3) Plots

Copied previous 90days's stats output from emc.parallel  (/lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/stats/global_chem) from 20251001 to 20260102 to PR stats output directory
submit ~/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last31days.sh
submit ~/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_aeronet_last90days.sh
submit ~/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last31days.sh
submit ~/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.sh
submit ~/dev/drivers/scripts/plots/global_chem/jevs_plots_global_chem_headline_grid2obs_last90days.sh

Check figures for only 00Z and 12Z cycle output.

