### PR TITLE
feature/subseasonal_gdas_prep

### DIFF
--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
@@ -46,7 +46,7 @@ export NET=evs
 export STEP=prep
 export COMPONENT=subseasonal
 export RUN=atmos
-export OBSNAME="gfs ecmwf osi ghrsst umd nam ccpa"
+export OBSNAME="gfs ecmwf osi ghrsst umd gdas ccpa"
 export PREP_TYPE=obs
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN

--- a/ush/subseasonal/subseasonal_prep_obs.py
+++ b/ush/subseasonal/subseasonal_prep_obs.py
@@ -119,9 +119,9 @@ subseasonal_obs_dict = {
                                                        '{init?fmt=%Y%m%d}.nc'),
                       'vhours': ['00']},
 
-    'nam': {'arch_file_format': os.path.join(COMOUT_INITDATE,
-                                             'prepbufr_nam',
-                                             'prepbufr.nam.'
+    'gdas': {'arch_file_format': os.path.join(COMOUT_INITDATE,
+                                             'prepbufr_gdas',
+                                             'prepbufr.gdas.'
                                              +'{init?fmt=%Y%m%d%H}'),
                       'vhours': ['00', '12']},
     'ccpa': {'prod_file_format': os.path.join(COMINccpa, 'ccpa.'
@@ -158,19 +158,16 @@ for OBS in OBSNAME:
                 DATA, 'mail_missing_'+OBS+'_valid'
                 +CDATEm1_dt.strftime('%Y%m%d%H')+'.sh'
             )
-        if OBS == 'nam':
-            offset_hr = str(int(CDATE_dt.strftime('%H'))%6
-            ).zfill(2)
-            offset_CDATE_dt = (
-                CDATE_dt + datetime.timedelta(hours=int(offset_hr))
-            )
-            prod_file_format = os.path.join(COMINobsproc, 'nam.'
+        if OBS == 'gdas':
+            prod_file_format = os.path.join(COMINobsproc, 'gdas.'
                                             +'{init?fmt=%Y%m%d}',
-                                            'nam.t{init?fmt=%2H}z.'
-                                            +'prepbufr.tm'+offset_hr)
+                                            '{init?fmt=%H}',
+                                            'atmos', 'gdas.t'
+                                            +'{init?fmt=%H}'
+                                            +'z.prepbufr')
             prod_file = sub_util.format_filler(
-                prod_file_format, offset_CDATE_dt, 
-                offset_CDATE_dt, 'anl', {}
+                prod_file_format, CDATE_dt, 
+                CDATE_dt, 'anl', {}
             )
             arch_file = sub_util.format_filler(
                 obs_dict['arch_file_format'], CDATE_dt, CDATE_dt,

--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -860,7 +860,7 @@ def prep_prod_ghrsst_ospo_file(daily_source_file, daily_dest_file,
 
 def prep_prod_prepbufr_file(source_file, dest_file, date_dt,
                             log_missing_file):
-    """! Do prep work for obsproc prepbufr nam files
+    """! Do prep work for obsproc prepbufr gdas files
 
          Args:
              source_file      - source file (string)
@@ -887,7 +887,7 @@ def prep_prod_prepbufr_file(source_file, dest_file, date_dt,
             run_shell_command([SPLIT_BY_SUBSET, prepped_file])
     else:
         log_missing_file_obs(log_missing_file, source_file,
-                             f"Prepbufr NAM",
+                             f"Prepbufr GDAS",
                              date_dt)
     if check_file_exists_size(split_file):
         copy_file(split_file, dest_file)


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR replaces NAM prepbufr files with GDAS prepbufr files for the subseasonal prep step. This is in accordance of the NAM model being retired and needing to switch to GDAS for grid2obs verification source.
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Not really, but sooner the better for other developers to see/make similar changes in their own components.
* Do you have any planned upcoming annual leave/PTO? Yes, Jan 8
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Make prtest directory
git clone https://github.com/ShannonShields-NOAA/EVS.git
cd EVS
git checkout feature/subseasonal_gdas_prep_final
Link fix directory
cd dev/drivers/scripts/prep/subseasonal/
Change the following in jevs_prep_subseasonal_obs.sh:
export HOMEevs to point to your prtest directory
export KEEPDATA=YES
export SENDMAIL=NO
export COMOUT to where you want the prep output
Run the obs prep job: qsub jevs_prep_subseasonal_obs.sh
The job should only take around 30 sec.