### PR TITLE
Feature/subseasonal gefs prep refinement

### DIFF
--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q "dev"
 #PBS -A VERF-DEV
-#PBS -l walltime=02:30:00
-#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=300GB
+#PBS -l walltime=00:35:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=80GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -4,7 +4,7 @@
 #PBS -q "dev"
 #PBS -A VERF-DEV
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=80GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=120GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=02:30:00
-#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=300GB
+#PBS -l walltime=00:35:00
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=80GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:35:00
-#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=80GB
+#PBS -l place=vscatter:shared,select=1:ncpus=1:ompthreads=1:mem=120GB
 #PBS -l debug=true
 
 export model=evs

--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -534,15 +534,8 @@ def prep_prod_gefs_file(source_afile, source_bfile, prepped_file, dest_file,
     """
     # Environment variables and executables
     WGRIB2 = os.environ['WGRIB2']
-    EXECevs = os.environ['EXECevs']
-    # Working file names
-    working_file1 = prepped_file+'.tmp1'
-    # Prep file
+    # Prep file and define the variables/levels for extraction
     if prep_method == 'full': 
-        if forecast_hour == 0:
-            wgrib_fhr = 'anl'
-        else:
-            wgrib_fhr = forecast_hour
         thin_var_level_list = [
             'HGT:500 mb',
             'ULWRF:top of atmosphere',
@@ -563,19 +556,25 @@ def prep_prod_gefs_file(source_afile, source_bfile, prepped_file, dest_file,
         
         if check_file_exists_size(source_afile) \
                 and check_file_exists_size(source_bfile):
-            run_shell_command(['>', prepped_file])
-            for thin_var_level in thin_var_level_list:
-                run_shell_command([WGRIB2, '-match', '"'+thin_var_level+'"',
-                                   source_afile+'|'+WGRIB2, '-i', 
-                                   source_afile,
-                                   '-grib', working_file1])
-                run_shell_command(['cat', working_file1, '>>', prepped_file])
-                run_shell_command([WGRIB2, '-match', '"'+thin_var_level+'"',
-                                   source_bfile+'|'+WGRIB2, '-i',
-                                   source_bfile,
-                                   '-grib', working_file1])
-                run_shell_command(['cat', working_file1, '>>', prepped_file])
-                os.remove(working_file1)
+            # Create a temporary pattern file for grep
+            pattern_file = f"{prepped_file}.patterns"
+            with open(pattern_file, 'w') as f:
+                f.write('\n'.join(thin_var_level_list) + '\n')
+            # Extract from source_afile
+            extract_a_cmd = (
+                f"grep -Ff {pattern_file} {source_afile}.idx | "
+                f"{WGRIB2} -i {source_afile} -grib {prepped_file}"
+            )
+            run_shell_command(['sh', '-c', extract_a_cmd])
+            # Extract from source_bfile and APPEND
+            extract_b_cmd = (
+                f"grep -Ff {pattern_file} {source_bfile}.idx | "
+                f"{WGRIB2} -i {source_bfile} -append -grib {prepped_file}"
+            )
+            run_shell_command(['sh', '-c', extract_b_cmd])
+            # Clean up the pattern file
+            if os.path.exists(pattern_file):
+                os.remove(pattern_file)
         else:
             log_missing_file_model(log_missing_file, source_afile,
                                    'gefs', init_dt,

--- a/ush/subseasonal/subseasonal_util.py
+++ b/ush/subseasonal/subseasonal_util.py
@@ -562,14 +562,14 @@ def prep_prod_gefs_file(source_afile, source_bfile, prepped_file, dest_file,
                 f.write('\n'.join(thin_var_level_list) + '\n')
             # Extract from source_afile
             extract_a_cmd = (
-                f"grep -Ff {pattern_file} {source_afile}.idx | "
-                f"{WGRIB2} -i {source_afile} -grib {prepped_file}"
+                f" 'grep -Ff {pattern_file} {source_afile}.idx | "
+                f"{WGRIB2} -i {source_afile} -grib {prepped_file}' "
             )
             run_shell_command(['sh', '-c', extract_a_cmd])
             # Extract from source_bfile and APPEND
             extract_b_cmd = (
-                f"grep -Ff {pattern_file} {source_bfile}.idx | "
-                f"{WGRIB2} -i {source_bfile} -append -grib {prepped_file}"
+                f" 'grep -Ff {pattern_file} {source_bfile}.idx | "
+                f"{WGRIB2} -i {source_bfile} -append -grib {prepped_file}' "
             )
             run_shell_command(['sh', '-c', extract_b_cmd])
             # Clean up the pattern file


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR utilizes Daniel Kokron's unit2 test code into the subseasonal_util.py script in order to make the GEFS prep job more efficient and faster. Daniel Kokron (GDIT) and Jacob Carley (EIB) have been wanting this change for some time. With the code changes, the job now runs in about 22 mins compared to 1.5+ hrs. Job resource allocations were also adjusted based on a few test runs in the dev/driver and ecf scripts.
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes, these changes are wanted by NCO/EIB in EVS v2.0.3.
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  **Not for prep, but we might want to discuss if we wish to bump up the start times of the stat jobs now that the GEFS prep finishes much sooner. This would depend though on the high watermark and other job start times in EVS.**
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Create a prtest directory 
git clone https://github.com/ShannonShields-NOAA/EVS.git
cd EVS
git checkout feature/subseasonal_gefs_prep_refinement
Link fix directory
cd dev/drivers/scripts/prep/subseasonal/
Please change the following in dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh:
export HOMEevs (point to your prtest directory)
export KEEPDATA=YES
export SENDMAIL=NO
export COMOUT (point to where you want the prep output)
qsub jevs_prep_subseasonal_gefs.sh
I will compare the output to the parallel to make sure files match. I already conducted a quick sanity check to make sure the prep files using this new methodology work with stats step (variable order when looking at file with wgrib2 command doesn't matter).