### PR TITLE
Add REFS plotting scripts

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last31days.sh
@@ -1,0 +1,44 @@
+#PBS -N jevs_plots_cam_refs_grid2obs_cape_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=9:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=grid2obs_cape
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=31
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last90days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_grid2obs_cape_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=9:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=grid2obs_cape
+export MODELNAME=refs
+
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last31days.sh
@@ -1,0 +1,44 @@
+#PBS -N jevs_plots_cam_refs_grid2obs_ctc_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=6:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=grid2obs_ctc
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=31
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last90days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_grid2obs_ctc_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=6:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=grid2obs_ctc
+export MODELNAME=refs
+
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last31days.sh
@@ -1,0 +1,45 @@
+#PBS -N jevs_plots_cam_refs_grid2obs_ecnt_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=66:mem=40GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=grid2obs_ecnt
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=31
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last90days.sh
@@ -1,0 +1,45 @@
+#PBS -N jevs_plots_cam_refs_grid2obs_ecnt_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:30:00
+#PBS -l place=vscatter,select=1:ncpus=66:mem=50GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=grid2obs_ecnt
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_last31days.sh
@@ -1,0 +1,45 @@
+#PBS -N jevs_plots_cam_refs_precip_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=4:ncpus=76:mem=100GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=precip
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=31
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_precip_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=4:ncpus=76:mem=200GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=precip
+export MODELNAME=refs
+
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_spatial.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_spatial.sh
@@ -1,0 +1,43 @@
+#PBS -N jevs_plots_cam_refs_precip_spatial
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=2:mem=5GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=precip_spatial
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_profile_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_profile_last31days.sh
@@ -1,0 +1,47 @@
+#PBS -N jevs_plots_cam_refs_profile_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=60:mem=60GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=profile
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=31
+export valid_time=both
+
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_profile_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_profile_last90days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_profile_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=60:mem=60GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=profile
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+export valid_time=both
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last31days.sh
@@ -28,7 +28,7 @@ module load prod_envir/${prod_envir_ver}
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
-export KEEPDATA=YES
+export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last31days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_snowfall_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=30:mem=20GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=snowfall
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=YES
+export SENDMAIL=YES
+export SENDDBN=NO
+
+
+export vhr=00
+export last_days=31
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last90days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_snowfall_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=30:mem=20GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=snowfall
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+export FIXevs=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/EVS/fix
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last31days.sh
@@ -1,0 +1,46 @@
+#PBS -N jevs_plots_cam_refs_spcoutlook_last31days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=6:mem=5GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=spcoutlook
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=31
+export valid_time=both
+export EVAL_PERIOD='last31days'
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last90days.sh
@@ -1,0 +1,47 @@
+#PBS -N jevs_plots_cam_refs_spcoutlook_last90days
+#PBS -j oe
+#PBS -q dev
+#PBS -S /bin/bash
+#PBS -A VERF-DEV
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=6:mem=5GB
+#PBS -l debug=true
+
+set -x
+
+export OMP_NUM_THREADS=1
+
+export NET=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/${USER}/EVS
+source $HOMEevs/versions/run.ver
+
+export envir=prod
+
+export STEP=plots
+export COMPONENT=cam
+export RUN=atmos
+export VERIF_CASE=spcoutlook
+export MODELNAME=refs
+
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export KEEPDATA=NO
+export SENDMAIL=YES
+export SENDDBN=NO
+
+export vhr=00
+export last_days=90
+export EVAL_PERIOD='last90days'
+export valid_time=both
+
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/$USER/$NET/$evs_ver_2d
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
+export FIXevs=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/EVS/fix
+
+${HOMEevs}/jobs/JEVS_PLOTS_CAM

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1691,6 +1691,22 @@ suite evs_nco
               trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_spcoutlook == complete
             task jevs_plots_cam_href_grid2obs_cape_last90days
               trigger :TIME >= 1430 and :TIME < 2030 and ../../../../06/evs/stats/cam/jevs_stats_cam_href_grid2obs == complete
+            task jevs_plots_cam_refs_grid2obs_ecnt_last90days
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_grid2obs == complete
+            task jevs_plots_cam_refs_grid2obs_ctc_last90days
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_grid2obs == complete
+            task jevs_plots_cam_refs_snowfall_last90days
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_snowfall == complete
+            task jevs_plots_cam_refs_profile_last90days
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_grid2obs == complete
+            task jevs_plots_cam_refs_precip_last90days
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_precip == complete
+            task jevs_plots_cam_refs_precip_spatial
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_precip == complete
+            task jevs_plots_cam_refs_spcoutlook_last90days
+              trigger :TIME >= 1230 and :TIME < 1830 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_spcoutlook == complete
+            task jevs_plots_cam_refs_grid2obs_cape_last90days
+              trigger :TIME >= 1430 and :TIME < 2030 and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_grid2obs == complete
           endfamily 
         endfamily   # 12 plots
       endfamily  # evs

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last31days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_grid2obs_cape_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=9:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="grid2obs_cape"
+export MODELNAME=refs
+export last_days=31
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_cape_last90days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_grid2obs_cape_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=9:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="grid2obs_cape"
+export MODELNAME=refs
+export last_days=90
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last31days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_grid2obs_ctc_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=6:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=31
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="grid2obs_ctc"
+export MODELNAME=refs
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ctc_last90days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_grid2obs_ctc_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=6:ncpus=85:mem=40GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=90
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="grid2obs_ctc"
+export MODELNAME=refs
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last31days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_grid2obs_ecnt_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=66:mem=40GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=31
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="grid2obs_ecnt"
+export MODELNAME=refs
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_grid2obs_ecnt_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_grid2obs_ecnt_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:30:00
+#PBS -l place=vscatter,select=1:ncpus=66:mem=50GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=90
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="grid2obs_ecnt"
+export MODELNAME=refs
+export valid_time=both
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_last31days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_precip_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=4:ncpus=76:mem=100GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=31
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="precip"
+export MODELNAME=refs
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_precip_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=4:ncpus=76:mem=200GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=90
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="precip"
+export MODELNAME=refs
+export valid_time=both
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_spatial.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_spatial.ecf
@@ -1,0 +1,71 @@
+#PBS -N evs_plots_cam_refs_precip_spatial
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=2:mem=5GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="precip_spatial"
+export MODELNAME=refs
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_profile_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_profile_last31days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_profile_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=60:mem=60GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=31
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="profile"
+export MODELNAME=refs
+export valid_time=both
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_profile_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_profile_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_profile_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=60:mem=60GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=90
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="profile"
+export MODELNAME=refs
+export valid_time=both
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last31days.ecf
@@ -1,0 +1,73 @@
+#PBS -N evs_plots_cam_refs_snowfall_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=30:mem=20GB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=31
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="snowfall"
+export MODELNAME=refs
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_snowfall_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_snowfall_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=30:mem=20GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export last_days=90
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="snowfall"
+export MODELNAME=refs
+export valid_time=both
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last31days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_spcoutlook_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=6:mem=5GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="spcoutlook"
+export MODELNAME=refs
+export last_days=31
+export valid_time=both
+export EVAL_PERIOD=last31days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_spcoutlook_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_refs_spcoutlook_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:10:00
+#PBS -l place=vscatter,select=1:ncpus=6:mem=5GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export OMP_NUM_THREADS=1
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="spcoutlook"
+export MODELNAME=refs
+export last_days=90
+export valid_time=both
+export EVAL_PERIOD=last90days
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/jobs/JEVS_PLOTS_CAM
+++ b/jobs/JEVS_PLOTS_CAM
@@ -68,9 +68,10 @@ export cycle=${cycle:-t${vhr}z}
 setpdy.sh 31
 . ./PDY
 
-if [ $MODELNAME = href ] ; then
+if [ $MODELNAME = href ] || [ $MODELNAME = refs ] ; then
    export VDATE=${VDATE:-$PDYm2}
    export INITDATE=${INITDATE:-$PDYm2}
+   export eval_period=${EVAL_PERIOD:-last90days}
 else
    if [ $VERIF_CASE = severe ] ; then
       export VDATE=${VDATE:-$PDYm7}
@@ -90,12 +91,16 @@ fi
 ####################################
 export COMROOT=${COMROOT:-$(compath.py $envir/com)}
 
-if  [ $MODELNAME = href ] ; then
+if  [ $MODELNAME = href ] || [ $MODELNAME = refs ] || [ $MODELNAME = refs_prob ] ; then
   export EVSINapcp24mean=${COMIN:-$(compath.py $envir/com/$NET/${evs_ver})}/stats/$COMPONENT/${RUN}.${VDATE}/$MODELNAME/precip/precip_mean24
   export COMIN=${COMIN:-$(compath.py $envir/com/$NET/$evs_ver)}/stats/$COMPONENT/$MODELNAME.$VDATE
   export COMOUT=${COMOUT:-$(compath.py -o $NET/${evs_ver})}/$STEP/$COMPONENT/$RUN.$VDATE
   export DATA_IN=${DATA_IN:-$DATAROOT}
-  export ush_dir=$USHevs/cam/ush_href_plot_py
+  if  [ $MODELNAME = href ] ; then
+    export ush_dir=$USHevs/cam/ush_href_plot_py
+  else
+    export ush_dir=$USHevs/cam/ush_refs_plot_py
+  fi
 else
   export COMIN=${COMIN:-$(compath.py $envir/com/$NET/$evs_ver)}
   export COMOUT=${COMOUT:-$(compath.py -o $NET/$evs_ver/$STEP/$COMPONENT)}

--- a/jobs/JEVS_PLOTS_CAM
+++ b/jobs/JEVS_PLOTS_CAM
@@ -91,7 +91,7 @@ fi
 ####################################
 export COMROOT=${COMROOT:-$(compath.py $envir/com)}
 
-if  [ $MODELNAME = href ] || [ $MODELNAME = refs ] || [ $MODELNAME = refs_prob ] ; then
+if  [ $MODELNAME = href ] || [ $MODELNAME = refs ] ; then
   export EVSINapcp24mean=${COMIN:-$(compath.py $envir/com/$NET/${evs_ver})}/stats/$COMPONENT/${RUN}.${VDATE}/$MODELNAME/precip/precip_mean24
   export COMIN=${COMIN:-$(compath.py $envir/com/$NET/$evs_ver)}/stats/$COMPONENT/$MODELNAME.$VDATE
   export COMOUT=${COMOUT:-$(compath.py -o $NET/${evs_ver})}/$STEP/$COMPONENT/$RUN.$VDATE

--- a/scripts/plots/cam/exevs_plots_refs_grid2obs_cape.sh
+++ b/scripts/plots/cam/exevs_plots_refs_grid2obs_cape.sh
@@ -1,0 +1,404 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs cape plotting python script
+# Last updated: 
+#               05/10/2025, Updated restart/MPMD,  by Binbin Zhou Lynker@EMC/NCEP
+#               01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#               07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP
+#               05/30/2023, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_cape_plots
+ if [ ! -d  $restart ] ; then
+  mkdir -p $restart
+ fi
+fi
+
+export interp_pnts=''
+
+export init_end=$VDATE
+export valid_end=$VDATE
+export obsv=" - Validation: RAOB"
+
+model_list='REFS_MEAN'
+models='REFS_MEAN'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+  $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day REFS_MEAN
+  n=$((n+1))
+done 
+
+export fcst_init_hour="0,6,12,18"
+init_time='init00z_06z_12z_18z'
+line_type=ctc
+verif_case=grid2obs
+
+#*****************************************
+# Build a POE file to collect sub-jobs
+# ****************************************
+> run_all_poe.sh
+
+for valid_time in 00 12 ; do 
+
+ for stats in csi fbias  ; do 
+
+   stat_list=$stats
+   VARs='CAPEsfc MLCAPE'
+   score_types='lead_average threshold_average'
+
+  for score_type in $score_types ; do
+ 
+    if [ $score_type = lead_average ] ; then   
+       thresholds="250  500 1000 2000"
+       fcst_leads="6,12,18,24,30,36,42,48"
+    elif [ $score_type = threshold_average ] ; then
+       thresholds=">=250,>=500,>=1000,>=2000"
+       fcst_leads="6 12 18 24 30 36 42 48"
+    fi 
+
+   for threshold in $thresholds ; do 
+
+    for fcst_lead in $fcst_leads ; do 
+
+	#thresh and lead are just for file names
+	  if [  $score_type = lead_average ] ; then
+	      thresh=$threshold
+	      lead=all_leads
+	  elif [  $score_type = threshold_average ] ; then
+	      thresh=all_thresholds
+	      lead=$fcst_lead
+	 fi
+
+     for VAR in $VARs ; do 
+
+       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+	    
+       if [ $VAR = CAPEsfc ]  ; then
+          FCST_LEVEL_values="L0"
+          variable="cape"
+       elif [ $VAR = MLCAPE ] ; then
+	  FCST_LEVEL_values="ML"
+	  variable="mlcape"
+       fi 	  
+
+       if [ $VAR = CAPEsfc ] || [ $VAR = MLCAPE ] ; then 
+           doms="dom1 dom2 dom3 dom4 dom5 dom6 dom7 dom8"
+       fi 
+
+       for dom in $doms ; do 
+
+         if [ $VAR = CAPEsfc ] || [ $VAR = MLCAPE ] ; then
+	     if [ $dom = dom1 ] ; then
+	         VX_MASK_LIST="CONUS, CONUS_East, CONUS_West"
+	         subregions="conus conus_east conus_west"
+	     elif [ $dom = dom2 ] ; then
+	         VX_MASK_LIST="CONUS_South, CONUS_Central, Alaska"
+		 subregions="conus_south conus_central alaska"
+	     elif [ $dom = dom3 ] ; then
+	         VX_MASK_LIST="Appalachia, CPlains, DeepSouth"
+		 subregions="appalachia cplains deepsouth"
+	     elif [ $dom = dom4 ] ; then
+	         VX_MASK_LIST="GreatBasin, GreatLakes, Mezquital"
+		 subregions="greatbasin greatlakes mezquital"
+	     elif [ $dom = dom5 ] ; then
+	         VX_MASK_LIST="MidAtlantic, NorthAtlantic, NPlains"
+		 subregions="midatlantic northatlantic nplains"
+	     elif [ $dom = dom6 ] ; then
+	         VX_MASK_LIST="NRockies, PacificNW, PacificSW"
+		 subregions="nrockies pacificnw pacificsw"
+	     elif [ $dom = dom7 ] ; then
+	         VX_MASK_LIST="SRockies, Prairie, Southeast"
+		 subregions="srockies prairie southeast"
+	     elif [ $dom = dom8 ] ; then
+	         VX_MASK_LIST="Southwest, SPlains"
+		 subregions="southwest splains"
+             fi
+        fi
+
+     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+
+        OBS_LEVEL_value=$FCST_LEVEL_value
+
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+
+        if [ $score_type = lead_average ] ; then
+          thresh_fcst=">=${threshold}"
+          thresh_obs=$thresh_fcst
+          tail=ge${thresh}
+        elif [ $score_type = threshold_average ] ; then
+          thresh_fcst=${threshold}
+          thresh_obs=$thresh_fcst
+          tail=f${lead}
+        else
+          thresh_fcst=' '
+          thresh_obs=' '
+          tail='other'
+        fi
+
+	 #*********************
+	 # Build sub-jobs
+	 #*********************
+         > run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh  
+
+      #***********************************************************************************************************************************
+      #  Check if this sub-job has been completed in the previous run for restart
+      if [ ! -e $restart/run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.completed ] ; then
+      #***********************************************************************************************************************************
+
+        echo "#!/bin/ksh" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        echo "set -x" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        verif_type=conus_sfc
+
+	save_dir=$DATA/plots/run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}
+        plot_dir=$save_dir/sfc_upper/$eval_period
+        mkdir -p $plot_dir
+	mkdir -p $save_dir/data
+     
+	echo "export save_dir=$save_dir" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+	if [ $score_type = lead_average ] ; then
+           echo "export PLOT_TYPE=lead_average_valid" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        else		
+           echo "export PLOT_TYPE=$score_type" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        fi
+
+        echo "export field=${var}_${level}" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+        fi
+
+
+         echo "export var_name=$VAR" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+         echo "export interp=BILIN" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+         echo "export score_py=$score_type" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$valid_time!g" -e "s!fcst_lead!$fcst_lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+         chmod +x  run_py.${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+         echo "${DATA}/scripts/run_py.${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+	#Save for restart and tar files 
+	 echo "for domain in $subregions ; do " >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	 echo "  plot=${plot_dir}/${score_type}_regional_\${domain}_valid_${valid_time}z_${variable}_${stats}_${tail}.png" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	 echo "  if [ -s \$plot ] ; then " >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+     	 echo "     cp -v \$plot $all_plots" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	 echo "     echo completed >${plot_dir}/run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.completed" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+	#Copy files to restart directory
+	 echo "    if [ $SENDCOM = YES ] ; then" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	 echo "     cp -v $all_plots/${score_type}_regional_\${domain}_valid_${valid_time}z_${variable}_${stats}_${tail}.png $restart" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	 echo "    fi" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+         echo "  fi" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+	 echo "done" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+	 echo "if [ -e ${plot_dir}/run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.completed ] ; then" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh 
+         echo " [[ $SENDCOM = YES ]] && cp -v ${plot_dir}/run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.completed $restart" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+         echo "fi" >> run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh
+
+	 chmod +x  run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh 
+         echo "${DATA}/scripts/run_${stats}.${thresh}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${valid_time}.sh" >> run_all_poe.sh
+
+       else
+	 for domain in $subregions ; do 
+	   if [ -s ${restart}/${score_type}_regional_${domain}_valid_${valid_time}z_${variable}_${stats}_${tail}.png ] ; then
+             cp -v ${restart}/${score_type}_regional_${domain}_valid_${valid_time}z_${variable}_${stats}_${tail}.png $all_plots
+	   fi 
+         done	 
+       fi
+
+     done #end of FCST_LEVEL_value
+
+    done #end of VAR
+
+  done #end of fcst_lead
+
+ done #end of dom 
+
+ done #end of score_type
+
+ done #end of thresh 
+
+done #end of stats 
+
+done #end of valid_time
+
+chmod +x run_all_poe.sh
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 765 -ppn 85 --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+cd $all_plots
+
+for score_type in lead_average threshold_average; do
+
+ for valid in 00z 12z ; do
+
+  for var in cape mlcape ; do
+   if [ $var = cape ] ; then
+       level=l0
+       stats="csi fbias"
+   elif [ $var = mlcape ] ; then
+       level=ml
+       stats="csi fbias"
+   fi
+
+  if [ $score_type = lead_average ] ; then
+     scoretype=fhrmean
+     leads="all"
+  else 
+     scoretype=threshmean
+     leads="6 12 18 24 30 36 42 48"
+  fi 
+
+  for stat in $stats ; do
+
+   for domain in conus conus_east conus_west conus_south conus_central alaska appalachia cplains deepsouth greatbasin greatlakes mezquital midatlantic northatlantic nrockies pacificnw pacificsw prairie southeast southwest splains nplains srockies ; do
+
+    for lead in $leads ; do   
+      if [ $lead = 6 ] ; then
+	  new_lead=006
+      else 
+	  new_lead=0$lead
+      fi
+
+     if [ $domain = alaska ] ; then
+         new_domain=$domain
+     elif [ $domain = conus ] ; then
+	 new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+   	 new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+   	 new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+	 new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     elif [ $domain = appalachia ] ; then
+	 new_domain=buk_apl
+     elif [ $domain = cplains  ] ; then
+         new_domain=buk_cpl
+     elif [ $domain = deepsouth  ] ; then	
+         new_domain=buk_ds
+     elif [ $domain = greatbasin ] ; then
+         new_domain=buk_grb	     
+     elif [ $domain = greatlakes ] ; then
+         new_domain=buk_grlk	     
+     elif [ $domain = mezquital ] ; then
+         new_domain=buk_mez	     
+     elif [ $domain = midatlantic ] ; then
+         new_domain=buk_matl	     
+     elif [ $domain = northatlantic ] ; then
+         new_domain=buk_ne	     
+     elif [ $domain = nrockies ] ; then
+         new_domain=buk_nrk	     
+     elif [ $domain = pacificnw ] ; then
+         new_domain=buk_npw	     
+     elif [ $domain = pacificsw ] ; then
+         new_domain=buk_psw	     
+     elif [ $domain = prairie ] ; then
+         new_domain=buk_pra	     
+     elif [ $domain = southeast ] ; then
+         new_domain=buk_se	     
+     elif [ $domain = southwest ] ; then
+         new_domain=buk_sw	     
+     elif [ $domain = splains ] ; then
+         new_domain=buk_spl	     
+     elif [ $domain = nplains ] ; then
+	 new_domain=buk_npl
+     elif [ $domain = srockies ] ; then
+         new_domain=buk_srk	     
+     fi
+
+      if [ $score_type = lead_average ] ; then
+   
+          for thresh in ge250 ge500 ge1000 ge2000 ; do
+	   if [ -s ${score_type}_regional_${domain}_valid_${valid}_${var}_${stat}_${thresh}.png ] ; then
+             mv ${score_type}_regional_${domain}_valid_${valid}_${var}_${stat}_${thresh}.png evs.refs.${stat}_${thresh}.${var}_${level}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+           fi
+          done
+      else
+	  if [ -s ${score_type}_regional_${domain}_valid_${valid}_${var}_${stat}_f${lead}.png ] ; then   
+           mv ${score_type}_regional_${domain}_valid_${valid}_${var}_${stat}_f${lead}.png  evs.refs.${stat}.${var}_${level}.last${last_days}days.${scoretype}_valid${valid}_f${new_lead}.${new_domain}.png
+
+     	  fi
+       fi
+
+      done #lead
+    done #domain
+   done #stat
+  done  #var
+ done   #valid 
+done    #score_type
+
+if [ -s evs*.png ] ; then
+ tar -cvf evs.plots.refs.grid2obs.cape.last${last_days}days.v${VDATE}.tar evs*.png
+fi
+
+# Cat the plotting log files
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out`
+  for log_file in $log_files ; do
+   echo "Start: $log_file"
+   cat  "$log_file" 
+   echo "End: $log_file"
+  done
+fi
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.grid2obs.cape.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.grid2obs.cape.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+ $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.grid2obs.cape.last${last_days}days.v${VDATE}.tar
+fi

--- a/scripts/plots/cam/exevs_plots_refs_grid2obs_ctc.sh
+++ b/scripts/plots/cam/exevs_plots_refs_grid2obs_ctc.sh
@@ -1,0 +1,523 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs ctc plotting python script
+# Last updated: 
+#               05/10/2025, Updated restart/MPMD,  by Binbin Zhou Lynker@EMC/NCEP
+#               01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#               07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP
+#               05/30/2024, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots 
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_ctc_plots
+ if [ ! -d  $restart ] ; then
+   mkdir -p $restart
+ fi
+fi 
+
+export interp_pnts=''
+
+export init_end=$VDATE
+export valid_end=$VDATE
+
+model_list='REFS_MEAN'
+models='REFS_MEAN'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+  $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day REFS_MEAN
+  export err=$?; err_chk
+  n=$((n+1))
+done 
+
+export fcst_init_hour="0,6,12,18"
+init_time='init00z_06z_12z_18z'
+
+verif_case=grid2obs
+line_type='ctc'
+
+#*****************************************
+# Build a POE file to collect sub-jobs
+#****************************************
+> run_all_poe.sh
+
+for fcst_valid_hour in 00 03 06 09 12 15 18 21 ; do
+    
+if [ "$fcst_valid_hour" -eq "03" ] || [ "$fcst_valid_hour" -eq "09" ] || [ "$fcst_valid_hour" -eq "15" ] || [ "$fcst_valid_hour" -eq "21" ] ; then
+ stats_list="csi_fbias ratio_pod_csi"
+else
+ stats_list="csi_fbias ets_fbias ratio_pod_csi"
+fi
+for stats in $stats_list ; do 
+ if [ "$fcst_valid_hour" -eq "03" ] || [ "$fcst_valid_hour" -eq "09" ] || [ "$fcst_valid_hour" -eq "15" ] || [ "$fcst_valid_hour" -eq "21" ] ; then
+    if [ $stats = csi_fbias ] ; then
+       stat_list='csi, fbias'
+       VARs='VISsfc HGTcldceil'
+       score_types='lead_average threshold_average'
+    elif [ $stats = ratio_pod_csi ] ; then
+       stat_list='sratio, pod, csi'
+       VARs='VISsfc HGTcldceil'
+       score_types='performance_diagram'   
+    else
+     err_exit "$stats is not a valid stat for vhr $fcst_valid_hour"
+    fi   
+ elif [ "$fcst_valid_hour" -eq "06" ] || [ "$fcst_valid_hour" -eq "18" ] ; then
+    if [ $stats = csi_fbias ] ; then
+       stat_list='csi, fbias'
+       VARs='VISsfc HGTcldceil'
+       score_types='lead_average threshold_average'
+    elif [ $stats = ets_fbias ] ; then
+       stat_list='ets, fbias'
+       VARs='TCDC'
+       score_types='lead_average threshold_average'
+    elif [ $stats = ratio_pod_csi ] ; then
+       stat_list='sratio, pod, csi'
+       VARs='VISsfc HGTcldceil TCDC'
+       score_types='performance_diagram'   
+    else
+     err_exit "$stats is not a valid stat for vhr $fcst_valid_hour"
+    fi   
+ else
+    if [ $stats = csi_fbias ] ; then
+       stat_list='csi, fbias'
+       VARs='VISsfc HGTcldceil'
+       score_types='lead_average threshold_average'
+    elif [ $stats = ets_fbias ] ; then
+       stat_list='ets, fbias'
+       VARs='TCDC'
+       score_types='lead_average threshold_average'
+    elif [ $stats = ratio_pod_csi ] ; then
+       stat_list='sratio, pod, csi'
+       VARs='VISsfc HGTcldceil CAPEsfc TCDC MLCAPE'
+       score_types='performance_diagram'   
+    else
+     err_exit "$stats is not a valid stat for vhr $fcst_valid_hour"
+    fi   
+ fi
+ for score_type in $score_types ; do
+
+  export fcst_leads="6,9,12,15,18,21,24,27,30,33,36,39,42,45,48"
+
+  for fcst_lead in $fcst_leads ; do 
+
+    #just for sub-job names	  
+    lead=all_leads
+
+    for VAR in $VARs ; do 
+
+       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+	
+       if [ $VAR = CAPEsfc ] ; then 
+	  new_var=cape
+       elif [ $VAR = MLCAPE ] ; then
+	  new_var=mlcape
+       elif [ $VAR = VISsfc ] ; then
+	  new_var=vis
+       elif [ $VAR = HGTcldceil ] ; then
+          new_var=hgtcldceil
+       elif [ $VAR = TCDC ] ; then
+          new_var=tcdc
+       fi
+
+       if [ $VAR = CAPEsfc ] || [ $VAR = VISsfc ] || [ $VAR = HGTcldceil ] || [ $VAR = TCDC ] ; then
+          FCST_LEVEL_values="L0"
+       elif [ $VAR = MLCAPE ] ; then
+	  FCST_LEVEL_values="ML"
+       fi 	  
+
+       doms="dom1 dom2 dom3 dom4 dom5 dom6 dom7 dom8"
+
+       for dom in $doms ; do 
+
+	 if [ $dom = dom1 ] ; then
+            VX_MASK_LIST="CONUS, CONUS_East, CONUS_West"
+	    subregions="conus conus_east conus_west"
+         elif [ $dom = dom2 ] ; then
+	    VX_MASK_LIST="CONUS_South, CONUS_Central, Alaska"
+	    subregions="conus_south conus_central alaska"
+         elif [ $dom = dom3 ] ; then
+	    VX_MASK_LIST="Appalachia, CPlains, DeepSouth"
+	    subregions="appalachia cplains deepsouth"
+         elif [ $dom = dom4 ] ; then
+	    VX_MASK_LIST="GreatBasin, GreatLakes, Mezquital"
+	    subregions="greatbasin greatlakes mezquital"
+	 elif [ $dom = dom5 ] ; then
+	    VX_MASK_LIST="MidAtlantic, NorthAtlantic, NPlains"
+	    subregions="midatlantic northatlantic nplains"
+	 elif [ $dom = dom6 ] ; then
+            VX_MASK_LIST="NRockies, PacificNW, PacificSW" 
+	    subregions="nrockies pacificnw pacificsw"
+	 elif [ $dom = dom7 ] ; then
+            VX_MASK_LIST="SRockies, Prairie, Southeast"
+	    subregions="srockies prairie southeast"
+	 elif [ $dom = dom8 ] ; then
+            VX_MASK_LIST="Southwest, SPlains"
+	    subregions="southwest splains"
+	 fi
+
+      for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+
+        OBS_LEVEL_value=$FCST_LEVEL_value
+
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+
+	 #**********************
+	 # Build sub-jobs
+	 # *********************
+         > run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh  
+
+       #***********************************************************************************************************************************
+       #  Check if this sub-job has been completed in the previous run for restart
+       if [ ! -e $restart/run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.completed ] ; then
+       #***********************************************************************************************************************************
+
+        verif_type=conus_sfc
+	echo "#!/bin/ksh" >>  run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	echo "set -x" >>  run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+       
+	save_dir=$DATA/plots/run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}
+	plot_dir=$save_dir/sfc_upper/$eval_period
+	mkdir -p $plot_dir
+	mkdir -p $save_dir/data
+
+	echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+        if [ $VAR = CAPEsfc ] || [ $VAR = MLCAPE ] ; then
+	  echo "export obsv=\" - Validation: RAOB\" " >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	elif [ $VAR = VISsfc ] || [ $VAR = HGTcldceil ] || [ $VAR = TCDC ] ; then
+	  echo "export obsv=\" - Validation: METAR\" " >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        fi	   
+
+	if [ $score_type = lead_average ] ; then
+           echo "export PLOT_TYPE=lead_average_valid" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        else            
+           echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        fi
+
+        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+        fi
+
+
+         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+         echo "export interp=BILIN" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+	 if [ $VAR = CAPEsfc ] || [ $VAR = MLCAPE ] ; then
+           thresh_fcst='>=250, >=500, >=1000, >=2000'
+	 elif [ $VAR = VISsfc  ] ; then
+           thresh_fcst='<805, <1609, <4828, <8045, <16090'
+         elif [ $VAR = HGTcldceil  ] ; then
+            thresh_fcst='<152, <305, <914, <1524, <3048'
+	 elif [ $VAR = TCDC ] ; then
+	    #Binbin Note: can not set threshold operands '<' and '>=' together in the threshold list
+            #thresh_fcst='<10, >=10, >=50, >=90'		 
+            thresh_fcst='>=10, >=50, >=90'		 
+         fi	    
+	 thresh_obs=$thresh_fcst
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+         echo "${DATA}/scripts/run_py.${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+	 #Save for restart
+         echo "for domain in $subregions ; do " >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "  if [ -s ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_${new_var}_*.png ] ; then " >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "    cp -v ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_${new_var}_*.png $all_plots" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "    echo completed >${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.completed" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+	 #Copy files to restart directory
+	 echo "   if [ $SENDCOM = YES ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "     cp -v $all_plots/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_${new_var}_*.png $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "   fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "  fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+	 echo "done" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+	 echo "if [ -e ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.completed ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+         echo "  [[ $SENDCOM = YES ]] && cp -v ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.completed $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+         echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh
+
+         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh 
+         echo "${DATA}/scripts/run_${stats}.${score_type}.${lead}.${VAR}.${dom}.${FCST_LEVEL_value}.${fcst_valid_hour}.sh" >> run_all_poe.sh
+
+      else
+         for domain in $subregions ; do
+           if [ -s $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${new_var}_*.png ] ; then
+             cp -v $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${new_var}_*.png $all_plots
+           fi
+         done	   
+      fi
+
+     done #end of FCST_LEVEL_value
+
+    done #end of VAR
+
+  done #end of fcst_lead
+
+ done #end of dom 
+
+ done #end of score_type
+
+done #end of stats 
+
+done #end of valid 
+
+chmod +x run_all_poe.sh
+
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 510 -ppn 85 --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+cd $all_plots
+
+for valid in 00z 03z 06z 09z 12z 15z 18z 21z ; do
+
+ for domain in conus conus_east conus_west conus_south conus_central alaska  appalachia cplains deepsouth greatbasin greatlakes mezquital midatlantic northatlantic nrockies pacificnw pacificsw prairie southeast southwest splains nplains srockies ; do
+
+     if [ $domain = alaska ] ; then
+         new_domain=$domain
+     elif [ $domain = conus ] ; then
+	 new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+   	 new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+   	 new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+	 new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     elif [ $domain = appalachia ] ; then
+	 new_domain=buk_apl
+     elif [ $domain = cplains  ] ; then
+         new_domain=buk_cpl
+     elif [ $domain = deepsouth  ] ; then	
+         new_domain=buk_ds
+     elif [ $domain = greatbasin ] ; then
+         new_domain=buk_grb	     
+     elif [ $domain = greatlakes ] ; then
+         new_domain=buk_grlk	     
+     elif [ $domain = mezquital ] ; then
+         new_domain=buk_mez	     
+     elif [ $domain = midatlantic ] ; then
+         new_domain=buk_matl	     
+     elif [ $domain = northatlantic ] ; then
+         new_domain=buk_ne	     
+     elif [ $domain = nrockies ] ; then
+         new_domain=buk_nrk	     
+     elif [ $domain = pacificnw ] ; then
+         new_domain=buk_npw	     
+     elif [ $domain = pacificsw ] ; then
+         new_domain=buk_psw	     
+     elif [ $domain = prairie ] ; then
+         new_domain=buk_pra	     
+     elif [ $domain = southeast ] ; then
+         new_domain=buk_se	     
+     elif [ $domain = southwest ] ; then
+         new_domain=buk_sw	     
+     elif [ $domain = splains ] ; then
+         new_domain=buk_spl	     
+     elif [ $domain = nplains ] ; then
+	 new_domain=buk_npl
+     elif [ $domain = srockies ] ; then
+         new_domain=buk_srk	     
+     fi
+ for var in vis hgtcldceil tcdc cape mlcape; do
+  if [ $var = vis ] ; then
+    var_new=$var
+    level=l0
+  elif [ $var = hgtcldceil ] ; then
+    var_new=ceiling
+    level=l0
+  elif [ $var = tcdc ] ; then
+    var_new=cloud
+    level=l0
+  elif [ $var = cape ] ; then
+    var_new=cape
+    level=l0
+  elif [ $var = mlcape ] ; then
+    var_new=mlcape
+    level=ml
+  fi
+
+  if [ -s performance_diagram_regional_${domain}_valid_${valid}_${var}_*.png ] ; then
+    mv performance_diagram_regional_${domain}_valid_${valid}_${var}_*.png evs.refs.ctc.${var_new}_${level}.last${last_days}days.perfdiag_valid${valid}.${new_domain}.png
+  fi 
+
+ done
+done
+done
+
+for valid in 00z 03z 06z 09z 12z 15z 18z 21z ; do
+
+ for score_type in lead_average threshold_average; do
+
+  for var in vis hgtcldceil tcdc ; do
+   if [ $var = vis ] ; then
+       var_new=$var
+       level=l0
+       stats="csi_fbias csi fbias"
+   elif [ $var = hgtcldceil ] ; then
+       var_new=ceiling
+       level=l0
+       stats="csi_fbias csi fbias"
+   elif [ $var = tcdc ] ; then
+       var_new=cloud
+       level=l0
+       stats="ets_fbias ets fbias" 
+   fi
+
+  if [ $score_type = lead_average ] ; then
+     scoretype=fhrmean
+  elif [ $score_type = threshold_average ] ; then
+     scoretype=threshmean
+  fi 
+
+  for stat in $stats ; do
+
+    for domain in conus conus_east conus_west conus_south conus_central alaska appalachia cplains deepsouth greatbasin greatlakes mezquital midatlantic northatlantic nrockies pacificnw pacificsw prairie southeast southwest splains nplains srockies ; do
+
+     if [ $domain = alaska ] ; then
+         new_domain=$domain
+     elif [ $domain = conus ] ; then
+	 new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+   	 new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+   	 new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+	 new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     elif [ $domain = appalachia ] ; then
+	 new_domain=buk_apl
+     elif [ $domain = cplains  ] ; then
+         new_domain=buk_cpl
+     elif [ $domain = deepsouth  ] ; then	
+         new_domain=buk_ds
+     elif [ $domain = greatbasin ] ; then
+         new_domain=buk_grb	     
+     elif [ $domain = greatlakes ] ; then
+         new_domain=buk_grlk	     
+     elif [ $domain = mezquital ] ; then
+         new_domain=buk_mez	     
+     elif [ $domain = midatlantic ] ; then
+         new_domain=buk_matl	     
+     elif [ $domain = northatlantic ] ; then
+         new_domain=buk_ne	     
+     elif [ $domain = nrockies ] ; then
+         new_domain=buk_nrk	     
+     elif [ $domain = pacificnw ] ; then
+         new_domain=buk_npw	     
+     elif [ $domain = pacificsw ] ; then
+         new_domain=buk_psw	     
+     elif [ $domain = prairie ] ; then
+         new_domain=buk_pra	     
+     elif [ $domain = southeast ] ; then
+         new_domain=buk_se	     
+     elif [ $domain = southwest ] ; then
+         new_domain=buk_sw	     
+     elif [ $domain = splains ] ; then
+         new_domain=buk_spl	     
+     elif [ $domain = nplains ] ; then
+	 new_domain=buk_npl
+     elif [ $domain = srockies ] ; then
+         new_domain=buk_srk	     
+     fi
+     if [ -s ${score_type}_regional_${domain}_valid_${valid}_${var}_${stat}*.png ] ; then
+         mv ${score_type}_regional_${domain}_valid_${valid}_${var}_${stat}*.png evs.refs.${stat}.${var_new}_${level}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+     fi
+
+       done #domain
+    done #stat
+   done  #var
+ done    #score_type
+done
+
+if [ -s evs*.png ] ; then
+ tar -cvf evs.plots.refs.grid2obs.ctc.last${last_days}days.v${VDATE}.tar evs*.png
+fi 
+
+# Cat the plotting log files
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out`
+  for log_file in $log_files ; do
+     echo "Start: $log_file"
+     cat  "$log_file"
+     echo "End: $log_file"
+  done
+fi
+
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.grid2obs.ctc.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.grid2obs.ctc.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.grid2obs.ctc.last${last_days}days.v${VDATE}.tar
+fi
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/scripts/plots/cam/exevs_plots_refs_grid2obs_ecnt.sh
+++ b/scripts/plots/cam/exevs_plots_refs_grid2obs_ecnt.sh
@@ -1,0 +1,400 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs ecnt plotting python script
+# Last updated: 
+#                 05/10/2025,  Updated MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#                 01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#                 07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP
+#                 05/30/2024, Binbin Zhou Lynker@EMC/NCEP
+##******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_ecnt_plots
+ if [ ! -d  $restart ] ; then
+  mkdir -p $restart
+ fi
+fi
+
+export interp_pnts=''
+
+export init_end=$VDATE
+export valid_end=$VDATE
+
+model_list='REFS'
+models='REFS'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+  $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day "$model_list"
+  export err=$?; err_chk
+  n=$((n+1))
+done 
+
+
+VX_MASK_LIST="CONUS, CONUS_East, CONUS_West, CONUS_South, CONUS_Central, Alaska, Appalachia, CPlains, DeepSouth, GreatBasin, GreatLakes, Mezquital, MidAtlantic, NorthAtlantic, NPlains, NRockies, PacificNW, PacificSW, Prairie, Southeast, Southwest, SPlains, SRockies"
+																  
+export fcst_init_hour="0,6,12,18"
+
+verif_case=grid2obs
+
+#*****************************************
+# Build a POE file to collect sub-jobs
+# ****************************************
+> run_all_poe.sh
+
+for fcst_valid_hour in 00 03 06 09 12 15 18 21 ; do
+
+ for stats in rmse_spread ; do 
+   if [ $stats = rmse_spread  ] ; then
+     stat_list='rmse, spread'
+     line_type='ecnt'
+     if [ "$fcst_valid_hour" -eq "00" ] || [ "$fcst_valid_hour" -eq "12" ] ; then
+       VARs='TMP2m DPT2m UGRD10m VGRD10m RH2m PRMSL WIND10m GUSTsfc HPBL'
+     else
+       VARs='TMP2m DPT2m UGRD10m VGRD10m RH2m PRMSL WIND10m GUSTsfc'
+     fi
+     score_types='lead_average'
+   else
+     err_exit "$stats is not a valid stat"
+   fi   
+
+ for score_type in $score_types ; do
+
+  export fcst_init_hour="0,6,12,18"
+  init_time='init00z_06z_12z_18z'
+
+  export fcst_leads="6,9,12,15,18,21,24,27,30,33,36,39,42,45,48"
+
+  for lead in $fcst_leads ; do 
+
+    for VAR in $VARs ; do 
+
+       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+	    
+       if [ $VAR = TMP2m ] || [ $VAR = DPT2m ] || [ $VAR = RH2m ] ; then 
+          FCST_LEVEL_values="Z2"
+       elif [ $VAR = UGRD10m ] || [ $VAR = VGRD10m ] || [ $VAR = WIND10m ] ; then
+          FCST_LEVEL_values="Z10"
+       elif [ $VAR = PRMSL ] || [ $VAR = GUSTsfc ] || [ $VAR = HPBL ] ; then
+          FCST_LEVEL_values="L0"
+       fi
+
+       if [ $VAR = TMP2m ] ; then
+	  new_var=tmp
+       elif [ $VAR = DPT2m ] ; then
+	  new_var=dpt
+       elif [ $VAR = RH2m ] ; then
+	  new_var=rh
+       elif [ $VAR = UGRD10m  ] ; then
+          new_var=ugrd
+       elif [ $VAR = VGRD10m  ] ; then
+          new_var=vgrd
+       elif [ $VAR = WIND10m ] ; then
+          new_var=wind
+       elif [ $VAR = PRMSL ] ; then
+          new_var=mslet
+       elif [ $VAR = GUSTsfc ] ; then
+          new_var=gust
+       elif [ $VAR = HPBL ] ; then
+          new_var=hpbl
+       fi	  
+
+     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+
+	OBS_LEVEL_value=$FCST_LEVEL_value
+
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+
+        doms="dom1 dom2 dom3 dom4 dom5 dom6 dom7 dom8"
+
+	for dom in $doms ; do
+
+         if [ $dom = dom1 ] ; then
+	    VX_MASK_LIST="CONUS, CONUS_East, CONUS_West" 
+	    subregions="conus conus_east conus_west"
+	  elif [ $dom = dom2 ] ; then
+	    VX_MASK_LIST="CONUS_South, CONUS_Central, Alaska"
+	    subregions="conus_south conus_central alaska"
+          elif [ $dom = dom3 ] ; then
+            VX_MASK_LIST="Appalachia, CPlains, DeepSouth"
+            subregions="appalachia cplains deepsouth"	
+	  elif [ $dom = dom4 ] ; then
+            VX_MASK_LIST="GreatBasin, GreatLakes, Mezquital"
+	    subregions="greatbasin greatlakes mezquital"
+	  elif [ $dom = dom5 ] ; then
+            VX_MASK_LIST="MidAtlantic, NorthAtlantic, NPlains"
+            subregions="midatlantic northatlantic nplains"
+          elif [ $dom = dom6 ] ; then
+            VX_MASK_LIST="NRockies, PacificNW, PacificSW"
+	    subregions="nrockies pacificnw pacificsw"
+           elif [ $dom = dom7 ] ; then
+	    VX_MASK_LIST="SRockies, Prairie, Southeast"
+            subregions="srockies prairie southeast"
+	   elif [ $dom = dom8 ] ; then
+            VX_MASK_LIST="Southwest, SPlains"
+            subregions="southwest splains"	    
+	 fi
+
+	 #****************
+	 # Build sub-jobs
+	 # **************
+         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh  
+
+      #***********************************************************************************************************************************
+      #  Check if this sub-job has been completed in the previous run for restart
+      if [ ! -e $restart/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.completed ] ; then
+      #***********************************************************************************************************************************
+     
+	echo "#!/bin/ksh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh 
+	echo "set -x" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh 
+        verif_type=conus_sfc
+
+        save_dir=$DATA/plots/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}
+        plot_dir=$save_dir/sfc_upper/$eval_period
+        mkdir -p $plot_dir
+        mkdir -p $save_dir/data
+
+        echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+	if [ $VAR = HPBL ] ; then
+	  echo "export obsv=\" - Validation: RAOB\" " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	else
+	  echo "export obsv=\" - Validation: METAR\" " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	fi
+
+        echo "export PLOT_TYPE=lead_average_valid" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+        fi
+
+
+         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+         echo "export interp=BILIN" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+         thresh_fcst=' '
+	 thresh_obs=' '
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+         echo "${DATA}/scripts/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+         #Save for restart and tar files
+	 echo "for domain in $subregions ; do "  >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	 echo "if [ -s ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_*${new_var}_${stats}.png ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	 echo " cp -v ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_*${new_var}_${stats}.png $all_plots" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	 echo " echo completed >${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.completed" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh 
+
+	 #Copy files to restart directory
+	 echo " if [ $SENDCOM = YES ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	 echo "  cp -v ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_*${new_var}_${stats}.png $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	 echo "  cp -v ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.completed $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh 
+	 echo " fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+	 echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+         echo "done" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh
+
+         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh 
+         echo "${DATA}/scripts/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${fcst_valid_hour}.${dom}.sh" >> run_all_poe.sh
+
+       else
+	 for domain in $subregions ; do
+           if [ -s $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${new_var}_${stats}.png ] ; then
+	     cp -v $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${new_var}_${stats}.png $all_plots 
+           fi
+         done	   
+       fi 
+
+      done #end of dom 
+
+     done #end of FCST_LEVEL_value
+
+    done #end of VAR
+
+  done #end of fcst_lead
+
+ done #end of score_type
+
+done #end of stats 
+
+done #valid 
+
+chmod +x run_all_poe.sh
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 66 -ppn 66 --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+cd $all_plots
+
+for valid in 00z 03z 06z 09z 12z 15z 18z 21z ; do
+for stats in  rmse_spread ; do
+ for score_type in lead_average ; do
+
+  scoretype=fhrmean
+  vars='prmsl tmp dpt ugrd vgrd rh wind gust mslet hpbl'
+
+   for domain in conus conus_east conus_west conus_south conus_central alaska appalachia cplains deepsouth greatbasin greatlakes mezquital midatlantic northatlantic nrockies pacificnw pacificsw prairie southeast southwest splains nplains srockies ; do
+
+     if [ $domain = alaska ] ; then
+         new_domain=$domain
+     elif [ $domain = conus ] ; then
+	 new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+   	 new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+   	 new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+	 new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     elif [ $domain = appalachia ] ; then
+	 new_domain=buk_apl
+     elif [ $domain = cplains  ] ; then
+         new_domain=buk_cpl
+     elif [ $domain = deepsouth  ] ; then	
+         new_domain=buk_ds
+     elif [ $domain = greatbasin ] ; then
+         new_domain=buk_grb	     
+     elif [ $domain = greatlakes ] ; then
+         new_domain=buk_grlk	     
+     elif [ $domain = mezquital ] ; then
+         new_domain=buk_mez	     
+     elif [ $domain = midatlantic ] ; then
+         new_domain=buk_matl	     
+     elif [ $domain = northatlantic ] ; then
+         new_domain=buk_ne	     
+     elif [ $domain = nrockies ] ; then
+         new_domain=buk_nrk	     
+     elif [ $domain = pacificnw ] ; then
+         new_domain=buk_npw	     
+     elif [ $domain = pacificsw ] ; then
+         new_domain=buk_psw	     
+     elif [ $domain = prairie ] ; then
+         new_domain=buk_pra	     
+     elif [ $domain = southeast ] ; then
+         new_domain=buk_se	     
+     elif [ $domain = southwest ] ; then
+         new_domain=buk_sw	     
+     elif [ $domain = splains ] ; then
+         new_domain=buk_spl	     
+     elif [ $domain = nplains ] ; then
+	 new_domain=buk_npl
+     elif [ $domain = srockies ] ; then
+         new_domain=buk_srk	     
+     fi
+    for var in $vars ; do
+
+      if [ $var = mslet ] ; then
+	  var_new=prmsl
+      else
+	  var_new=$var
+      fi
+
+      if [ $var = tmp ] || [ $var = dpt ] || [ $var = rh ]; then
+	 level='2m'
+	 new_level='z2'
+      elif [ $var = ugrd ] || [ $var = vgrd ] || [ $var = wind ] ; then
+	 level='10m'
+	 new_level='z10'
+      elif [ $var = mslet ] || [ $var = gust ] || [ $var = hpbl ] ; then
+	 level='l0'
+      fi
+
+
+      if [ $var = mslet ] || [ $var = gust ] || [  $var = hpbl ] ; then
+	if [ -s ${score_type}_regional_${domain}_valid_${valid}_${var}_${stats}.png ] ; then
+          mv ${score_type}_regional_${domain}_valid_${valid}_${var}_${stats}.png  evs.refs.${stats}.${var}_${level}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+        fi 
+      else
+	if [ -s ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}.png ] ; then
+          mv ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}.png  evs.refs.${stats}.${var}_${new_level}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+        fi
+      fi
+
+     done #var
+   done  #domain
+ done    #score_type
+done     #stats
+done     #valid 
+
+if [ -s evs*.png ] ; then
+ tar -cvf evs.plots.refs.grid2obs.ecnt.last${last_days}days.v${VDATE}.tar evs*.png
+fi
+
+# Cat the plotting log files
+
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out` 
+  for log_file in $log_files ; do   
+    echo "Start: $log_file"
+    cat  "$log_file"    
+    echo "End: $log_file"
+  done   
+fi
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.grid2obs.ecnt.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.grid2obs.ecnt.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.grid2obs.ecnt.last${last_days}days.v${VDATE}.tar
+fi  
+
+
+
+
+
+
+

--- a/scripts/plots/cam/exevs_plots_refs_precip.sh
+++ b/scripts/plots/cam/exevs_plots_refs_precip.sh
@@ -1,0 +1,394 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs cape plotting python script
+# Last updated:
+#              05/10/2025, Updated restart/MPMD,  by Binbin Zhou Lynker@EMC/NCEP
+#              01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#              07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP 
+#              05/30/2024, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_precip_plots
+ if [ ! -d  $restart ] ; then
+  mkdir -p $restart
+ fi     
+fi
+
+
+export interp_pnts=''
+
+export init_end=$VDATE
+export valid_end=$VDATE
+
+model_list='REFS_MEAN REFS_AVRG REFS_LPMM REFS_PMMN'
+models='REFS_MEAN,  REFS_AVRG, REFS_LPMM, REFS_PMMN'
+
+VX_MASK_LISTs='CONUS CONUS_East CONUS_West CONUS_South CONUS_Central Alaska'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  #hrs=`expr $n \* 24`
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+   $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day "$model_list"
+  n=$((n+1))
+done 
+
+
+verif_case=precip
+verif_type=ccpa
+
+#*****************************************
+# Build a POE file to collect sub-jobs
+# ****************************************
+> run_all_poe.sh
+
+for VX_MASK_LIST in $VX_MASK_LISTs ; do
+ 	
+  domain=`echo $VX_MASK_LIST | tr '[A-Z]' '[a-z]'`
+
+for stats in ets_fbias ratio_pod_csi fss ; do 
+ if [ $stats = ets_fbias ] ; then
+    stat_list='ets, fbias'
+    line_tp='ctc'
+    VARs='APCP_01 APCP_03 APCP_24'
+    interp_pnts=''
+    score_types='threshold_average '
+ elif [ $stats = ratio_pod_csi ] ; then
+    stat_list='sratio, pod, csi'
+    line_tp='ctc'
+    VARs='APCP_01 APCP_03 APCP_24'
+    interp_pnts=''
+    score_types='performance_diagram'
+ elif [ $stats = fss ] ; then
+    stat_list='fss'
+    line_tp='nbrcnt'
+    VARs='APCP_01 APCP_03 APCP_24'    
+    interp_pnts='1,9,25,49,91,121'
+    score_types='threshold_average' 
+ else
+  err_exit "$stats is not a valid stat"
+ fi   
+
+ for score_type in $score_types ; do
+
+  for VAR in $VARs ; do
+ 
+   var=`echo $VAR | tr '[A-Z]' '[a-z]'`
+
+   if [ $VAR = APCP_01 ] ; then
+	#export fcst_leads='3,6,9,12,15,18,21,24'
+	export fcst_leads='1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24'
+	export fcst_valid_hours='00 03 06 09 12 15 18 21'
+	FCST_LEVEL_values=A01
+   elif [ $VAR = APCP_03 ] ; then
+         export fcst_leads='3,6,9,12,15,18,21,24,27,30,33,36,39,42,45,48'
+	 export fcst_valid_hours='00 03 06 09 12 15 18 21'
+	 FCST_LEVEL_values=A03
+   elif [ $VAR = APCP_24 ] ; then
+         export fcst_leads='24,30,36,42,48'
+	 export fcst_valid_hours='12'
+	 FCST_LEVEL_values=A24
+   fi
+
+  for lead in $fcst_leads ; do 
+
+     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+
+	if [ $VX_MASK_LIST = Alaska ] ; then
+          OBS_LEVEL_value=L0
+	else
+          OBS_LEVEL_value=$FCST_LEVEL_value
+        fi
+
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+
+      for line_type in $line_tp ; do 
+
+       for fcst_valid_hour in $fcst_valid_hours ; do	      
+
+	 #***************
+	 # Build sub-jobs
+	 # ***************
+         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh  
+
+      #***********************************************************************************************************************************
+      #  Check if this sub-job has been completed in the previous run for restart
+      if [ ! -e $restart/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.completed ] ; then
+      #***********************************************************************************************************************************
+        
+        echo "#!/bin/ksh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "set -x" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        save_dir=$DATA/plots/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}
+	plot_dir=$save_dir/precip/$eval_period
+	mkdir -p $plot_dir
+	mkdir -p $save_dir/data
+
+	echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+	echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+
+	if [ $VX_MASK_LIST = Alaska ] ; then
+	  echo "export obsv=\" - Validation: MRMS\" " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	else
+	  echo "export obsv=\" - Validation: CCPA\" " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	fi
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        fi
+
+
+         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+	 if [ $stats = fss ] ; then
+	   
+	   echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         else	   
+           echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 fi
+
+         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+ 
+	 if [ $VAR = APCP_01 ] ; then
+           thresh_fcst='>=0.254, >=2.54, >=6.35, >=12.7, >=25.4'
+         elif [ $VAR = APCP_03 ] ; then
+           thresh_fcst='>=2.54, >=6.35, >=12.7, >=25.4, >=50.8'
+         elif [ $VAR = APCP_24 ] ; then
+           thresh_fcst='>=12.7, >=25.4, >=50.8, >=76.2'
+	 fi
+	 thresh_obs=$thresh_fcst
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         echo "${DATA}/scripts/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+	 echo "if [ -s ${plot_dir}/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${var}*.png ] ; then " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "  cp -v ${plot_dir}/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${var}*.png $all_plots" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "  echo completed >${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.completed" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 #Copy files to restart directory
+         echo "  if [ $SENDCOM = YES ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "    cp -v $all_plots/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${var}*.png $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "    cp -v ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.completed $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "  fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh 
+         echo "${DATA}/scripts/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh" >> run_all_poe.sh
+
+       else
+	if [ -s $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${var}*.png ] ; then
+	  cp -v $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_*${var}*.png $all_plots
+	fi
+       fi 
+
+       done # end of fcst_valid_hour
+
+      done #end of line_type
+
+     done #end of FCST_LEVEL_value
+
+    done #end of VAR
+
+  done #end of fcst_lead
+
+ done #end of score_type
+
+done #end of stats 
+
+done #end of vx_mask_list
+chmod +x run_all_poe.sh
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 304 -ppn 76 --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+
+cd $all_plots
+
+for stats in ets fbias fss ; do
+  score_type='threshold_average' 
+  scoretype='threshmean'
+
+  for var in apcp_01 apcp_03 apcp_24 ; do
+
+    if [ $var = apcp_01 ] || [ $var = apcp_03 ] ; then
+      valids="00z 03z 06z 09z 12z 15z 18z 21z"
+    elif [ $var = apcp_24 ] ; then
+      valids="12z"
+    fi 
+
+    if [ $var = apcp_01 ] ; then
+      new_var=apcp_a01
+    elif [ $var = apcp_03 ] ; then
+       new_var=apcp_a03
+    elif [ $var = apcp_24 ] ; then
+       new_var=apcp_a24
+    fi 
+
+    level=${var:5:2}h
+    if [ $stats = fss ] ; then 
+       if [ $var = apcp_01 ] ; then
+        lead=width1-3-5-7-9-11_f1_to_f24
+       elif [ $var = apcp_03 ] ; then
+        lead=width1-3-5-7-9-11_f3_to_f48
+       elif [ $var = apcp_24 ] ; then
+        lead=width1-3-5-7-9-11_f24-30-36-42-48
+       fi	
+    else	    
+      if [ $var = apcp_01 ] ; then
+        lead=f1_to_f24
+      elif [ $var = apcp_03 ] ; then
+        lead=f3_to_f48
+      elif [ $var = apcp_24 ] ; then
+        lead=f24-30-36-42-48
+      fi
+    fi
+
+   for domain in conus conus_east conus_west conus_south conus_central alaska  ; do
+
+     if [ $domain = alaska ] ; then
+       new_domain=$domain
+     elif [ $domain = conus ] ; then
+       new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+       new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+       new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+       new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+       new_domain=buk_conus_c
+     fi
+
+    for valid in $valids ; do
+ 
+      if [ -s ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}_${lead}.png ] ; then
+        ls ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}_${lead}.png
+        mv ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}_${lead}.png  evs.refs.${stats}.${new_var}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+      fi
+    done
+  done
+
+ done
+done
+
+
+score_type='performance_diagram'  
+scoretype='perfdiag'
+
+for var in apcp_01 apcp_03 apcp_24 ; do
+  
+    if [ $var = apcp_01 ] || [ $var = apcp_03 ] ; then
+	 valids="00z 03z 06z 09z 12z 15z 18z 21z"
+    elif [ $var = apcp_24 ] ; then
+         valids="12z"
+    fi
+
+    level=${var:5:2}h
+    if [ $var = apcp_01 ] ; then
+        lead=f1_to_f24__ge0.254ge2.54ge6.35ge12.7ge25.4
+	new_var=apcp_a01
+    elif [ $var = apcp_03 ] ; then
+        lead=f3_to_f48__ge2.54ge6.35ge12.7ge25.4ge50.8
+	new_var=apcp_a03
+    elif [ $var = apcp_24 ] ; then
+        lead=f24-30-36-42-48__ge12.7ge25.4ge50.8ge76.2
+	new_var=apcp_a24
+    fi
+
+   for domain in conus conus_east conus_west conus_south conus_central alaska  ; do
+    for valid in $valids ; do
+
+     if [ $domain = alaska ] ; then
+         new_domain=$domain
+     elif [ $domain = conus ] ; then
+	 new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+   	 new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+   	 new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+	 new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     fi
+
+      if [ -s ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${lead}.png ] ; then
+       mv ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${lead}.png  evs.refs.ctc.${new_var}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+      fi
+
+    done
+  done
+done
+
+if [ -s evs*.png ] ; then
+  tar -cvf evs.plots.refs.precip.last${last_days}days.v${VDATE}.tar evs*.png
+fi
+
+# Cat the plotting log files
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out`
+  for log_file in $log_files ; do
+     echo "Start: $log_file"
+     cat  "$log_file"
+     echo "End: $log_file"
+  done
+fi
+
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.precip.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.precip.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.precip.last${last_days}days.v${VDATE}.tar
+fi
+

--- a/scripts/plots/cam/exevs_plots_refs_precip_spatial.sh
+++ b/scripts/plots/cam/exevs_plots_refs_precip_spatial.sh
@@ -1,0 +1,106 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs precip spatial map plotting 
+#           python script
+# Last updated: 05/30/2024, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+cd $DATA
+
+export machine=${machine:-"WCOSS2"}
+
+export VERIF_CASE=grid2grid
+export evs_run_mode=production
+export plot_verbosity=INFO
+export JOB_GROUP=plot
+export VERIF_TYPE=precip
+export job_var=24hrAccumMaps
+export fhr_start=24
+export fhr_end=48
+export fhr_inc=24
+export valid_hr_start=12
+export valid_hr_end=12
+export valid_hr_inc=24
+export init_hr_start=12
+export init_hr_end=12
+export init_hr_inc=24
+export model_list='refsmean refslpmm refspmmn refsavrg'
+export model_plot_name_list='refsmean refslpmm refspmmn refsavrg'
+export obs_name=24hrCCPA
+export event_equalization=NO
+export start_date=$VDATE
+export end_date=$VDATE
+export date_type=VALID
+export grid=G270
+export fcst_var_name=APCP
+export fcst_var_level_list='A24'
+export fcst_var_thresh_list='NA'
+export obs_var_name=APCP
+export obs_var_level_list='A24'
+export obs_var_thresh_list='NA'
+export interp_method=NEAREST
+export interp_points_list='1'
+export line_type=SL1L2
+export stat=FBAR
+export vx_mask=CONUS
+export plots_list=precip_spatial_map
+export job_name=SL1L2/FBAR/24hrAccumMaps/CONUS/precip_spatial_map
+
+mkdir -p $DATA/grid2grid_plots/plot_output/atmos.${VDATE}/logs
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+for model in $model_list ; do
+ MODEL=`echo $model | tr '[a-z]' '[A-Z]'`	
+ target=$DATA/grid2grid_plots/data/$model
+ mkdir -p $target
+ for fhr in 24 48 ; do
+  last=`$NDATE -$fhr ${VDATE}12`	
+  INITDATE=${last:0:8}
+  ln -sf $EVSINapcp24mean/${model}.$INITDATE.t12z.G227.24h.f${fhr}.nc  $target/${model}_precip_24hrAccum_init${INITDATE}12_fhr0${fhr}.nc
+ done
+done
+
+target=$DATA/grid2grid_plots/data/ccpa
+mkdir -p $target
+ln -sf $EVSINapcp24mean/ccpa24h.t12z.G240.nc  $target/ccpa_precip_24hrAccum_valid${VDATE}12.nc
+
+#**************************************
+# Run spatial map python scripts
+# *************************************
+python $USHevs/cam/ush_refs_plot_py/refs_atmos_plots.py
+export err=$?; err_chk
+
+cd $DATA/grid2grid_plots/plot_output/atmos.${VDATE}/precip/SL1L2_FBAR_24hrAccumMaps_CONUS_precip_spatial_map/images
+
+if [ -s refs*.gif ] ; then
+ tar -cvf evs.plots.refs.precip.spatial.map.v${VDATE}.tar *.gif
+fi 
+
+# Cat the plotting log files
+log_dirs="$DATA/*/*/*/logs"
+for log_dir in $log_dirs; do
+    if [ -d $log_dir ]; then
+        log_file_count=$(find $log_dir -type f | wc -l)
+        if [[ $log_file_count -ne 0 ]]; then
+            log_files=("$log_dir"/*)
+            for log_file in "${log_files[@]}"; do
+                if [ -f "$log_file" ]; then
+                    echo "Start: $log_file"
+                    cat "$log_file"
+                    echo "End: $log_file"
+                fi
+            done
+        fi
+    fi
+done
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.precip.spatial.map.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.precip.spatial.map.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.precip.spatial.map.v${VDATE}.tar
+fi

--- a/scripts/plots/cam/exevs_plots_refs_profile.sh
+++ b/scripts/plots/cam/exevs_plots_refs_profile.sh
@@ -1,0 +1,392 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs profile plotting python script
+# Last updated:
+#              05/10/2025, Updated restart/MPMD,  by Binbin Zhou Lynker@EMC/NCEP
+#              01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#              07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP 
+#              05/30/2024, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_profile_plots
+ if [ ! -d  $restart ] ; then
+  mkdir -p $restart
+ fi
+fi
+
+
+export interp_pnts='' 
+
+export init_end=$VDATE
+export valid_end=$VDATE
+
+model_list='REFS'
+models='REFS'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+export obsv=" - Validation: RAOB"
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  #hrs=`expr $n \* 24`
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+  $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day "$model_list"
+  export err=$?; err_chk
+  n=$((n+1))
+done 
+
+export fcst_init_hour="0,6,12,18"
+valid_time='valid00_12z'
+init_time='init00z_06z_12z_18Z'
+
+verif_case=grid2obs
+verif_type=upper_air
+
+#*****************************************
+# Build a POE file to collect sub-jobs
+#****************************************
+> run_all_poe.sh
+
+for stats in rmse_spread bss ; do 
+
+if [ $stats = rmse_spread  ] ; then
+  stat_list='rmse, spread'
+  line_tp='ecnt'
+  score_types='stat_by_level'
+  VARS='HGT TMP UGRD VGRD RH'
+  stats_rst=rmse_spread
+elif [ $stats = bss ] ; then
+  stat_list='bss_smpl'
+  line_tp='pstd'  
+  score_types='lead_average'
+  VARS='TMP_lt0C WIND_ge30kt WIND_ge40kt'
+  stats_rst=bss_smpl
+else
+  err_exit "$stats is not a valid stat"
+fi   
+
+ for fcst_valid_hour in 00 12 ; do
+
+  for score_type in $score_types ; do
+
+   if [ $score_type = lead_average ] ; then
+     export fcst_leads="6,12,18,24,30,36,42,48"
+   else 
+     export fcst_leads="6 12 18 24 30 36 42 48"
+   fi
+
+   for lead in $fcst_leads ; do 
+
+    export fcst_lead=$lead
+
+    if [[ "$fcst_lead" == "6" ]] || [[ "$fcst_lead" == "18" ]] || [[ "$fcst_lead" == "30" ]] || [[ "$fcst_lead" == "42" ]] ; then
+       VX_MASK_LIST="CONUS, Alaska, PRico"
+    elif [[ "$fcst_lead" == "12" ]] || [[ "$fcst_lead" == "24" ]] || [[ "$fcst_lead" == "36" ]] || [[ "$fcst_lead" == "48" ]] ; then
+       VX_MASK_LIST="CONUS, Hawaii"
+    else
+       VX_MASK_LIST="CONUS, Alaska"
+    fi
+
+    for VAR in $VARS ; do 
+
+       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+
+       if [ $score_type = stat_by_level ] ; then
+         FCST_LEVEL_values="P1000,P975,P950,P925,P900,P875,P850,P825,P800,P750,P700,P650,P600,P550,P500,P400,P300,P200"
+       elif [ $score_type = lead_average ] ; then 
+	  if [ $VAR = TMP_lt0C ] ; then
+	     FCST_LEVEL_values="P850"
+          elif [ $VAR = WIND_ge30kt ] ; then
+             FCST_LEVEL_values="P850 P700"
+	  elif [ $VAR = WIND_ge40kt ] ; then
+             FCST_LEVEL_values="P850 P700"
+	  fi
+       fi	  
+     
+     for FCST_LEVEL_value in $FCST_LEVEL_values ; do  
+
+       if [ $score_type = lead_average ] ; then
+        p_mb=${FCST_LEVEL_value:1:4}mb
+       fi	
+
+       if [ $score_type = stat_by_level ] ; then
+	  var_rst=${var}
+	  lead_rst=_f${lead}
+       elif [ $score_type = lead_average ] ; then
+	if [ $VAR = TMP_lt0C ] ; then 
+	  var_rst=${p_mb}_tmp_ens_freq_lt273.15
+	  lead_rst="_eq273.15"
+        elif [ $VAR = WIND_ge30kt ] ; then 
+          var_rst=${p_mb}_wind_ens_freq_ge15.4
+	  lead_rst="_eq0.10000"
+        elif [ $VAR = WIND_ge40kt ] ; then
+          var_rst=${p_mb}_wind_ens_freq_ge20.58
+          lead_rst="_eq0.10000"	  
+        fi
+       fi
+ 	     
+       OBS_LEVEL_value=$FCST_LEVEL_value
+
+       level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+
+      for line_type in $line_tp ; do 
+
+	 #*********************
+	 # Build sub-jobs
+	 # ********************
+         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh  
+      #***********************************************************************************************************************************
+      #  Check if this sub-job has been completed in the previous run for restart
+      if [ ! -e $restart/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.completed ] ; then
+      #***********************************************************************************************************************************
+
+	echo "#!/bin/ksh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	echo "set -x" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+        save_dir=$DATA/plots/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}
+	plot_dir=$save_dir/sfc_upper/$eval_period
+	mkdir -p $plot_dir
+	mkdir -p $save_dir/data
+
+	echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+	if [ $score_type = lead_average ] ; then
+	    echo "export PLOT_TYPE=lead_average_valid" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+        else	    
+            echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+        fi
+
+        echo "export field=${var}_${level}" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+        fi
+
+         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "export interp=BILIN" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+         if [ $line_tp = ecnt ] ; then
+	   thresh_fcst=' '
+	   thresh_obs=' '
+	 elif [ $line_tp = pstd ] ; then
+	    if [ $VAR = TMP_lt0C ] ; then
+	       thresh_fcst='==273.15'
+	       thresh_obs='<273.15'
+             elif [ $VAR =  WIND_ge30kt ] ; then
+	       thresh_fcst='==0.10000'
+	       thresh_obs='>=15.4'
+	     elif [ $VAR =  WIND_ge40kt ] ; then
+	       thresh_fcst='==0.10000'
+               thresh_obs='>=20.58'
+             fi	       
+	 fi
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g" -e "s!thresh_obs!$thresh_obs!g"  -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$fcst_lead!g" -e "s!interp_pnts!$interp_pnts!g"  $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+         echo "${DATA}/scripts/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+         #Save for restart and tar files
+	 echo "for domain in conus alaska hawaii prico ; do" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo " if [ -s ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_${var_rst}_${stats_rst}${lead_rst}.png ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	 echo "   cp -v ${plot_dir}/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_${var_rst}_${stats_rst}${lead_rst}.png $all_plots" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	 echo "   echo completed >${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.completed" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         #Copy files to restart directory"
+	 echo "   if [ $SENDCOM = YES ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	 echo "      cp -v $all_plots/${score_type}_regional_\${domain}_valid_${fcst_valid_hour}z_${var_rst}_${stats_rst}${lead_rst}.png $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	 echo "   fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+	 echo " fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "done" >>run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+	 echo "if [ -e ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.completed ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "  [[ $SENDCOM = YES ]] && cp -v ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.completed $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+         echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh
+
+	 chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh 
+         echo "${DATA}/scripts/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${fcst_valid_hour}.sh" >> run_all_poe.sh
+
+       else
+	 for domain in conus alaska hawaii prico ; do
+          if [ -s $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${var_rst}_${stats_rst}${lead_rst}.png ] ; then
+	    cp -v $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${var_rst}_${stats_rst}${lead_rst}.png $all_plots
+          fi
+         done	  
+       fi
+
+      done #end of line_type
+
+     done # end of level
+
+    done #end of VAR
+
+   done #end of fcst_lead
+
+  done # end of fcst_valid_hour 
+
+ done #end of score_type
+
+done #end of stats 
+
+chmod +x run_all_poe.sh
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 60 -ppn 60  --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+cd $all_plots
+
+for valid in 00z 12z ; do
+
+ for stats in rmse_spread bss_smpl ; do
+  if [ $stats = rmse_spread ] ; then
+   score_types='stat_by_level'
+   vars='hgt rh tmp ugrd vgrd'
+   leads='6 12 18 24 30 36 42 48'
+  else
+   score_types='lead_average'
+   vars='700mb_wind_ens_freq_ge15.4 700mb_wind_ens_freq_ge20.58 850mb_tmp_ens_freq_lt273.15 850mb_wind_ens_freq_ge15.4 850mb_wind_ens_freq_ge20.58'
+   leads="all"
+  fi
+
+
+ for score_type in $score_types  ; do
+  
+  if [ $score_type = stat_by_level ] ; then
+     scoretype='vertprof'
+  elif [ $score_type = lead_average ] ; then
+     scoretype='fhrmean'
+  fi
+    
+   for domain in conus alaska hawaii prico; do
+
+       if [ $domain = conus ] ; then
+	    new_domain='buk_conus'
+       else
+            new_domain=$domain
+       fi
+
+
+    for var in $vars ; do
+
+      if [ $score_type = lead_average  ] ; then
+	level=p${var:0:3}
+        end=eq0.10000.png
+
+	if [ $var = 700mb_wind_ens_freq_ge15.4 ] ; then
+	  var_new=windspeed_p700
+	  thresh=ge30
+	elif [ $var = 700mb_wind_ens_freq_ge20.58 ] ; then
+	  var_new=windspeed_p700
+          thresh=ge40
+	elif [ $var = 850mb_wind_ens_freq_ge15.4 ] ; then
+	  var_new=windspeed_p850
+	  thresh=ge30
+        elif [ $var = 850mb_wind_ens_freq_ge20.58 ] ; then
+          var_new=windspeed_p850	
+	  thresh=ge40
+        elif [ $var = 850mb_tmp_ens_freq_lt273.15 ] ; then
+	  var_new=tmp_p850
+	  thresh=lt0
+          end=eq273.15.png
+	fi
+      else
+        level=''
+	var_new=${var}_all
+      fi	
+
+      for lead in $leads ; do
+        if [ $lead = 6 ] ; then
+           new_lead=006
+        else
+          new_lead=0$lead
+        fi
+
+       if [ ${score_type} = lead_average ] ; then
+	 if [ -s ${score_type}_regional_${domain}_valid_${valid}_${var}_${stats}_${end} ] ; then
+	     
+             mv ${score_type}_regional_${domain}_valid_${valid}_${var}_${stats}_${end}  evs.refs.${stats}_${thresh}.${var_new}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+         fi 
+       else
+	  if [ -s ${score_type}_regional_${domain}_valid_${valid}_${var}_${stats}_f${lead}.png ] ; then
+   	     mv ${score_type}_regional_${domain}_valid_${valid}_${var}_${stats}_f${lead}.png  evs.refs.${stats}.${var_new}.last${last_days}days.${scoretype}_valid${valid}_f${new_lead}.${new_domain}.png
+          fi 
+       fi
+      done #lead
+
+    done #var
+   done  #domain
+ done    #score_type
+done     #stats
+done     #vlaid
+
+if [ -s evs*.png ] ; then
+ tar -cvf evs.plots.refs.profile.last${last_days}days.v${VDATE}.tar evs*.png
+fi
+
+# Cat the plotting log files
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out`
+  for log_file in $log_files ; do
+     echo "Start: $log_file"
+     cat  "$log_file"
+     echo "End: $log_file"
+  done  
+fi
+
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.profile.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.profile.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.profile.last${last_days}days.v${VDATE}.tar
+fi
+

--- a/scripts/plots/cam/exevs_plots_refs_snowfall.sh
+++ b/scripts/plots/cam/exevs_plots_refs_snowfall.sh
@@ -1,0 +1,354 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs snowfall plotting python script
+# Last updated:
+#              05/10/2025, Updated restart/MPMD,  by Binbin Zhou Lynker@EMC/NCEP
+#              01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#              07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP 
+#              05/30/2024, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_snowfall_plots
+ if [ ! -d  $restart ] ; then
+  mkdir -p $restart
+ fi 
+fi
+
+
+export interp_pnts=''
+
+export init_end=$VDATE
+export valid_end=$VDATE
+
+model_list='REFS_SNOW'
+models='REFS_SNOW'
+
+VX_MASK_LISTs='CONUS CONUS_East CONUS_West CONUS_South CONUS_Central'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+export obsv=" - Validation: NOHRSC"
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  #hrs=`expr $n \* 24`
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+  $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day "$model_list"
+  export err=$?; err_chk
+  n=$((n+1))
+done 
+
+verif_case=precip
+verif_type=ccpa
+
+#***************************************
+# Build a POE file to collect sub=jobs
+# **************************************
+> run_all_poe.sh
+
+for VX_MASK_LIST in $VX_MASK_LISTs ; do
+ 
+   domain=`echo $VX_MASK_LIST | tr '[A-Z]' '[a-z]'`
+
+for stats in ets_fbias ratio_pod_csi fss ; do 
+ if [ $stats = ets_fbias ] ; then
+    stat_list='ets, fbias'
+    line_tp='ctc'
+    VARs='WEASD'
+    interp_pnts=''
+    score_types='threshold_average '
+ elif [ $stats = ratio_pod_csi ] ; then
+    stat_list='sratio, pod, csi'
+    line_tp='ctc'
+    VARs='WEASD'
+    interp_pnts=''
+    score_types='performance_diagram'
+ elif [ $stats = fss ] ; then
+    stat_list='fss'
+    line_tp='nbrcnt'
+    VARs='WEASD'    
+    interp_pnts='1,9,25,49,91,121'
+    score_types='threshold_average' 
+ else
+  err_exit "$stats is not a valid stat"
+ fi   
+
+ for score_type in $score_types ; do
+
+  for VAR in $VARs ; do
+
+     var=`echo $VAR | tr '[A-Z]' '[a-z]'`
+
+     for FCST_LEVEL_value in A06 A24 ; do
+ 
+	 OBS_LEVEL_value=$FCST_LEVEL_value
+
+    	 if [ $FCST_LEVEL_value  = A06 ] ; then
+            export fcst_leads='6,12,18,24,30,36,42,48'
+            export fcst_valid_hours='00 06 12 18'
+	    accum=06h
+         elif [ $FCST_LEVEL_value = A24 ] ; then
+            export fcst_leads='24,30,36,42,48'
+            export fcst_valid_hours='00 12'
+	    accum=24h
+         fi
+
+
+      for lead in $fcst_leads ; do
+
+        level=`echo $FCST_LEVEL_value | tr '[A-Z]' '[a-z]'`      
+
+       for line_type in $line_tp ; do 
+
+        for fcst_valid_hour in $fcst_valid_hours ; do
+
+	 #*****************************
+	 # Build sub-jobs
+	 # ****************************
+         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh  
+
+      #***********************************************************************************************************************************
+      #  Check if this sub-job has been completed in the previous run for restart
+      if [ ! -e $restart/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.completed ] ; then
+      #***********************************************************************************************************************************
+      
+	echo "#!/bin/ksh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh 
+	echo "set -x" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh 
+
+	save_dir=$DATA/plots/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}
+	plot_dir=$save_dir/precip/$eval_period
+        mkdir -p $plot_dir
+        mkdir -p $save_dir/data
+
+	echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+	echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+        fi
+
+
+         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+	 if [ $stats = fss ] ; then
+	   
+	   echo "export interp=NBRHD_SQUARE" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         else	   
+           echo "export interp=NEAREST" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 fi
+
+         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+ 
+         thresh_fcst='>=0.0254, >=0.1016, >=0.2032, >=0.3048'
+	 thresh_obs=$thresh_fcst
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$fcst_valid_hour!g" -e "s!fcst_lead!$lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         echo "${DATA}/scripts/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+	 echo "if [ -s ${plot_dir}/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${accum}_${var}*.png ] ; then " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         echo "  cp -v ${plot_dir}/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${accum}_${var}*.png $all_plots" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "  echo completed >${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.completed" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+         #Copy files to restart directory
+	 echo "  if [ $SENDCOM = YES ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "    cp -v $all_plots/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${accum}_${var}*.png $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "    cp -v ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.completed $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "  fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+	 echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh
+
+         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh 
+         echo "${DATA}/scripts/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${VX_MASK_LIST}.${fcst_valid_hour}.sh" >> run_all_poe.sh
+
+        else
+	 if [ -s $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${accum}_${var}*.png ] ; then
+	   cp -v $restart/${score_type}_regional_${domain}_valid_${fcst_valid_hour}z_${accum}_${var}*.png $all_plots
+         fi	   
+        fi
+
+       done #end of fcst_valid_hour 
+
+      done #end of line_type
+
+     done #end of FCST_LEVEL_value
+
+    done #end of VAR
+
+  done #end of fcst_lead
+
+ done #end of score_type
+
+done #end of stats 
+
+done #end of vx_mask_list
+chmod +x run_all_poe.sh
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 30 -ppn 30 --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+cd $all_plots
+
+for stats in ets fbias fss ; do
+  score_type='threshold_average' 
+  scoretype='threshmean'
+
+  for var in weasd ; do
+   for level in 06h 24h ; do
+    if [ $stats = fss ] ; then 
+       if [ $level = 06h ] ; then
+        valids="00z 06z 12z 18z"
+        lead=width1-3-5-7-9-11_f6-12-18-24-30-36-42-48
+	new_level=a06
+       elif [ $level = 24h ] ; then
+        valids="00z 12z"
+        lead=width1-3-5-7-9-11_f24-30-36-42-48
+	 new_level=a24
+       fi	
+    else	    
+      if [ $level = 06h ] ; then
+	valids="00z 06z 12z 18z"
+        lead=f6-12-18-24-30-36-42-48
+	 new_level=a06
+      elif [ $level = 24h ] ; then
+        valids="00z 12z"
+        lead=f24-30-36-42-48
+	 new_level=a24
+      fi
+    fi
+
+   for valid in $valids ; do   
+    for domain in conus conus_east conus_west conus_south conus_central  ; do
+        
+     if [ $domain = conus ] ; then
+	 new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+   	 new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+   	 new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+	 new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     fi
+
+     if [ -s ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}_${lead}.png ] ; then
+       mv ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${stats}_${lead}.png  evs.refs.${stats}.${var}_${new_level}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+     fi
+    done
+   done
+  done
+ done
+done
+
+
+score_type='performance_diagram'  
+scoretype='perfdiag'
+
+for var in weasd ; do
+ for level in 06h 24h ; do
+    if [ $level = 06h ] ; then
+        valids="00z 06z 12z 18z"
+        lead=f6-12-18-24-30-36-42-48__ge0.0254ge0.1016ge0.2032ge0.3048
+	 new_level=a06
+    elif [ $level = 24h ] ; then
+        valids="00z 12z"
+        lead=f24-30-36-42-48__ge0.0254ge0.1016ge0.2032ge0.3048
+	 new_level=a24
+    fi
+
+   for valid in $valids ; do
+    for domain in conus conus_east conus_west conus_south conus_central  ; do
+
+     if [ $domain = conus ] ; then
+         new_domain=buk_conus
+     elif [ $domain = conus_east ] ; then
+         new_domain=buk_conus_e
+     elif [ $domain = conus_west ] ; then
+         new_domain=buk_conus_w
+     elif [ $domain = conus_south ] ; then
+         new_domain=buk_conus_s
+     elif [ $domain = conus_central ] ; then
+         new_domain=buk_conus_c
+     fi
+
+      if [ -s ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${lead}.png ] ; then
+         mv ${score_type}_regional_${domain}_valid_${valid}_${level}_${var}_${lead}.png  evs.refs.ctc.${var}_${new_level}.last${last_days}days.${scoretype}_valid${valid}.${new_domain}.png
+      fi 
+    done
+   done
+ done
+done
+
+if [ -s evs*.png ] ; then
+  tar -cvf evs.plots.refs.snowfall.last${last_days}days.v${VDATE}.tar evs*.png
+fi
+
+# Cat the plotting log files
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out`
+  for log_file in $log_files ; do
+     echo "Start: $log_file"
+     cat  "$log_file"
+     echo "End: $log_file"
+  done   
+fi 
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.snowfall.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.snowfall.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.snowfall.last${last_days}days.v${VDATE}.tar
+fi
+
+
+
+
+

--- a/scripts/plots/cam/exevs_plots_refs_spcoutlook.sh
+++ b/scripts/plots/cam/exevs_plots_refs_spcoutlook.sh
@@ -1,0 +1,292 @@
+#!/bin/ksh
+#*******************************************************************************
+# Purpose: setup environment, paths, and run the refs spcoutlook plotting python 
+#          script
+# Last updated: 
+#               05/10/2025, Updated restart/MPMD,  by Binbin Zhou Lynker@EMC/NCEP
+#               01/10/2025, add MPMD, by Binbin Zhou Lynker@EMC/NCEP
+#               07/09/2024, add restart, by Binbin Zhou Lynker@EMC/NCEP
+#               05/30/2025, Binbin Zhou Lynker@EMC/NCEP
+#******************************************************************************
+set -x 
+
+mkdir -p $DATA/scripts
+cd $DATA/scripts
+
+export machine=${machine:-"WCOSS2"}
+export output_base_dir=$DATA/stat_archive
+mkdir -p $output_base_dir
+
+all_plots=$DATA/plots/all_plots
+mkdir -p $all_plots
+if [ $SENDCOM = YES ] ; then
+ restart=$COMOUT/restart/$last_days/refs_spcoutlook_plots
+ if [ ! -d  $restart ] ; then
+  mkdir -p $restart
+ fi
+fi
+
+
+export interp_pnts=''
+
+export init_end=$VDATE
+export valid_end=$VDATE
+
+model_list='REFS_MEAN'
+models='REFS_MEAN'
+
+n=0
+while [ $n -le $last_days ] ; do
+    hrs=$((n*24))
+    first_day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+    n=$((n+1))
+done
+
+export init_beg=$first_day
+export valid_beg=$first_day
+export obsv=" - Validation: RAOB"
+
+
+#*************************************************************
+# Virtual link the refs's stat data files of last 31/90 days
+#*************************************************************
+n=0
+while [ $n -le $last_days ] ; do
+  #hrs=`expr $n \* 24`
+  hrs=$((n*24))
+  day=`$NDATE -$hrs ${VDATE}00|cut -c1-8`
+  echo $day
+  $USHevs/cam/evs_get_refs_stat_file_link_plots.sh $day REFS_MEAN
+  n=$((n+1))
+done 
+																  
+export fcst_init_hour="0,6,12,18"
+init_time='init00z_06z_12z_18z'
+
+verif_case=grid2obs
+
+#********************************************
+# Total SPC outlook area masks = 6 x 3 = 18
+#********************************************
+VX_MASK_LIST="DAY1_MRGL,  DAY2_MRGL, DAY3_MRGL, DAY1_TSTM,  DAY2_TSTM, DAY3_TSTM,  DAY1_SLGT,  DAY2_SLGT, DAY3_SLGT, DAY1_ENH,  DAY2_ENH, DAY3_ENH, DAY1_MDT,  DAY2_MDT, DAY3_MDT, DAY1_HIGH,  DAY2_HIGH, DAY3_HIGH"
+
+
+#*********************************************
+# Build a POE file to collect sub-jobs
+# ********************************************
+> run_all_poe.sh
+
+for stats in csi_fbias ratio_pod_csi ; do 
+ if [ $stats = csi_fbias ] ; then
+    stat_list='csi, fbias'
+    line_tp='ctc'
+    VARs='CAPEsfc MLCAPE'
+    score_types='lead_average threshold_average'
+ elif [ $stats = ratio_pod_csi ] ; then
+    stat_list='sratio, pod, csi'
+    line_tp='ctc'
+    VARs='CAPEsfc MLCAPE'
+    score_types='performance_diagram'   
+ else
+  err_exit "$stats is not a valid stat"
+ fi   
+
+ for score_type in $score_types ; do
+ 
+  #no space between fcst_lead hour, so take it as one string! 	 
+  export fcst_leads="6,12,15,24,30,36,42,48"
+
+  for lead in $fcst_leads ; do 
+
+    for VAR in $VARs ; do 
+
+       var=`echo $VAR | tr '[A-Z]' '[a-z]'` 
+	    
+       if [ $VAR = CAPEsfc ] ; then
+          FCST_LEVEL_values="L0"
+	  var_rst=cape
+       elif [ $VAR = MLCAPE ] ; then
+	  FCST_LEVEL_values="ML"
+	  var_rst=mlcape
+       fi 	  
+
+     for FCST_LEVEL_value in $FCST_LEVEL_values ; do 
+
+        OBS_LEVEL_value=$FCST_LEVEL_value
+
+      for line_type in $line_tp ; do 
+
+       for valid_time in 00 12 ; do
+
+	 #****************************
+	 #  Build sub-jobs
+	 #****************************
+         > run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh  
+       #***********************************************************************************************************************************
+       #  Check if this sub-job has been completed in the previous run for restart
+       if [ ! -e $restart/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.completed ] ; then
+       #***********************************************************************************************************************************
+
+        verif_type=conus_sfc
+
+	echo "#!/bin/ksh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	echo "set -x" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        save_dir=$DATA/plots/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}
+	plot_dir=$save_dir/sfc_upper/$eval_period
+	mkdir -p $plot_dir
+	mkdir -p $save_dir/data
+
+        echo "export save_dir=$save_dir" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	echo "export log_metplus=$save_dir/log_verif_plotting_job.out" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	echo "export prune_dir=$save_dir/data" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+	if [ $score_type = lead_average ] ; then
+	  echo "export PLOT_TYPE=lead_average_valid " >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	else
+	  echo "export PLOT_TYPE=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        fi
+
+        echo "export vx_mask_list='$VX_MASK_LIST'" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        echo "export verif_case=$verif_case" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        echo "export verif_type=$verif_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+        echo "export log_level=DEBUG" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+
+        if [ $score_type = valid_hour_average ] ; then
+          echo "export date_type=INIT" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        else
+          echo "export date_type=VALID" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        fi
+
+
+         echo "export var_name=$VAR" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+         echo "export fcts_level=$FCST_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+         echo "export obs_level=$OBS_LEVEL_value" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+         echo "export line_type=$line_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+         echo "export interp=BILIN" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+         echo "export score_py=$score_type" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+         thresh_fcst='>=250, >=500, >=1000, >=2000'
+	 thresh_obs=$thresh_fcst
+
+         sed -e "s!model_list!$models!g" -e "s!stat_list!$stat_list!g"  -e "s!thresh_fcst!$thresh_fcst!g"  -e "s!thresh_obs!$thresh_obs!g"   -e "s!fcst_init_hour!$fcst_init_hour!g" -e "s!fcst_valid_hour!$valid_time!g" -e "s!fcst_lead!$lead!g"  -e "s!interp_pnts!$interp_pnts!g" $USHevs/cam/evs_refs_plots_config.sh > run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+         chmod +x  run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+	 echo "${DATA}/scripts/run_py.${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+         echo "if [ -s ${plot_dir}/${score_type}_regional_*_valid_${valid_time}z_${var_rst}*.png ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	 echo "  cp -v ${plot_dir}/${score_type}_regional_*_valid_${valid_time}z_${var_rst}*.png $all_plots" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	 echo "  echo completed >${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.completed" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+        
+	 #Copy files to restart directory
+	 echo "  if [ $SENDCOM = YES ] ; then" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	 echo "    cp -v $all_plots/${score_type}_regional_*_valid_${valid_time}z_${var_rst}*.png $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh       
+	 echo "    cp -v ${plot_dir}/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.completed $restart" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	 echo "  fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+	 echo "fi" >> run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh
+
+         chmod +x  run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh 
+         echo "${DATA}/scripts/run_${stats}.${score_type}.${lead}.${VAR}.${FCST_LEVEL_value}.${line_type}.${valid_time}.sh" >> run_all_poe.sh
+
+        else 
+          cp -v ${restart}/${score_type}_regional_*_valid_${valid_time}z_${var_rst}*.png $all_plots
+
+       fi
+
+       done #end of valid time
+
+      done #end of line_type
+
+     done #end of FCST_LEVEL_value
+
+    done #end of VAR
+
+  done #end of fcst_lead
+
+ done #end of score_type
+
+done #end of stats 
+
+chmod +x run_all_poe.sh
+
+#***************************************************************************
+# Run the POE script in parallel or in sequence order to generate png files
+#**************************************************************************
+mpiexec -np 6 -ppn 6 --cpu-bind verbose,depth cfp ${DATA}/scripts/run_all_poe.sh
+export err=$?; err_chk
+
+
+#**************************************************
+# Change plot file names to meet the EVS standard
+#**************************************************
+cd $all_plots
+
+for domain in day1_mrgl day1_slgt day1_tstm day1_enh day1_mdt day1_high day2_mrgl day2_slgt day2_tstm day2_enh day2_mdt day2_high day3_mrgl day3_slgt day3_tstm day3_enh day3_mdt day3_high ; do
+ for var in cape mlcape ; do
+  if [ $var = cape ] ; then
+    var_new=cape
+    level=l0
+  elif [ $var = mlcape ] ; then
+    var_new=mlcape
+    level=ml
+  fi
+
+  for valid in 00z 12z ; do 
+  if ls lead_average_regional_${domain}_valid_${valid}_${var}*.png 1> /dev/null 2>&1; then
+     mv lead_average_regional_${domain}_valid_${valid}_${var}*.png  evs.refs.csi_fbias.${var_new}_${level}.last${last_days}days.fhrmean_valid${valid}.${domain}.png
+  fi
+  if ls threshold_average_regional_${domain}_valid_${valid}_${var}_csi*.png 1> /dev/null 2>&1; then
+     mv threshold_average_regional_${domain}_valid_${valid}_${var}_csi*.png  evs.refs.csi.${var_new}_${level}.last${last_days}days.threshmean_valid${valid}.${domain}.png
+  fi
+  if ls threshold_average_regional_${domain}_valid_${valid}_${var}_fbias*.png 1> /dev/null 2>&1; then
+     mv threshold_average_regional_${domain}_valid_${valid}_${var}_fbias*.png  evs.refs.fbias.${var_new}_${level}.last${last_days}days.threshmean_valid${valid}.${domain}.png
+  fi
+  if ls performance_diagram_regional_${domain}_valid_${valid}_${var}*.png 1> /dev/null 2>&1; then
+     mv performance_diagram_regional_${domain}_valid_${valid}_${var}*.png evs.refs.ctc.${var_new}_${level}.last${last_days}days.perfdiag_valid${valid}.${domain}.png
+  fi
+
+  done
+ done
+done
+ 	
+if [ -s evs*.png ] ; then
+  tar -cvf evs.plots.refs.spcoutlook.last${last_days}days.v${VDATE}.tar evs*.png
+fi
+
+# Cat the plotting log files
+log_dir="$DATA/plots"
+if [ -s $log_dir/*/log*.out ]; then
+  log_files=`ls $log_dir/*/log*.out`
+  for log_file in $log_files ; do
+     echo "Start: $log_file"
+     cat  "$log_file"
+     echo "End: $log_file"
+  done  
+fi
+
+
+if [ $SENDCOM = YES ] && [ -s evs.plots.refs.spcoutlook.last${last_days}days.v${VDATE}.tar ] ; then
+ cp -v evs.plots.refs.spcoutlook.last${last_days}days.v${VDATE}.tar  $COMOUT/.  
+fi
+
+if [ $SENDDBN = YES ] ; then
+   $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job $COMOUT/evs.plots.refs.spcoutlook.last${last_days}days.v${VDATE}.tar
+fi
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/ush/cam/ush_refs_plot_py/check_variables.py
+++ b/ush/cam/ush_refs_plot_py/check_variables.py
@@ -1,0 +1,738 @@
+#! /usr/bin/env python3
+
+import sys
+import logging
+import re
+from pathlib import Path
+
+# Variables to check:
+# VERIF_CASE
+# info case: 
+# warning case: should match one of the known verif cases
+# error case: should be string (in quotes), should not be empty
+def check_VERIF_CASE(VERIF_CASE):
+    if not isinstance(VERIF_CASE, str):
+        print(f"FATAL ERROR: The provided VERIF_CASE ('{VERIF_CASE}') is not a string."
+                     + f"  VERIF_CASE must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not VERIF_CASE:
+        print(f"FATAL ERROR: The provided VERIF_CASE is empty. VERIF_CASE cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    return VERIF_CASE
+
+# VERIF_TYPE
+# info case:
+# warning case:should match one of the the known verif cases
+# error case: should be a string(in quotes), shouild not be empty
+def check_VERIF_TYPE(VERIF_TYPE):
+    if not isinstance(VERIF_TYPE, str):
+        print(f"FATAL ERROR: The provided VERIF_TYPE ('{VERIF_TYPE}') is not a string."
+                     + f"  VERIF_TYPE must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not VERIF_TYPE:
+        print(f"FATAL ERROR: The provided VERIF_TYPE is empty. VERIF_TYPE cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    return VERIF_TYPE
+
+# URL_HEADER
+# info case: whether or not an empty string is provided
+# warning case:
+# error case:should be a string (in quotes), should be alphanumeric, should follow file naming conventions
+def check_URL_HEADER(URL_HEADER):
+    if not isinstance(URL_HEADER, str):
+        print(f"FATAL ERROR: The provided URL_HEADER ('{URL_HEADER}') is not a string."
+                     + f"  URL_HEADER must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if re.search(r'[^A-Za-z0-9_\-\\]', URL_HEADER):
+        print(f"FATAL ERROR: The provided URL_HEADER string ('{URL_HEADER}') contains"
+                     + f" invalid characters. URL_HEADER must be made of"
+                     + f" alphanumeric characters, hyphen, and/or underscore."
+                     + f" Check the plotting configuration file.")
+        sys.exit(1)
+    if not URL_HEADER:
+        print(f"The provided URL_HEADER is empty. Plot file names will"
+                     + f" not include a header.")
+    return URL_HEADER
+
+# USH_DIR
+# info case:whether or not an empty string is provided
+# warning case:
+# error case:should be a string, should follow proper directory structure
+def check_USH_DIR(USH_DIR):
+    if not isinstance(USH_DIR, str):
+        print(f"FATAL ERROR: The provided USH_DIR ('{USH_DIR}') is not a string."
+                     + f"  USH_DIR must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not Path(USH_DIR).exists():
+        print(f"WARNING: The provided USH_DIR ('{USH_DIR}') does not exist on the"
+                       + f" current system.")
+    if not Path(USH_DIR).is_dir():
+        print(f"WARNING: The provided USH_DIR ('{USH_DIR}') is not a directory.")
+    if not USH_DIR:
+        print(f"The provided USH_DIR is empty. Will look for USH files"
+                     + f" in the current working directory.")
+    return USH_DIR
+
+# PRUNE_DIR
+# info case: whether or not an empty string is provided
+# warning case:
+# error case: should be a string, should follow proper directory structure
+def check_PRUNE_DIR(PRUNE_DIR):
+    if not isinstance(PRUNE_DIR, str):
+        print(f"FATAL ERROR: The provided PRUNE_DIR ('{PRUNE_DIR}') is not a string."
+                     + f"  PRUNE_DIR must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not Path(PRUNE_DIR).exists():
+        print(f"WARNING: The provided PRUNE_DIR ('{PRUNE_DIR}') does not exist on the"
+                       + f" current system.")
+    if not Path(PRUNE_DIR).is_dir():
+        print(f"WARNING: The provided PRUNE_DIR ('{PRUNE_DIR}') is not a directory.")
+    if not PRUNE_DIR:
+        print(f"The provided PRUNE_DIR is empty. Will store pruned stat files"
+                     + f" in the current working directory.")
+    return PRUNE_DIR
+
+# SAVE_DIR
+# info case:whether or not an empty string is provided
+# warning case:
+# error case: should be a string, should follow proper directory structure
+def check_SAVE_DIR(SAVE_DIR):
+    if not isinstance(SAVE_DIR, str):
+        print(f"FATAL ERROR: The provided SAVE_DIR ('{SAVE_DIR}') is not a string."
+                     + f"  SAVE_DIR must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not Path(SAVE_DIR).exists():
+        print(f"WARNING: The provided SAVE_DIR ('{SAVE_DIR}') does not exist on the"
+                       + f" current system.")
+    if not Path(SAVE_DIR).is_dir():
+        print(f"WARNING: The provided SAVE_DIR ('{SAVE_DIR}') is not a directory.")
+    if not SAVE_DIR:
+        print(f"The provided SAVE_DIR is empty. Will store plots"
+                     + f" in the current working directory.")
+    return SAVE_DIR
+
+# OUTPUT_BASE_DIR
+# info case: whether or not an empty string is provided
+# warning case:
+# error case:should be a string, should follow proper directory structure
+def check_OUTPUT_BASE_DIR(OUTPUT_BASE_DIR):
+    if not isinstance(OUTPUT_BASE_DIR, str):
+        print(f"FATAL ERROR: The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') is not a string."
+                     + f"  OUTPUT_BASE_DIR must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not Path(OUTPUT_BASE_DIR).exists():
+        print(f"WARNING: The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') does not exist on the"
+                       + f" current system.")
+    if not Path(OUTPUT_BASE_DIR).is_dir():
+        print(f"WARNING: The provided OUTPUT_BASE_DIR ('{OUTPUT_BASE_DIR}') is not a directory.")
+    if not OUTPUT_BASE_DIR:
+        print(f"The provided OUTPUT_BASE_DIR is empty. Will look for stat files"
+                     + f" in the current working directory.")
+    return OUTPUT_BASE_DIR
+
+# LOG_METPLUS
+# info case:
+# warning case:
+# error case: should be a string, should follow proper directory structure, should not be empty
+def check_LOG_METPLUS(LOG_METPLUS):
+    if not isinstance(LOG_METPLUS, str):
+        print(f"FATAL ERROR: The provided LOG_METPLUS ('{LOG_METPLUS}') is not a string."
+                     + f"  LOG_METPLUS must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not LOG_METPLUS:
+        print(f"WARNING: The provided LOG_METPLUS is empty. The logger will be"
+                       + f" the root logger of the hierarchy.")
+    return LOG_METPLUS
+
+# LOG_LEVEL
+# info case: 
+# warning case: whether or not log level is currently supported
+# error case: should be a string, should match one of the possible log levels
+def check_LOG_LEVEL(LOG_LEVEL):
+    if not isinstance(LOG_LEVEL, str):
+        print(f"FATAL ERROR: The provided LOG_LEVEL ('{LOG_LEVEL}') is not a string."
+                     + f" LOG_LEVEL must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if str(LOG_LEVEL).upper() not in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]:
+        print(f"WARNING: The provided LOG_LEVEL ('{LOG_LEVEL}') may not be"
+                       + f" supported by the logger.  Consider using one of"
+                       + f" 'DEBUG', 'INFO', 'WARNING', 'ERROR', or"
+                       + f" 'CRITICAL'.")
+    if str(LOG_LEVEL).upper() not in ["ERROR", "WARNING", "INFO", "DEBUG"]:
+        print(f"WARNING: You provided the following LOG_LEVEL: '{LOG_LEVEL}'."
+                       + f" Note that the plotting scripts currently only log at"
+                       + f" 'ERROR', 'WARNING', 'INFO' and 'DEBUG' levels.")
+    if not LOG_LEVEL:
+        print(f"FATAL ERROR: The provided LOG_LEVEL is empty. LOG_LEVEL cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    return LOG_LEVEL
+
+# MET_VERSION
+# info case: 
+# warning case:
+# error case: string be a string, string should contain an integer or a floating point number
+def check_MET_VERSION(MET_VERSION):
+    if not isinstance(MET_VERSION, str):
+        print(f"FATAL ERROR: The provided MET_VERSION ('{MET_VERSION}') is not a string."
+                     + f" MET_VERSION must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not re.search(r'^[1-9]\d*(\.\d+)?$', MET_VERSION):
+        print(f"FATAL ERROR: The provided MET_VERSION ('{MET_VERSION}') is not a"
+                     + f" parseable number. Check the plotting configuration"
+                     + f" file.")
+        sys.exit(1)
+    return MET_VERSION
+
+# MODEL
+# info case:
+# warning case:
+# error case: should be a string, should be comma-separated or contain no other symbols than letters, numbers, dashes, and underlines
+def check_MODEL(MODEL):
+    if not isinstance(MODEL, str):
+        print(f"FATAL ERROR: The provided MODEL ('{MODEL}') is not a string."
+                     + f" MODEL must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not re.search(r'(^[ A-Za-z0-9,\-_]+)$', MODEL):
+        print(f"FATAL ERROR: The provided MODEL ('{MODEL}') is not valid. MODEL may"
+                     + f" contain letters, numbers, hyphens, underscores,"
+                     + f" commas, and spaces only. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    return MODEL
+
+# DATE_TYPE
+# info case:
+# warning case:
+# error case: should be a string, should be either INIT or VALID
+def check_DATE_TYPE(DATE_TYPE):
+    if not isinstance(DATE_TYPE, str):
+        print(f"FATAL ERROR: The provided DATE_TYPE ('{DATE_TYPE}') is not a string."
+                     + f" DATE_TYPE must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if str(DATE_TYPE).upper() not in ['INIT', 'VALID']:
+        print(f"FATAL ERROR: You provided the following DATE_TYPE: '{DATE_TYPE}'."
+                     + f" DATE_TYPE must be either 'INIT' or 'VALID'. Check"
+                     + f" the plotting configuration file.")
+        sys.exit(1)
+    return DATE_TYPE
+
+
+# EVAL_PERIOD
+# info case: Whether or not a TEST will be used and what that means
+# warning case: Should be either TEST or a valid EVAL PERIOD
+# error case: should be a string, should be alphanumeric, 
+def check_EVAL_PERIOD(EVAL_PERIOD):
+    if not isinstance(EVAL_PERIOD, str):
+        print(f"FATAL ERROR: The provided EVAL_PERIOD ('{EVAL_PERIOD}') is not a string."
+                     + f" EVAL_PERIOD must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if re.search(r'[^A-Za-z0-9_\-\\]', EVAL_PERIOD):
+        print(f"FATAL ERROR: The provided EVAL_PERIOD string ('{EVAL_PERIOD}') contains"
+                     + f" invalid characters. EVAL_PERIOD must be made of"
+                     + f" alphanumeric characters, hyphen, and/or underscore."
+                     + f" Check the plotting configuration file.")
+        sys.exit(1)
+    if EVAL_PERIOD=="TEST":
+        print(f"Since the EVAL_PERIOD is set to 'TEST', will use a"
+                    + f" custom INIT/VALID period.")
+    else:
+        print(f"Since the EVAL_PERIOD is not set to 'TEST', will use a"
+                    + f" preset INIT/VALID period (check ush/settings.py for"
+                    + f" possible presets).")
+    return EVAL_PERIOD
+
+
+# VALID_BEG
+# info case:
+# warning case:
+# error case: should be a string, if DATE_TYPE="VALID" or plot is valid_hour_average then should contain numbers only, should be YYYYMMDD format only, should be earlier than VALID_END, and cannot be blank 
+def check_VALID_BEG(VALID_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
+    if not isinstance(VALID_BEG, str):
+        print(f"FATAL ERROR: The provided VALID_BEG ('{VALID_BEG}') is not a string."
+                     + f" VALID_BEG must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if ((str(DATE_TYPE).upper() == "VALID" 
+                or str(plot_type).lower() == "valid_hour_average")
+            and EVAL_PERIOD == "TEST"):
+        if not VALID_BEG:
+            print(f"FATAL ERROR: The provided VALID_BEG is empty. Since DATE_TYPE is"
+                         + f" '{str(DATE_TYPE).upper()}', plot_type is"
+                         + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
+                         + f" '{str(EVAL_PERIOD).upper()}', VALID_BEG cannot be"
+                         + f" empty. Check the plotting configuration file.")
+            sys.exit(1)
+        if not VALID_BEG.isdigit():
+            print(f"FATAL ERROR: The provided VALID_BEG ('{VALID_BEG}') contains"
+                         + f" non-numeric characters. VALID_BEG may only"
+                         + f" contain numeric characters. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if not len(VALID_BEG) == 8:
+            print(f"FATAL ERROR: The provided VALID_BEG ('{VALID_BEG}') is too short"
+                         + f" or too long.  VALID_BEG must be a date"
+                         + f" in the form of YYYYMMDD. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+    return VALID_BEG
+
+
+
+# VALID_END
+# info case:
+# warning case:
+# error case: should be a string, if DATE_TYPE="VALID" or plot is valid_hour_average then should contain numbers only, should be YYYYMMDD format only, should be later than VALID_BEG, and cannot be blank 
+def check_VALID_END(VALID_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
+    if not isinstance(VALID_END, str):
+        print(f"FATAL ERROR: The provided VALID_END ('{VALID_END}') is not a string."
+                     + f" VALID_END must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if ((str(DATE_TYPE).upper() == "VALID" 
+                or str(plot_type).lower() == "valid_hour_average")
+            and EVAL_PERIOD == "TEST"):
+        if not VALID_END:
+            print(f"FATAL ERROR: The provided VALID_END is empty. Since DATE_TYPE is"
+                         + f" '{str(DATE_TYPE).upper()}', plot_type is"
+                         + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
+                         + f" '{str(EVAL_PERIOD).upper()}', VALID_END cannot be"
+                         + f" empty. Check the plotting configuration file.")
+            sys.exit(1)
+        if not VALID_END.isdigit():
+            print(f"FATAL ERROR: The provided VALID_END ('{VALID_END}') contains"
+                         + f" non-numeric characters. VALID_END may only"
+                         + f" contain numeric characters. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if not len(VALID_END) == 8:
+            print(f"FATAL ERROR: The provided VALID_END ('{VALID_END}') is too short"
+                         + f" or too long.  VALID_END must be a date"
+                         + f" in the form of YYYYMMDD. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+    return VALID_END
+
+
+# INIT_BEG
+# info case:
+# warning case:
+# error case: should be a string, if DATE_TYPE="INIT" then should contain numbers only, should be YYYYMMDD format only, should be earlier than INIT_END, and cannot be blank 
+def check_INIT_BEG(INIT_BEG, DATE_TYPE, EVAL_PERIOD, plot_type=None):
+    if not isinstance(INIT_BEG, str):
+        print(f"FATAL ERROR: The provided INIT_BEG ('{INIT_BEG}') is not a string."
+                     + f" INIT_BEG must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if ((str(DATE_TYPE).upper() == "INIT" 
+                or str(plot_type).lower() == "valid_hour_average")
+            and EVAL_PERIOD == "TEST"):
+        if not INIT_BEG:
+            print(f"FATAL ERROR: The provided INIT_BEG is empty. Since DATE_TYPE is"
+                         + f" '{str(DATE_TYPE).upper()}', plot_type is"
+                         + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
+                         + f" '{str(EVAL_PERIOD).upper()}', INIT_BEG cannot be"
+                         + f" empty. Check the plotting configuration file.")
+            sys.exit(1)
+        if not INIT_BEG.isdigit():
+            print(f"FATAL ERROR: The provided INIT_BEG ('{INIT_BEG}') contains"
+                         + f" non-numeric characters. INIT_BEG may only"
+                         + f" contain numeric characters. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if not len(INIT_BEG) == 8:
+            print(f"FATAL ERROR: The provided INIT_BEG ('{INIT_BEG}') is too short"
+                         + f" or too long.  INIT_BEG must be a date"
+                         + f" in the form of YYYYMMDD. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+    return INIT_BEG
+
+
+# INIT_END
+# info case:
+# warning case:
+# error case: should be a string, if DATE_TYPE="INIT" then should contain numbers only, should be YYYYMMDD format only, should be later than INIT_BEG, and cannot be blank 
+def check_INIT_END(INIT_END, DATE_TYPE, EVAL_PERIOD, plot_type=None):
+    if not isinstance(INIT_END, str):
+        print(f"FATAL ERROR: The provided INIT_END ('{INIT_END}') is not a string."
+                     + f" INIT_END must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if ((str(DATE_TYPE).upper() == "INIT" 
+                or str(plot_type).lower() == "valid_hour_average")
+            and EVAL_PERIOD == "TEST"):
+        if not INIT_END:
+            print(f"FATAL ERROR: The provided INIT_END is empty. Since DATE_TYPE is"
+                         + f" '{str(DATE_TYPE).upper()}', plot_type is"
+                         + f" '{str(plot_type).lower()}', and EVAL_PERIOD is"
+                         + f" '{str(EVAL_PERIOD).upper()}', INIT_END cannot be"
+                         + f" empty. Check the plotting configuration file.")
+            sys.exit(1)
+        if not INIT_END.isdigit():
+            print(f"FATAL ERROR: The provided INIT_END ('{INIT_END}') contains"
+                         + f" non-numeric characters. INIT_END may only"
+                         + f" contain numeric characters. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if not len(INIT_END) == 8:
+            print(f"FATAL ERROR: The provided INIT_END ('{INIT_END}') is too short"
+                         + f" or too long.  INIT_END must be a date"
+                         + f" in the form of YYYYMMDD. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+    return INIT_END
+
+# FCST_INIT_HOUR
+# info case:
+# warning case:
+# error case: should be a string, if DATE_TYPE="INIT" then should be a comma-separated list of numbers between and including  0 and 23 (leading zeros are fine), no symbols other than numbers, commas, and spaces, should not be blank
+def check_FCST_INIT_HOUR(FCST_INIT_HOUR, DATE_TYPE, plot_type=None):
+    if not isinstance(FCST_INIT_HOUR, str):
+        print(f"FATAL ERROR: The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is not a string."
+                     + f" FCST_INIT_HOUR must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if (str(DATE_TYPE).upper() == "INIT" 
+            or str(plot_type).lower() == "valid_hour_average"):
+        if not FCST_INIT_HOUR:
+            print(f"FATAL ERROR: The provided FCST_INIT_HOUR is empty. Since DATE_TYPE is"
+                         + f" '{str(DATE_TYPE).upper()}' and plot type is"
+                         + f" '{str(plot_type).lower()}', FCST_INIT_HOUR cannot be"
+                         + f" empty. Check the plotting configuration file.")
+            sys.exit(1)
+        if not re.search(r'(^[ 0-9,]+)$', FCST_INIT_HOUR):
+            print(f"FATAL ERROR: The provided FCST_INIT_HOUR ('{FCST_INIT_HOUR}') is"
+                         + f" not valid. FCST_INIT_HOUR may contain numbers,"
+                         + f" commas, and spaces only. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+    return FCST_INIT_HOUR
+
+# FCST_VALID_HOUR
+# info case:
+# warning case:
+# error case: should be a string, if DATE_TYPE="VALID" then should be a comma-separated list of numbers between and including  0 and 23 (leading zeros are fine), no symbols other than numbers, commas, and spaces, should not be blank
+def check_FCST_VALID_HOUR(FCST_VALID_HOUR, DATE_TYPE, plot_type=None):
+    if not isinstance(FCST_VALID_HOUR, str):
+        print(f"FATAL ERROR: The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is not a string."
+                     + f" FCST_VALID_HOUR must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if (str(DATE_TYPE).upper() == "VALID" 
+            or str(plot_type).lower() == "valid_hour_average"):
+        if not FCST_VALID_HOUR:
+            print(f"FATAL ERROR: The provided FCST_VALID_HOUR is empty. Since DATE_TYPE is"
+                         + f" '{str(DATE_TYPE).upper()}' and plot type is"
+                         + f" '{str(plot_type).lower()}', FCST_VALID_HOUR cannot be"
+                         + f" empty. Check the plotting configuration file.")
+            sys.exit(1)
+        if not re.search(r'(^[ 0-9,]+)$', FCST_VALID_HOUR):
+            print(f"FATAL ERROR: The provided FCST_VALID_HOUR ('{FCST_VALID_HOUR}') is"
+                         + f" not valid. FCST_VALID_HOUR may contain numbers,"
+                         + f" commas, and spaces only. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+    return FCST_VALID_HOUR
+
+# FCST_LEVEL
+# info case:
+# warning case: should be a valid level (start with a valid letter)
+# error case: should be a string, should not be blank
+def check_FCST_LEVEL(FCST_LEVEL):
+    if not isinstance(FCST_LEVEL, str):
+        print(f"FATAL ERROR: The provided FCST_LEVEL ('{FCST_LEVEL}') is not a string."
+                     + f" FCST_LEVEL must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not FCST_LEVEL:
+        print(f"FATAL ERROR: The provided FCST_LEVEL is empty. FCST_LEVEL cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    return FCST_LEVEL
+
+# OBS_LEVEL
+# info case: whether or not OBS_LEVEL matches FCST_LEVEL
+# warning case: should be a valid level (start with a valid letter)
+# error case: should be a string, should not be blank
+def check_OBS_LEVEL(OBS_LEVEL):
+    if not isinstance(OBS_LEVEL, str):
+        print(f"FATAL ERROR: The provided OBS_LEVEL ('{OBS_LEVEL}') is not a string."
+                     + f" OBS_LEVEL must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not OBS_LEVEL:
+        print(f"FATAL ERROR: The provided OBS_LEVEL is empty. OBS_LEVEL cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    return OBS_LEVEL
+
+# var_name
+# info case:
+# warning case:
+# error case: should be a string, should not be blank
+def check_var_name(var_name):
+    if not isinstance(var_name, str):
+        print(f"FATAL ERROR: The provided var_name ('{var_name}') is not a string."
+                     + f" var_name must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not var_name:
+        print(f"FATAL ERROR: The provided var_name is empty. var_name cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    if re.search(r'[^ A-Za-z0-9,_\-]', var_name):
+        print(f"FATAL ERROR: The provided var_name string ('{var_name}') contains"
+                     + f" invalid characters. var_name must be made of"
+                     + f" alphanumeric characters, hyphen, underscore, commas"
+                     + f" and/or spaces only. Check the plotting configuration"
+                     + f" file.")
+        sys.exit(1)
+    return var_name
+
+# VX_MASK_LIST
+# info case:
+# warning case: 
+# error case: should be a string, should not be blank
+def check_VX_MASK_LIST(VX_MASK_LIST):
+    if not isinstance(VX_MASK_LIST, str):
+        print(f"FATAL ERROR: The provided VX_MASK_LIST ('{VX_MASK_LIST}') is not a string."
+                     + f" VX_MASK_LIST must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not VX_MASK_LIST:
+        print(f"FATAL ERROR: The provided VX_MASK_LIST is empty. VX_MASK_LIST cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    if re.search(r'[^ A-Za-z0-9,_\-]', VX_MASK_LIST):
+        print(f"FATAL ERROR: The provided VX_MASK_LIST string ('{VX_MASK_LIST}') contains"
+                     + f" invalid characters. VX_MASK_LIST must be made of"
+                     + f" alphanumeric characters, hyphen, underscore, commas"
+                     + f" and/or spaces only. Check the plotting configuration"
+                     + f" file.")
+        sys.exit(1)
+    return VX_MASK_LIST
+
+# FCST_LEAD
+# info case:
+# warning case:
+# error case: should be a string, should not be blank, should be a comma-separated list of positive numbers 
+def check_FCST_LEAD(FCST_LEAD):
+    if not isinstance(FCST_LEAD, str):
+        print(f"FATAL ERROR: The provided FCST_LEAD ('{FCST_LEAD}') is not a string."
+                     + f" FCST_LEAD must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not FCST_LEAD:
+        print(f"FATAL ERROR: The provided FCST_LEAD is empty. FCST_LEAD cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    if re.search(r'[^ 0-9,]', FCST_LEAD):
+        print(f"FATAL ERROR: The provided FCST_LEAD string ('{FCST_LEAD}') contains"
+                     + f" invalid characters. FCST_LEAD must be made of"
+                     + f" numerics, commas and/or spaces only. Check the"
+                     + f" plotting configuration file.")
+        sys.exit(1)
+    return FCST_LEAD
+
+# LINE_TYPE
+# info case:
+# warning case: should matcha known line type
+# error case: should be a string, should not be blank
+def check_LINE_TYPE(LINE_TYPE):
+    if not isinstance(LINE_TYPE, str):
+        print(f"FATAL ERROR: The provided LINE_TYPE ('{LINE_TYPE}') is not a string."
+                     + f" LINE_TYPE must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not LINE_TYPE:
+        print(f"FATAL ERROR: The provided LINE_TYPE is empty. LINE_TYPE cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    if re.search(r'[^ A-Za-z0-9]', LINE_TYPE):
+        print(f"FATAL ERROR: The provided LINE_TYPE string ('{LINE_TYPE}') contains"
+                     + f" invalid characters. LINE_TYPE must be made of"
+                     + f" alphanumeric characters only. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    return LINE_TYPE
+
+# INTERP
+# info case:
+# warning case: should match a known interp
+# error case: should be a string, should not be blank
+def check_INTERP(INTERP):
+    if not isinstance(INTERP, str):
+        print(f"FATAL ERROR: The provided INTERP ('{INTERP}') is not a string."
+                     + f" INTERP must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not INTERP:
+        print(f"FATAL ERROR: The provided INTERP is empty. INTERP cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    if re.search(r'[^A-Za-z0-9_\-]', INTERP):
+        print(f"FATAL ERROR: The provided INTERP string ('{INTERP}') contains"
+                     + f" invalid characters. INTERP must be made of"
+                     + f" alphanumeric characters, hyphens, and/or underscores"
+                     + f" only. Check the plotting configuration file.")
+        sys.exit(1)
+    return INTERP
+
+# FCST_THRESH
+# info case:
+# warning case:
+# error case: should be a string, if line type is CTC, MCTC, PCT, NBRCTC then should not be blank, should contain comma-separated list of symbols and numbers, symbols should precede numbers, symbols should be either >,>=,<,<=,==,!=
+def check_FCST_THRESH(FCST_THRESH, LINE_TYPE):
+    if not isinstance(FCST_THRESH, str):
+        print(f"FATAL ERROR: The provided FCST_THRESH ('{FCST_THRESH}') is not a"
+                     + f" string. FCST_THRESH must be a string. Check the"
+                     + f" plotting configuration file.")
+        sys.exit(1)
+    if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
+        if not FCST_THRESH:
+            print(f"FATAL ERROR: The provided FCST_THRESH is empty. Since the"
+                         + f" provided line type is '{LINE_TYPE}', FCST_THRESH"
+                         + f" cannot be empty. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if re.search(r'[^A-Za-z0-9<>=.,! /-]', FCST_THRESH):
+            print(f"FATAL ERROR: The provided FCST_THRESH string ('{FCST_THRESH}') contains"
+                         + f" invalid characters. FCST_THRESH must be made of"
+                         + f" alphanumeric characters, comparison operators,"
+                         + f" periods, hyphens, commas and/or spaces only. Check the"
+                         + f" plotting configuration file.")
+            sys.exit(1)
+        if re.search(r'^((?![<=!>]).)*$', FCST_THRESH):
+            print(f"FATAL ERROR: The provided FCST_THRESH string ('{FCST_THRESH}')"
+                         + f" does not contain a valid comparison operator"
+                         + f" (<,>,<=,>=,!=,==). FCST_THRESH must contain a"
+                         + f" valid comparison operator.  Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if re.search(r'^((?![0-9]).)*$', FCST_THRESH):
+            print(f"FATAL ERROR: The provided FCST_THRESH string ('{FCST_THRESH}')"
+                         + f" contains no numerics (digits 0-9). FCST_THRESH"
+                         + f" must contain an integer or decimal in order to"
+                         + f" be valid.  Check the plotting configuration"
+                         + f" file.")
+            sys.exit(1)
+    return FCST_THRESH
+
+# OBS_THRESH
+# info case:
+# warning case: whether or not it matches FCST_THRESH
+# error case: should be a string, if line type is CTC, MCTC, PCT, NBRCTC then should not be blank, should contain comma-separated list of symbols and numbers, symbols should precede numbers, symbols should be either >,>=,<,<=,==,!=
+def check_OBS_THRESH(OBS_THRESH, FCST_THRESH, LINE_TYPE):
+    if not isinstance(OBS_THRESH, str):
+        print(f"FATAL ERROR: The provided OBS_THRESH ('{OBS_THRESH}') is not a"
+                     + f" string. OBS_THRESH must be a string. Check the"
+                     + f" plotting configuration file.")
+        sys.exit(1)
+    if str(LINE_TYPE).upper() in ['CTC','MCTC','PCT','NBRCTC']:
+        if not OBS_THRESH:
+            print(f"FATAL ERROR: The provided OBS_THRESH is empty. Since the"
+                         + f" provided line type is '{LINE_TYPE}', OBS_THRESH"
+                         + f" cannot be empty. Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if re.search(r'[^A-Za-z0-9<>=.,! /-]', OBS_THRESH):
+            print(f"FATAL ERROR: The provided OBS_THRESH string ('{OBS_THRESH}') contains"
+                         + f" invalid characters. OBS_THRESH must be made of"
+                         + f" alphanumeric characters, comparison operators,"
+                         + f" periods, hyphens, commas and/or spaces only. Check the"
+                         + f" plotting configuration file.")
+            sys.exit(1)
+        if re.search(r'^((?![<=!>]).)*$', OBS_THRESH):
+            print(f"FATAL ERROR: The provided OBS_THRESH string ('{OBS_THRESH}')"
+                         + f" does not contain a valid comparison operator"
+                         + f" (<,>,<=,>=,!=,==). OBS_THRESH must contain a"
+                         + f" valid comparison operator.  Check the plotting"
+                         + f" configuration file.")
+            sys.exit(1)
+        if re.search(r'^((?![0-9]).)*$', OBS_THRESH):
+            print(f"FATAL ERROR: The provided OBS_THRESH string ('{OBS_THRESH}')"
+                         + f" contains no numerics (digits 0-9). OBS_THRESH"
+                         + f" must contain an integer or decimal in order to"
+                         + f" be valid.  Check the plotting configuration"
+                         + f" file.")
+            sys.exit(1)
+        if (OBS_THRESH.replace(' ','') != FCST_THRESH.replace(' ','')
+                or len(re.split(r'[\s,]+', OBS_THRESH)) 
+                != len(re.split(r'[\s,]+', FCST_THRESH))):
+            print(f"WARNING: The provided OBS_THRESH string ('{OBS_THRESH}')"
+                           + f" is not equivalent to the provided FCST_THRESH"
+                           + f" string ('{FCST_THRESH}').")
+    return OBS_THRESH
+
+# STATS
+# info case:
+# warning case:
+# error case: should be a string, should not be blank, 
+def check_STATS(STATS):
+    if not isinstance(STATS, str):
+        print(f"FATAL ERROR: The provided STATS ('{STATS}') is not a string."
+                     + f" STATS must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not STATS:
+        print(f"FATAL ERROR: The provided STATS is empty. STATS cannot be"
+                     + f" empty. Check the plotting configuration file.")
+        sys.exit(1)
+    if re.search(r'[^ A-Za-z0-9,_\-]', STATS):
+        print(f"FATAL ERROR: The provided STATS string ('{STATS}') contains"
+                     + f" invalid characters. STATS must be made of"
+                     + f" alphanumeric characters, hyphen, underscore, commas"
+                     + f" and/or spaces only. Check the plotting configuration"
+                     + f" file.")
+        sys.exit(1)
+    return STATS
+
+# CONFIDENCE_INTERVALS
+# info case:
+# warning case: should not be blank
+# error case: should be a string
+def check_CONFIDENCE_INTERVALS(CONFIDENCE_INTERVALS):
+    if not isinstance(CONFIDENCE_INTERVALS, str):
+        print(f"FATAL ERROR: The provided CONFIDENCE_INTERVALS ('{CONFIDENCE_INTERVALS}') is not a string."
+                     + f" CONFIDENCE_INTERVALS must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if not CONFIDENCE_INTERVALS:
+        print(f"WARNING: The provided CONFIDENCE_INTERVALS is empty."
+                       + f" Confidence intervals will not be plotted. Set to"
+                       + f" 'True' if confidence intervals should be plotted.")
+    return CONFIDENCE_INTERVALS
+
+# INTERP_PTS
+# info case:
+# warning case: 
+# error case: should be a string, should be a comma-separated list of positive numbers 
+def check_INTERP_PTS(INTERP_PTS):
+    if not isinstance(INTERP_PTS, str):
+        print(f"FATAL ERROR: The provided INTERP_PTS ('{INTERP_PTS}') is not a string."
+                     + f" INTERP_PTS must be a string. Check the plotting"
+                     + f" configuration file.")
+        sys.exit(1)
+    if re.search(r'[^ 0-9,]', INTERP_PTS):
+        print(f"FATAL ERROR: The provided INTERP_PTS string ('{INTERP_PTS}') contains"
+                     + f" invalid characters. INTERP_PTS must be made of"
+                     + f" numerics, commas and/or spaces only. Check the"
+                     + f" plotting configuration file.")
+        sys.exit(1)
+    return INTERP_PTS

--- a/ush/cam/ush_refs_plot_py/df_preprocessing.py
+++ b/ush/cam/ush_refs_plot_py/df_preprocessing.py
@@ -1,0 +1,309 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          df_preprocessing.py
+# Contact(s):    Marcel Caron
+# Developed:     Dec. 2, 2021 by Marcel Caron
+# Last Modified: Apr. 22, 2022 by Marcel Caron
+# Abstract:      Collection of functions that initialize and filter dataframes
+#
+###############################################################################
+
+import os
+import sys
+import shutil
+import uuid
+import numpy as np
+import pandas as pd
+from datetime import timedelta as td
+
+SETTINGS_DIR = os.environ['USH_DIR']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from prune_stat_files import prune_data
+import plot_util
+
+
+# =================== FUNCTIONS =========================
+
+def get_valid_range(logger, date_type, date_range, date_hours, fleads):
+    if None in date_hours:
+        e = (f"FATAL ERROR: One or more FCST_{date_type}_HOURS is Nonetype. This may be"
+             + f" because the input string is empty.")
+        logger.error(e)
+        raise ValueError(e)
+    if date_type == 'INIT':
+        init_beg, init_end = date_range
+        valid_beg = (
+            init_beg.replace(hour=min(date_hours))
+            + td(hours=min(fleads))
+        )
+        valid_end = (
+            init_end.replace(hour=max(date_hours))
+            + td(hours=max(fleads))
+        )
+        valid_range = (valid_beg, valid_end)
+    elif date_type == 'VALID':
+        valid_range = date_range
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+    return valid_range
+
+def run_prune_data(logger, stats_dir, prune_dir, output_base_template, verif_case, 
+                   verif_type, line_type, valid_range, eval_period, var_name, 
+                   fcst_var_names, model_list, domain):
+    model_list = [str(model) for model in model_list]
+    tmp_dir = 'tmp'+str(uuid.uuid4().hex)
+    pruned_data_dir = os.path.join(
+        prune_dir,
+        (
+            str(line_type).upper()+'_'+str(var_name).upper()+'_'
+            +str(domain)+'_'+str(eval_period).upper()
+        ),
+        tmp_dir
+    )
+    # Check for pruned data, and run prune_data() if stat files are available
+    if os.path.isdir(stats_dir):
+        if len(os.listdir(stats_dir)):
+            logger.info(f"Looking for stat files in {stats_dir} using the"
+                        + f" template: {output_base_template}")
+            prune_data(
+                stats_dir, prune_dir, tmp_dir, output_base_template, valid_range, 
+                str(eval_period).upper(), str(verif_case).lower(), 
+                str(verif_type).lower(), str(line_type).upper(), 
+                str(domain), 
+                [str(fcst_var_name) for fcst_var_name in fcst_var_names],
+                str(var_name).upper(), model_list
+            )
+        else:
+            e1 = f"FATAL ERROR: {stats_dir} exists but is empty."
+            e2 = f"Populate {stats_dir} and retry."
+            logger.error(e1)
+            logger.error(e2)
+            raise OSError(e1+"\n"+e2)
+    else:
+        e1 = f"FATAL ERROR: {stats_dir} does not exist."
+        e2 = f"Create and populate {stats_dir} and retry."
+        logger.error(e1)
+        logger.error(e2)
+        raise OSError(e1+"\n"+e2)
+    return pruned_data_dir
+
+def check_empty(df, logger, called_from):
+    if df.empty:
+        logger.warning(f"Called from {called_from}:")
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return True
+    else:
+        return False
+
+def create_df(logger, stats_dir, pruned_data_dir, line_type, date_range, 
+              model_list, met_version, clear_prune_dir):
+    model_list = [str(model) for model in model_list]
+    # Create df combining pruned stats for all models in model_list
+    start_string = date_range[0].strftime('%HZ %d %B %Y')
+    end_string = date_range[1].strftime('%HZ %d %B %Y')
+    for model in model_list:
+        fpath = os.path.join(pruned_data_dir,f'{str(model)}.stat')
+        if not os.path.isfile(fpath):
+            logger.warning(
+                f"The stat file for {str(model)} does not exist in"
+                + f" {pruned_data_dir}."
+            )
+            logger.warning(
+                f"You might check whether the stats_dir ({stats_dir}) includes"
+                + f" {str(model)} data according to the output_base template,"
+                + f" given domain, variable, etc..."
+            )
+            logger.warning("Continuing ...")
+            continue
+        if not clear_prune_dir:
+            logger.debug(f"Creating dataframe using pruned data from {fpath}")
+        try:
+            df_og_colnames = plot_util.get_stat_file_base_columns(met_version)
+            df_line_type_colnames = plot_util.get_stat_file_line_type_columns(
+                logger, met_version, str(line_type).upper()
+            )
+            df_colnames = np.concatenate((
+                df_og_colnames, df_line_type_colnames
+            ))
+            df_tmp = pd.read_csv(
+                fpath, delim_whitespace=True, header=None, skiprows=1,
+                names=df_colnames, dtype=str, on_bad_lines='skip'
+            )
+            i = -1*len(df_line_type_colnames)
+            for col_name in df_colnames[i:]:
+                df_tmp[col_name] = df_tmp[col_name].astype(float)
+            try:
+                df = pd.concat([df, df_tmp])
+            except NameError:
+                df = df_tmp
+            except UnboundLocalError as e:
+                df = df_tmp
+        except pd.errors.EmptyDataError as e:
+            logger.warning(e)
+            logger.warning(f"The file in question:")
+            logger.warning(f"{fpath}")
+            logger.warning("Continuing ...")
+        except OSError as e:
+            logger.warning(e)
+            logger.warning(f"The file in question:")
+            logger.warning(f"{fpath}")
+            logger.warning("Continuing ...")
+    if clear_prune_dir:
+        try:
+            shutil.rmtree(pruned_data_dir)
+        except OSError as e:
+            logger.warning(e)
+            logger.warning(f"The directory in question:")
+            logger.warning(f"{pruned_data_dir}")
+            logger.warning("Continuing ...")
+    try:
+        if check_empty(df, logger, 'create_df'):
+            return None
+        else:
+            df.reset_index(drop=True, inplace=True)
+            return df
+    except UnboundLocalError as e:
+        logger.error(e)
+        logger.error(
+            "FATAL ERROR: Nonexistent dataframe. Check for earlier warning "
+            + "or error messages."
+        )
+        logger.error("Quitting ...")
+        sys.exit(1)
+
+def filter_by_level_type(df, logger, verif_type):
+    if df is None:
+        return None
+    if str(verif_type).lower() in ['pres', 'upper_air']:
+        df = df[
+            df['FCST_LEV'].str.startswith('P') 
+            & df['OBS_LEV'].str.startswith('P')
+        ]
+        df = df[~df['OBTYPE'].eq('ONLYSF')]
+    elif str(verif_type).lower() in ['sfc', 'conus_sfc', 'polar_sfc']:
+        df = df[
+            ~(df['FCST_LEV'].str.startswith('P') 
+            | df['OBS_LEV'].str.startswith('P'))
+        ]
+    if check_empty(df, logger, 'filter_by_level_type'):
+        return None
+    else:
+        return df
+
+def filter_by_var_name(df, logger, fcst_var_names, obs_var_names):
+    if df is None:
+        return None
+    df = df[
+        df['FCST_VAR'].isin(fcst_var_names) 
+        & df['OBS_VAR'].isin(obs_var_names)
+    ]
+
+    if check_empty(df, logger, 'filter_by_var_name'):
+        return None
+    else:
+        return df
+
+def filter_by_interp(df, logger, interp):
+    if df is None:
+        return None
+    df = df[df['INTERP_MTHD'].eq(str(interp).upper())]
+    if check_empty(df, logger, 'filter_by_interp'):
+        return None
+    else:
+        return df
+
+def filter_by_domain(df, logger, domain):
+    if df is None:
+        return None
+    df = df[df['VX_MASK'].eq(str(domain))]
+    if check_empty(df, logger, 'filter_by_domain'):
+        return None
+    else:
+        return df
+
+def create_lead_hours(df, logger):
+    if df is None:
+        return None
+    df['LEAD_HOURS'] = np.array([int(lead[:-4]) for lead in df['FCST_LEAD']])
+    if check_empty(df, logger, 'create_lead_hours'):
+        return None
+    else:
+        return df
+
+def create_valid_datetime(df, logger):
+    if df is None:
+        return None
+    df['VALID'] = pd.to_datetime(df['FCST_VALID_END'], format='%Y%m%d_%H%M%S')
+    if check_empty(df, logger, 'create_valid_datetime'):
+        return None
+    else:
+        return df
+
+def create_init_datetime(df, logger):
+    if df is None:
+        return None
+    df.reset_index(drop=True, inplace=True)
+    df['INIT'] = [
+        df['VALID'][v] - pd.DateOffset(hours=int(hour)) 
+        for v, hour in enumerate(df['LEAD_HOURS'])
+    ]
+    if check_empty(df, logger, 'create_init_datetime'):
+        return None
+    else:
+        return df
+
+def filter_by_date_range(df, logger, date_type, date_range):
+    if df is None:
+        return None
+    df = df.loc[
+        (df[str(date_type).upper()] >= date_range[0]) 
+        & (df[str(date_type).upper()] <= date_range[1])
+    ]
+    if check_empty(df, logger, 'filter_by_date_range'):
+        return None
+    else:
+        return df
+
+def filter_by_hour(df, logger, date_type, date_hours):
+    if df is None:
+        return None
+    df = df.loc[[x in date_hours for x in df[str(date_type).upper()].dt.hour]]
+    if check_empty(df, logger, 'filter_by_hour'):
+        return None
+    else:
+        return df
+
+def get_preprocessed_data(logger, stats_dir, prune_dir, output_base_template, 
+                          verif_case, verif_type, line_type, date_type, 
+                          date_range, eval_period, date_hours, fleads, 
+                          var_name, fcst_var_names, obs_var_names, model_list, 
+                          domain, interp, met_version, clear_prune_dir):
+    valid_range = get_valid_range(
+        logger, date_type, date_range, date_hours, fleads
+    )
+    pruned_data_dir = run_prune_data(
+        logger, stats_dir, prune_dir, output_base_template, verif_case, verif_type, 
+        line_type, valid_range, eval_period, var_name, fcst_var_names, model_list, 
+        domain
+    )
+    df = create_df(
+        logger, stats_dir, pruned_data_dir, line_type, date_range, model_list,
+        met_version, clear_prune_dir
+    )
+    df = filter_by_level_type(df, logger, verif_type)
+    df = filter_by_var_name(df, logger, fcst_var_names, obs_var_names)
+    df = filter_by_interp(df, logger, interp)
+    df = filter_by_domain(df, logger, domain)
+    df = create_lead_hours(df, logger)
+    df = create_valid_datetime(df, logger)
+    df = create_init_datetime(df, logger)
+    df = filter_by_date_range(df, logger, date_type, date_range)
+    df = filter_by_hour(df, logger, date_type, date_hours)
+    return df
+

--- a/ush/cam/ush_refs_plot_py/lead_average.py
+++ b/ush/cam/ush_refs_plot_py/lead_average.py
@@ -1,0 +1,1679 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          lead_average.py
+# Contact(s):    Marcel Caron
+# Developed:     Nov. 18, 2021 by Marcel Caron 
+# Last Modified: Jan. 18, 2023 by Marcel Caron             
+# Title:         Line plot of verification metric as a function of 
+#                lead time
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                varying by lead time, which represents the x-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import math
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(28.,14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def plot_lead_average(df: pd.DataFrame, logger: logging.Logger, 
+                      date_range: tuple, model_list: list, num: int = 0, 
+                      level: str = '500', flead='all', 
+                      fcst_thresh: list = ['<20'], obs_thresh: list = [''],
+                      metric1_name: str = 'BCRMSE', metric2_name: str = 'ME', 
+                      y_min_limit: float = -10., y_max_limit: float = 10., 
+                      y_lim_lock: bool = False, x_min_limit: float = -9999.,
+                      x_max_limit: float = 9999., x_lim_lock: bool = False,
+                      xlabel: str = 'Forecast Lead Hour', 
+                      date_type: str = 'VALID', date_hours: list = [0,6,12,18], 
+                      verif_type: str = 'pres', save_dir: str = '.',
+                      requested_var: str = 'HGT', line_type: str = 'SL1L2',
+                      dpi: int = 100, confidence_intervals: bool = False,
+                      interp_pts: list = [], bs_nrep: int = 5000, 
+                      bs_method: str = 'MATCHED_PAIRS', 
+                      ci_lev: float = .95, bs_min_samp: int = 30, 
+                      eval_period: str = 'TEST', save_header: str = '', 
+                      display_averages: bool = True, 
+                      plot_group: str = 'sfc_upper',
+                      sample_equalization: bool = True,
+                      plot_logo_left: bool = False, 
+                      plot_logo_right: bool = False, path_logo_left: str = '.',
+                      path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                      zoom_logo_right: float = 1., 
+                      delete_intermed_data: bool = True):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+   
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'u\u2013'+f'{flead[-1]}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads."
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(intep_pts, np.int):
+            interp_pts_string = f'(Wifth {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    if obs_thresh and '' not in obs_thresh:
+        requested_obs_thresh_symbol, requested_obs_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in obs_thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_obs_thresh_symbol):
+                if all(opt in t for t in requested_obs_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_obs_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" obs thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e)
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested obs thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e)
+        df_obs_thresh_symbol, df_obs_thresh_letter = list(
+            zip(*[
+                plot_util.format_thresh(t) 
+                for t in df['OBS_THRESH'].replace(np.nan, '', regex=True)
+            ])
+        )
+        df['OBS_THRESH_SYMBOL'] = df_obs_thresh_symbol
+        df['OBS_THRESH_VALUE'] = [str(item)[2:] for item in df_obs_thresh_letter]
+        requested_obs_thresh_value = [
+            str(item)[2:] for item in requested_obs_thresh_letter
+        ]
+        df = df[df['OBS_THRESH_SYMBOL'].isin(requested_obs_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_obs_thresh_symbol)[
+                ~np.isin(requested_obs_thresh_symbol, df['OBS_THRESH_SYMBOL'])
+            ]
+        )
+        requested_obs_thresh_symbol = (
+            np.array(requested_obs_thresh_symbol)[
+                np.isin(requested_obs_thresh_symbol, df['OBS_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} obs thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} obs threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+    if fcst_thresh and '' not in fcst_thresh:
+        requested_fcst_thresh_symbol, requested_fcst_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in fcst_thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_fcst_thresh_symbol):
+                if all(opt in t for t in requested_fcst_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_fcst_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" fcst thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e)
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested fcst thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e)
+        df_fcst_thresh_symbol, df_fcst_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+        )
+        df['FCST_THRESH_SYMBOL'] = df_fcst_thresh_symbol
+        df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_fcst_thresh_letter]
+        requested_fcst_thresh_value = [
+            str(item)[2:] for item in requested_fcst_thresh_letter
+        ]
+        df = df[df['FCST_THRESH_SYMBOL'].isin(requested_fcst_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_fcst_thresh_symbol)[
+                ~np.isin(requested_fcst_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        requested_fcst_thresh_symbol = (
+            np.array(requested_fcst_thresh_symbol)[
+                np.isin(requested_fcst_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} fcst thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} fcst threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model)
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL', 'LEAD_HOURS']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    if str(line_type).upper() == 'CTC':
+        df_aggregated = df_groups.sum()
+    else:
+        df_aggregated = df_groups.mean()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    df_aggregated = df_aggregated.reindex(
+        pd.MultiIndex.from_product(
+            [
+                np.unique(df_aggregated.index.get_level_values('MODEL')), 
+                np.unique(df_aggregated.index.get_level_values('LEAD_HOURS'))
+            ], 
+            names=['MODEL','LEAD_HOURS']
+        ), 
+        fill_value=np.nan
+    )
+    df_agg_no_nan_rows = ~df_aggregated.isna().any(axis=1)
+    max_leads = [
+        df_aggregated[df_agg_no_nan_rows].iloc[
+            df_aggregated[df_agg_no_nan_rows]
+            .index.get_level_values('MODEL') == model
+        ].index.get_level_values('LEAD_HOURS').max() for model in model_list
+    ]
+    remove_rows_by_lead = []
+    for m, model in enumerate(model_list):
+        df_model_group = df_aggregated.iloc[
+            df_aggregated.index.get_level_values('MODEL') == model
+        ]
+        rows_with_nans = df_model_group.index.get_level_values('LEAD_HOURS')[
+            df_model_group.isna().any(axis=1)
+        ]
+        remove_rows_by_lead_m = [
+            int(lead) for lead in rows_with_nans if lead < max_leads[m]
+        ]
+        remove_rows_by_lead = np.concatenate(
+            (remove_rows_by_lead, remove_rows_by_lead_m)
+        )
+    if delete_intermed_data:
+        df_aggregated = df_aggregated.drop(index=np.unique(remove_rows_by_lead), level=1)
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+   
+    units = df['FCST_UNITS'].tolist()[0]
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'PROB_MXUPHL25_A24_GEHWT':
+        units = 'decimal'
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR','SPREAD',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    coef, const = (None, None)
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        var_long_name_key = df['FCST_VAR'].tolist()[0]
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m', 'gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif str(var_long_name_key).upper() == 'TMP' and level[0] == 'P':
+            unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        if unit_convert:
+            if metric2_name is not None:
+                if (str(metric1_name).upper() in metrics_using_var_units
+                        and str(metric2_name).upper() in metrics_using_var_units):
+                    coef, const = (
+                        reference.unit_conversions[units]['formula'](
+                            None,
+                            return_terms=True
+                        )
+                    )
+            elif str(metric1_name).upper() in metrics_using_var_units:
+                coef, const = (
+                    reference.unit_conversions[units]['formula'](
+                        None,
+                        return_terms=True
+                    )
+                )
+    # Calculate desired metric
+    metric_long_names = []
+    for stat in [metric1_name, metric2_name]:
+        if stat:
+            stat_output = plot_util.calculate_stat(
+                logger, df_aggregated, str(stat).lower(), [coef, const]
+            )
+            df_aggregated[str(stat).upper()] = stat_output[0]
+            metric_long_names.append(stat_output[2])
+            if confidence_intervals:
+                ci_output = df_groups.apply(
+                    lambda x: plot_util.calculate_bootstrap_ci(
+                        logger, bs_method, x, str(stat).lower(), bs_nrep, 
+                        ci_lev, bs_min_samp, [coef, const]
+                    )
+                )
+                if any(ci_output['STATUS'] == 1):
+                    logger.warning(f"Failed attempt to compute bootstrap"
+                                   + f" confidence intervals.  Sample size"
+                                   + f" for one or more groups is too small."
+                                   + f" Minimum sample size can be changed"
+                                   + f" in settings.py.")
+                    logger.warning(f"Confidence intervals will not be"
+                                   + f" plotted.")
+                    confidence_intervals = False
+                    continue
+                ci_output = ci_output.reset_index(level=2, drop=True)
+                ci_output = (
+                    ci_output
+                    .reindex(df_aggregated.index)
+                    #.reindex(ci_output.index)
+                )
+                df_aggregated[str(stat).upper()+'_BLERR'] = ci_output[
+                    'CI_LOWER'
+                ].values
+                df_aggregated[str(stat).upper()+'_BUERR'] = ci_output[
+                    'CI_UPPER'
+                ].values
+    
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    if metric2_name is not None:
+        df_aggregated[str(metric2_name).upper()] = (
+            df_aggregated[str(metric2_name).upper()]
+        ).astype(float).tolist()
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index='LEAD_HOURS', dropna=False
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index='LEAD_HOURS'
+        )
+    #pivot_metric1 = pivot_metric1.dropna() 
+    if metric2_name is not None:
+        pivot_metric2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+            index='LEAD_HOURS', dropna=False
+        )
+        #pivot_metric2 = pivot_metric2.dropna() 
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index='LEAD_HOURS'
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index='LEAD_HOURS'
+        )
+        if metric2_name is not None:
+            pivot_ci_lower2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+                columns='MODEL', index='LEAD_HOURS'
+            )
+            pivot_ci_upper2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+                columns='MODEL', index='LEAD_HOURS'
+            )
+    # Reindex pivot table with full list of lead hours, introducing NaNs 
+    x_vals_pre = pivot_metric1.index.tolist()
+    lead_time_incr = np.diff(x_vals_pre)
+    if lead_time_incr.size == 0:
+        min_incr = 1
+    else:
+        min_incr = np.min(lead_time_incr)
+    incrs = [1,6,12,24]
+    incr_idx = np.digitize(min_incr, incrs)
+    if incr_idx < 1:
+        incr_idx = 1
+    incr = incrs[incr_idx-1]
+    if (metric2_name and (pivot_metric1.empty or pivot_metric2.empty)):
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    elif not metric2_name and pivot_metric1.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name}"
+            + f" stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected=False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model')!=-1):
+                    need_to_rename = models_sharing_colors[
+                        np.flatnonzero(np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1)[0]
+                    ]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model'+str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+    # Plot data
+    logger.info("Begin plotting ...")
+    if confidence_intervals:
+        indices_in_common1 = list(set.intersection(*map(
+            set, 
+            [
+                pivot_metric1.index, 
+                pivot_ci_lower1.index, 
+                pivot_ci_upper1.index
+            ]
+        )))
+        pivot_metric1 = pivot_metric1[pivot_metric1.index.isin(indices_in_common1)]
+        pivot_ci_lower1 = pivot_ci_lower1[pivot_ci_lower1.index.isin(indices_in_common1)]
+        pivot_ci_upper1 = pivot_ci_upper1[pivot_ci_upper1.index.isin(indices_in_common1)]
+        if sample_equalization:
+            pivot_counts = pivot_counts[pivot_counts.index.isin(indices_in_common1)]
+        if metric2_name is not None:
+            indices_in_common2 = list(set.intersection(*map(
+                set, 
+                [
+                    pivot_metric2.index, 
+                    pivot_ci_lower2.index, 
+                    pivot_ci_upper2.index
+                ]
+            )))
+            pivot_metric2 = pivot_metric2[pivot_metric2.index.isin(indices_in_common2)]
+            pivot_ci_lower2 = pivot_ci_lower2[pivot_ci_lower2.index.isin(indices_in_common2)]
+            pivot_ci_upper2 = pivot_ci_upper2[pivot_ci_upper2.index.isin(indices_in_common2)]
+    x_vals1 = pivot_metric1.index
+    if metric2_name is not None:
+        x_vals2 = pivot_metric2.index
+    y_min = y_min_limit
+    y_max = y_max_limit
+    if obs_thresh and '' not in obs_thresh:
+        obs_thresh_labels = np.unique(df['OBS_THRESH_VALUE'])
+        obs_thresh_argsort = np.argsort(obs_thresh_labels.astype(float))
+        requested_obs_thresh_argsort = np.argsort(
+            [float(item) for item in requested_obs_thresh_value]
+        )
+        obs_thresh_labels = [obs_thresh_labels[i] for i in obs_thresh_argsort]
+        requested_obs_thresh_labels = [
+            requested_obs_thresh_value[i] for i in requested_obs_thresh_argsort
+        ]
+    if fcst_thresh and '' not in fcst_thresh:
+        fcst_thresh_labels = np.unique(df['FCST_THRESH_VALUE'])
+        fcst_thresh_argsort = np.argsort(fcst_thresh_labels.astype(float))
+        requested_fcst_thresh_argsort = np.argsort(
+            [float(item) for item in requested_fcst_thresh_value]
+        )
+        fcst_thresh_labels = [fcst_thresh_labels[i] for i in fcst_thresh_argsort]
+        requested_fcst_thresh_labels = [
+            requested_fcst_thresh_value[i] for i in requested_fcst_thresh_argsort
+        ]
+    plot_reference = [False, False]
+    ref_metrics = ['OBAR']
+    if str(metric1_name).upper() in ref_metrics:
+        plot_reference[0] = True
+        pivot_reference1 = pivot_metric1
+        reference1 = pivot_reference1.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower1 = pivot_ci_lower1.mean(axis=1)
+            reference_ci_upper1 = pivot_ci_upper1.mean(axis=1)
+        if not np.any((pivot_reference1.T/reference1).T == 1.):
+            logger.warning(
+                f"{str(metric1_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[0] = False
+    if metric2_name is not None and str(metric2_name).upper() in ref_metrics:
+        plot_reference[1] = True
+        pivot_reference2 = pivot_metric2
+        reference2 = pivot_reference2.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower2 = pivot_ci_lower2.mean(axis=1)
+            reference_ci_upper2 = pivot_ci_upper2.mean(axis=1)
+        if not np.any((pivot_reference2.T/reference2).T == 1.):
+            logger.warning(
+                f"{str(metric2_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[1] = False
+    if np.any(plot_reference):
+        plotted_reference = [False, False]
+        if confidence_intervals:
+            plotted_reference_CIs = [False, False]
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms
+    )[0]
+    if metric2_name is not None:
+        if np.any(plot_reference):
+            ref_color_dict = model_colors.get_color_dict('obs')
+            handles = []
+            labels = []
+            line_settings = ['solid','dashed']
+            metric_names = [metric1_name, metric2_name]
+            for p, rbool in enumerate(plot_reference):
+                if rbool:
+                    handles += [
+                        f('', ref_color_dict['color'], line_settings[p], 5., 0, 'white')
+                    ]
+                else:
+                    handles += [
+                        f('', 'black', line_settings[p], 5., 0, 'white')
+                    ]
+                labels += [
+                    str(metric_names[p]).upper()
+                ]
+        else:
+            handles = [
+                f('', 'black', line_setting, 5., 0, 'white')
+                for line_setting in ['solid','dashed']
+            ]
+            labels = [
+                str(metric_name).upper()
+                for metric_name in [metric1_name, metric2_name]
+            ]
+    else:
+        handles = []
+        labels = []
+    if np.all([val==1 for val in pivot_metric1.count(axis=1)]):
+        connect_points = True
+    else:
+        connect_points = False
+    n_mods = 0
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        y_vals_metric1 = pivot_metric1[str(model_list[m])].values
+        y_vals_metric1_mean = np.nanmean(y_vals_metric1)
+        if metric2_name is not None:
+            y_vals_metric2 = pivot_metric2[str(model_list[m])].values
+            y_vals_metric2_mean = np.nanmean(y_vals_metric2)
+        if confidence_intervals:
+            y_vals_ci_lower1 = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper1 = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            if metric2_name is not None:
+                y_vals_ci_lower2 = pivot_ci_lower2[
+                    str(model_list[m])
+                ].values
+                y_vals_ci_upper2 = pivot_ci_upper2[
+                    str(model_list[m])
+                ].values
+        if not y_lim_lock:
+            if metric2_name is not None:
+                y_vals_both_metrics = np.concatenate((y_vals_metric1, y_vals_metric2))
+                if np.any(y_vals_both_metrics != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics)
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics)
+            else:
+                if np.any(y_vals_metric1 != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_metric1[y_vals_metric1 != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_metric1[y_vals_metric1 != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_metric1)
+                    y_vals_metric_max = np.nanmax(y_vals_metric1)
+            if n_mods == 0:
+                y_mod_min = y_vals_metric_min
+                y_mod_max = y_vals_metric_max
+                n_mods+=1
+            else:
+                if math.isinf(y_mod_min):
+                    y_mod_min = y_vals_metric_min
+                else:
+                    y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
+                if math.isinf(y_mod_max):
+                    y_mod_max = y_vals_metric_max
+                else:
+                    y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])
+            if (y_vals_metric_min > y_min_limit 
+                    and y_vals_metric_min <= y_mod_min):
+                y_min = y_vals_metric_min
+            if (y_vals_metric_max < y_max_limit 
+                    and y_vals_metric_max >= y_mod_max):
+                y_max = y_vals_metric_max
+        if np.abs(y_vals_metric1_mean) < 1E4:
+            metric1_mean_fmt_string = f' {y_vals_metric1_mean:.2f}'
+        else:
+            metric1_mean_fmt_string = f' {y_vals_metric1_mean:.2E}'
+        if plot_reference[0]:
+            if not plotted_reference[0]:
+                ref_color_dict = model_colors.get_color_dict('obs')
+                if connect_points:
+                    x_vals1_plot = x_vals1[~np.isnan(reference1)]
+                    y_vals1_plot = reference1[~np.isnan(reference1)]
+                else:
+                    x_vals1_plot = x_vals1
+                    y_vals1_plot = reference1
+                plt.plot(
+                    x_vals1_plot.tolist(), y_vals1_plot, 
+                    marker=ref_color_dict['marker'], 
+                    c=ref_color_dict['color'], mew=2., mec='white', 
+                    figure=fig, ms=ref_color_dict['markersize'], ls='solid', 
+                    lw=ref_color_dict['linewidth']
+                )
+                plotted_reference[0] = True
+        else:
+            if connect_points:
+                x_vals1_plot = x_vals1[~np.isnan(y_vals_metric1)]
+                y_vals1_plot = y_vals_metric1[~np.isnan(y_vals_metric1)]
+            else:
+                x_vals1_plot = x_vals1
+                y_vals1_plot = y_vals_metric1
+            plt.plot(
+                x_vals1_plot.tolist(), y_vals1_plot, 
+                marker=mod_setting_dicts[m]['marker'], 
+                c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='solid', 
+                lw=mod_setting_dicts[m]['linewidth']
+            )
+        if metric2_name is not None:
+            if np.abs(y_vals_metric2_mean) < 1E4:
+                metric2_mean_fmt_string = f' {y_vals_metric2_mean:.2f}'
+            else:
+                metric2_mean_fmt_string = f' {y_vals_metric2_mean:.2E}'
+            if plot_reference[1]:
+                if not plotted_reference[1]:
+                    if connect_points:
+                        x_vals2_plot = x_vals2[~np.isnan(reference2)]
+                        y_vals2_plot = reference2[~np.isnan(reference2)]
+                    else:
+                        x_vals2_plot = x_vals2
+                        y_vals2_plot = reference2
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.plot(
+                        x_vals2_plot.tolist(), y_vals2_plot, 
+                        marker=ref_color_dict['marker'], 
+                        c=ref_color_dict['color'], mew=2., mec='white', 
+                        figure=fig, ms=ref_color_dict['markersize'], ls='dashed', 
+                        lw=ref_color_dict['linewidth']
+                    )
+                    plotted_reference[1] = True
+            else:
+                if connect_points:
+                    x_vals2_plot = x_vals2[~np.isnan(y_vals_metric2)]
+                    y_vals2_plot = y_vals_metric2[~np.isnan(y_vals_metric2)]
+                else:
+                    x_vals2_plot = x_vals2
+                    y_vals2_plot = y_vals_metric2
+                plt.plot(
+                    x_vals2_plot.tolist(), y_vals2_plot, 
+                    marker=mod_setting_dicts[m]['marker'], 
+                    c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                    figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='dashed',
+                    lw=mod_setting_dicts[m]['linewidth']
+                )
+        if confidence_intervals:
+            if plot_reference[0]:
+                if not plotted_reference_CIs[0]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.errorbar(
+                        x_vals1.tolist(), reference1, 
+                        yerr=[np.abs(reference_ci_lower1), reference_ci_upper1], 
+                        fmt='none', ecolor=ref_color_dict['color'], 
+                        elinewidth=ref_color_dict['linewidth'],
+                        capsize=10., capthick=ref_color_dict['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+                    plotted_reference_CIs[0] = True
+            else:
+                plt.errorbar(
+                    x_vals1.tolist(), y_vals_metric1, 
+                    yerr=[np.abs(y_vals_ci_lower1), y_vals_ci_upper1], 
+                    fmt='none', ecolor=mod_setting_dicts[m]['color'], 
+                    elinewidth=mod_setting_dicts[m]['linewidth'],
+                    capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                    alpha=.70, zorder=0
+                )
+            if metric2_name is not None:
+                if plot_reference[1]:
+                    if not plotted_reference_CIs[1]:
+                        ref_color_dict = model_colors.get_color_dict('obs')
+                        plt.errorbar(
+                            x_vals2.tolist(), reference2, 
+                            yerr=[np.abs(reference_ci_lower2), reference_ci_upper2], 
+                            fmt='none', ecolor=ref_color_dict['color'], 
+                            elinewidth=ref_color_dict['linewidth'],
+                            capsize=10., capthick=ref_color_dict['linewidth'],
+                            alpha=.70, zorder=0
+                        )
+                        plotted_reference_CIs[1] = True
+                else:
+                    plt.errorbar(
+                        x_vals2.tolist(), y_vals_metric2, 
+                        yerr=[np.abs(y_vals_ci_lower2), y_vals_ci_upper2], 
+                        fmt='none', ecolor=mod_setting_dicts[m]['color'], 
+                        elinewidth=mod_setting_dicts[m]['linewidth'],
+                        capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+        handles+=[
+            f(
+                mod_setting_dicts[m]['marker'], mod_setting_dicts[m]['color'],
+                'solid', mod_setting_dicts[m]['linewidth'], 
+                mod_setting_dicts[m]['markersize'], 'white'
+            )
+        ]
+        if display_averages:
+            if metric2_name is not None:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string},'
+                    + f' {metric2_mean_fmt_string})'
+                ]
+            else:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string})'
+                ]
+        else:
+            labels+=[f'{model_plot_name}']
+
+    # Zero line
+    plt.axhline(y=0, color='black', linestyle='--', linewidth=1, zorder=0) 
+    metrics_with_axline_at_1 = [
+        'FBIAS','RSD'
+    ]
+    if (str(metric1_name).upper() in metrics_with_axline_at_1 
+            or str(metric2_name).upper() in metrics_with_axline_at_1):
+        plt.axhline(y=1, color='black', linestyle='--', linewidth=1, zorder=0)
+
+    # Configure axis ticks
+    if not x_lim_lock:
+        if metric2_name is not None:
+            xticks_min = np.min([x_vals1.tolist()[0], x_vals2.tolist()[0]])
+            xticks_max = np.max([x_vals1.tolist()[-1], x_vals2.tolist()[-1]])
+        else:
+            xticks_min = x_vals1.tolist()[0]
+            xticks_max = x_vals1.tolist()[-1]
+    else:
+        xticks_min = x_min_limit
+        xticks_max = x_max_limit
+    xticks = [
+        x_val for x_val in np.arange(xticks_min, xticks_max+incr, incr)
+    ] 
+    xtick_labels = [str(xtick) for xtick in xticks]
+    if len(xticks) < 48:
+        show_xtick_every = 1
+    else:
+        show_xtick_every = 2
+    xtick_labels_with_blanks = ['' for item in xtick_labels]
+    for i, item in enumerate(xtick_labels[::int(show_xtick_every)]):
+         xtick_labels_with_blanks[int(show_xtick_every)*i] = item
+    x_buffer_size = .015
+    ax.set_xlim(
+        xticks_min-incr*x_buffer_size, xticks_max+incr*x_buffer_size
+    )
+    y_range_categories = np.array([
+        [np.power(10.,y), 2.*np.power(10.,y)] 
+        for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+    ]).flatten()
+    round_to_nearest_categories = y_range_categories/20.
+    y_range = y_max-y_min
+    round_to_nearest =  round_to_nearest_categories[
+        np.digitize(y_range, y_range_categories[:-1])
+    ]
+    ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
+    ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
+    if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
+        ylim_min = float(
+            np.format_float_scientific(ylim_min, unique=False, precision=3)
+        )
+    yticks = np.arange(ylim_min, ylim_max+round_to_nearest, round_to_nearest)
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    units = df['FCST_UNITS'].tolist()[0]
+    if unit_convert:
+        if fcst_thresh and '' not in fcst_thresh:
+            fcst_thresh_labels = [float(tlab) for tlab in fcst_thresh_labels]
+            fcst_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    fcst_thresh_labels,
+                    rounding=True
+                )
+            )
+            fcst_thresh_labels = [str(tlab) for tlab in fcst_thresh_labels]
+        if obs_thresh and '' not in obs_thresh:
+            obs_thresh_labels = [float(tlab) for tlab in obs_thresh_labels]
+            obs_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    obs_thresh_labels,
+                    rounding=True
+                )
+            )
+            obs_thresh_labels = [str(tlab) for tlab in obs_thresh_labels]
+        units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    if metric2_name is not None:
+        metric1_string, metric2_string = metric_long_names
+        if (str(metric1_name).upper() in metrics_using_var_units
+                and str(metric2_name).upper() in metrics_using_var_units):
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string} and {metric2_string}'
+    else:
+        metric1_string = metric_long_names[0]
+        if str(metric1_name).upper() in metrics_using_var_units:
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string}'
+    ax.set_ylim(ylim_min, ylim_max)
+    ax.set_ylabel(ylabel)
+    ax.set_xlabel(xlabel) 
+    ax.set_xticklabels(xtick_labels_with_blanks)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', axis='y', pad=15
+    )
+    majticks = [i for i, item in enumerate(xtick_labels_with_blanks) if item]
+    for mt in majticks:
+        ax.xaxis.get_major_ticks()[mt].tick1line.set_markersize(8)
+
+    ax.legend(
+        handles, labels, loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=4, frameon=True, numpoints=2, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    #fig.subplots_adjust(bottom=.2, wspace=0, hspace=0)
+    fig.subplots_adjust(bottom=.15, wspace=0, hspace=0)
+    fig.subplots_adjust(top=0.85) 
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.5, linestyle='--', 
+        linewidth=.5, zorder=0
+    )
+
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        for count, xval in zip(counts, x_vals1.tolist()):
+            if not isinstance(count, str):
+                count = str(int(count))
+            ax.annotate(
+                f'{count}', xy=(xval,1.), 
+                xycoords=('data', 'axes fraction'), xytext=(0,18),
+                textcoords='offset points', va='top', fontsize=16,
+                color='dimgrey', ha='center'
+            )
+        ax.annotate(
+            '#SAMPLES', xy=(0.,1.), xycoords='axes fraction',
+            xytext=(-50, 21), textcoords='offset points', va='top', 
+            fontsize=11, color='dimgrey', ha='center'
+        )
+        #fig.subplots_adjust(top=.9)
+        fig.subplots_adjust(top=.85)
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = ''
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = ''
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'ML'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level_num}MB_'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'SB'
+        else:
+            level_string = ''
+            level_savename = ''
+    #Binbin add pres, anom
+    elif str(verif_type).lower() in ['sfc', 'conus_sfc', 'polar_sfc', 'mrms', 'metar', 'pres', 'anom']:
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = ''
+                else:
+                    level_string = 'Surface '
+                    level_savename = 'SFC_'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM_'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level_num}M_'
+        elif 'L' in str(level) or 'A' in str(level):
+            level_string = ''
+            level_savename = ''
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}_'
+    elif str(verif_type).lower() in ['ccpa']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'{level_num}H_'
+        else:
+            level_string = f''
+            level_savename = f''
+    else:
+        level_string = f'{level}'
+        level_savename = f'{level}_'
+    if var_savename == 'ICEC_Z0_mean':
+        level_string = ''
+    if var_savename == 'TMP_Z0_mean':
+        level_string = 'Sea Surface '
+    if metric2_name is not None:
+        title1 = f'{metric1_string} and {metric2_string}'
+    else:
+        title1 = f'{metric1_string}'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    fcst_thresh_on = (fcst_thresh and '' not in fcst_thresh)
+    obs_thresh_on = (obs_thresh and '' not in obs_thresh)
+    if metric1_string == 'Brier Score':
+        fcst_thresh_on = False
+        obs_thresh_on = False
+    if fcst_thresh_on:
+        fcst_thresholds_phrase = ', '.join([
+            f'{opt}{fcst_thresh_label}' 
+            for fcst_thresh_label in fcst_thresh_labels
+        ])
+        fcst_thresholds_save_phrase = ''.join([
+            f'{opt_letter}{fcst_thresh_label}' 
+            for fcst_thresh_label in requested_fcst_thresh_labels
+        ])
+    if obs_thresh_on:
+        obs_thresholds_phrase = ', '.join([
+            f'obs{opt}{obs_thresh_label}' 
+            for obs_thresh_label in obs_thresh_labels
+        ])
+        obs_thresholds_save_phrase = ''.join([
+            f'obs{opt_letter}{obs_thresh_label}'
+            for obs_thresh_label in requested_obs_thresh_labels
+        ])
+    if fcst_thresh_on:
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({fcst_thresholds_phrase} '
+                      + f'{units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({fcst_thresholds_phrase} '
+                      + f'unitless), {domain_string}')
+    elif obs_thresh_on:
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({obs_thresholds_phrase} '
+                      + f'{units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({obs_thresholds_phrase} '
+                      + f'unitless), {domain_string}')
+    else:
+        if units:
+            title2 = f'{level_string}{var_long_name} ({units}), {domain_string}'
+        else:
+            title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    if sample_equalization:
+        #title_pad=40
+        title_pad=30
+    else:
+        title_pad=None
+    ax.set_title(title_center, loc=plotter.title_loc, pad=title_pad)
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction', 
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.), xycoords='axes fraction', 
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'lead_average_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(level_savename).lower()}'
+                 + f'{str(var_savename).lower()}_{str(metric1_name).lower()}')
+    if metric2_name is not None:
+        save_name+=f'_{str(metric2_name).lower()}'
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    if fcst_thresh_on:
+        save_name+=f'_{str(fcst_thresholds_save_phrase).lower()}'
+    elif obs_thresh_on:
+        save_name+=f'_{str(obs_thresholds_save_phrase).lower()}'
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+    
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: {X_MIN_LIMIT}")
+    logger.debug(f"X_MAX_LIMIT: {X_MAX_LIMIT}")
+    logger.debug(f"X_LIM_LOCK: {X_LIM_LOCK}")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    if len(METRICS) == 1:
+        metrics = (METRICS[0], None)
+    elif len(METRICS) > 1:
+        metrics = METRICS[:2]
+    else:
+        e = (f"FATAL ERROR: Received no list of metrics.  Check that, for the METRICS"
+             + f" setting, a comma-separated string of at least one metric is"
+             + f" provided")
+        logger.error(e)
+        raise ValueError(e)
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e)
+    if (str(INTERP).upper()
+            not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e)
+    for metric in metrics:
+        if metric is not None:
+            if (str(metric).lower()
+                    not in case_specs['plot_stats_list']
+                    .replace(' ','').split(',')):
+                e = (f"FATAL ERROR: The requested metric is not valid for the"
+                     + f" requested case type ({VERIF_CASETYPE}) and"
+                     + f" line_type ({LINE_TYPE}): {metric}")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e)
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            fcst_okay = (
+                fcst_thresh in var_specs['fcst_var_thresholds'] 
+            )
+            obs_okay = (
+                obs_thresh in var_specs['obs_var_thresholds'] 
+            )
+            if (fcst_okay and obs_okay):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            fcst_okay = (
+                fcst_thresh in var_specs['fcst_var_thresholds']
+            )
+            obs_okay = (
+                obs_thresh in var_specs['obs_var_thresholds']
+            )
+            if (fcst_okay and obs_okay):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for l, fcst_level in enumerate(FCST_LEVELS):
+            if len(FCST_LEVELS) != len(OBS_LEVELS):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e)
+            if (FCST_LEVELS[l] not in var_specs['fcst_var_levels'] 
+                    or OBS_LEVELS[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid: "
+                        + f"{requested_var}/{fcst_level}")
+                logger.warning(e)
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the requested"
+                         + f" case type ({VERIF_CASETYPE}) and line_type"
+                         + f" ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    date_hours, FLEADS, requested_var, fcst_var_names, obs_var_names, 
+                    MODELS, domain, INTERP, MET_VERSION, clear_prune_dir
+                )
+                if df is None:
+                    continue
+                df_metric = df
+                plot_lead_average(
+                    df_metric, logger, date_range, MODELS, num=num, 
+                    flead=FLEADS, level=fcst_level, fcst_thresh=fcst_thresh, 
+                    obs_thresh=obs_thresh,
+                    metric1_name=metrics[0], metric2_name=metrics[1], 
+                    date_type=DATE_TYPE, y_min_limit=Y_MIN_LIMIT, 
+                    y_max_limit=Y_MAX_LIMIT, y_lim_lock=Y_LIM_LOCK, 
+                    x_min_limit=X_MIN_LIMIT, x_max_limit=X_MAX_LIMIT, 
+                    x_lim_lock=X_LIM_LOCK, xlabel=f'Forecast Lead Hour', 
+                    verif_type=VERIF_TYPE, line_type=LINE_TYPE, 
+                    date_hours=date_hours, save_dir=SAVE_DIR, 
+                    eval_period=EVAL_PERIOD, display_averages=display_averages, 
+                    save_header=URL_HEADER, plot_group=plot_group, 
+                    confidence_intervals=CONFIDENCE_INTERVALS, 
+                    interp_pts=INTERP_PNTS, bs_nrep=bs_nrep, 
+                    bs_method=bs_method, ci_lev=ci_lev, 
+                    bs_min_samp=bs_min_samp, 
+                    sample_equalization=sample_equalization,
+                    plot_logo_left=plot_logo_left, 
+                    plot_logo_right=plot_logo_right, 
+                    path_logo_left=path_logo_left, 
+                    path_logo_right=path_logo_right,
+                    zoom_logo_left=zoom_logo_left,
+                    zoom_logo_right=zoom_logo_right,
+                    delete_intermed_data=delete_intermed_data
+                )
+                num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = list(filter(None, check_STATS(os.environ['STATS']).replace(' ','').split(',')))
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+    X_MIN_LIMIT = toggle.plot_settings['x_min_limit']
+    X_MAX_LIMIT = toggle.plot_settings['x_max_limit']
+    X_LIM_LOCK = toggle.plot_settings['x_lim_lock']
+
+
+    # configure CIs
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_method = toggle.plot_settings['bs_method']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove 
+    # samples used to aggregate each statistic if the samples are not shared 
+    # by all models.  Required to display sample sizes 
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    delete_intermed_data = toggle.plot_settings['delete_intermed_data']
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    FCST_LEVELS = [str(level) for level in FCST_LEVELS]
+    OBS_LEVELS = [str(level) for level in OBS_LEVELS]
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/lead_average_valid.py
+++ b/ush/cam/ush_refs_plot_py/lead_average_valid.py
@@ -1,0 +1,1683 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          lead_average.py
+# Contact(s):    Marcel Caron
+# Developed:     Nov. 18, 2021 by Marcel Caron 
+# Last Modified: Jan. 18, 2023 by Marcel Caron             
+# Title:         Line plot of verification metric as a function of 
+#                lead time
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                varying by lead time, which represents the x-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import math
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(28.,14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def plot_lead_average(df: pd.DataFrame, logger: logging.Logger, 
+                      date_range: tuple, model_list: list, num: int = 0, 
+                      level: str = '500', flead='all', 
+                      fcst_thresh: list = ['<20'], obs_thresh: list = [''],
+                      metric1_name: str = 'BCRMSE', metric2_name: str = 'ME', 
+                      y_min_limit: float = -10., y_max_limit: float = 10., 
+                      y_lim_lock: bool = False, x_min_limit: float = -9999.,
+                      x_max_limit: float = 9999., x_lim_lock: bool = False,
+                      xlabel: str = 'Forecast Lead Hour', 
+                      date_type: str = 'VALID', date_hours: list = [0,6,12,18], 
+                      verif_type: str = 'pres', save_dir: str = '.',
+                      requested_var: str = 'HGT', line_type: str = 'SL1L2',
+                      dpi: int = 100, confidence_intervals: bool = False,
+                      interp_pts: list = [], bs_nrep: int = 5000, 
+                      bs_method: str = 'MATCHED_PAIRS', 
+                      ci_lev: float = .95, bs_min_samp: int = 30, 
+                      eval_period: str = 'TEST', save_header: str = '', 
+                      display_averages: bool = True, 
+                      plot_group: str = 'sfc_upper',
+                      sample_equalization: bool = True,
+                      plot_logo_left: bool = False, 
+                      plot_logo_right: bool = False, path_logo_left: str = '.',
+                      path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                      zoom_logo_right: float = 1., 
+                      delete_intermed_data: bool = True):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+   
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'u\u2013'+f'{flead[-1]}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads."
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(intep_pts, np.int):
+            interp_pts_string = f'(Wifth {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    if obs_thresh and '' not in obs_thresh:
+        requested_obs_thresh_symbol, requested_obs_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in obs_thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_obs_thresh_symbol):
+                if all(opt in t for t in requested_obs_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_obs_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" obs thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e)
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested obs thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e)
+        df_obs_thresh_symbol, df_obs_thresh_letter = list(
+            zip(*[
+                plot_util.format_thresh(t) 
+                for t in df['OBS_THRESH'].replace(np.nan, '', regex=True)
+            ])
+        )
+        df['OBS_THRESH_SYMBOL'] = df_obs_thresh_symbol
+        df['OBS_THRESH_VALUE'] = [str(item)[2:] for item in df_obs_thresh_letter]
+        requested_obs_thresh_value = [
+            str(item)[2:] for item in requested_obs_thresh_letter
+        ]
+        df = df[df['OBS_THRESH_SYMBOL'].isin(requested_obs_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_obs_thresh_symbol)[
+                ~np.isin(requested_obs_thresh_symbol, df['OBS_THRESH_SYMBOL'])
+            ]
+        )
+        requested_obs_thresh_symbol = (
+            np.array(requested_obs_thresh_symbol)[
+                np.isin(requested_obs_thresh_symbol, df['OBS_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} obs thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} obs threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+    if fcst_thresh and '' not in fcst_thresh:
+        requested_fcst_thresh_symbol, requested_fcst_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in fcst_thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_fcst_thresh_symbol):
+                if all(opt in t for t in requested_fcst_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_fcst_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" fcst thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e)
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested fcst thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e)
+        df_fcst_thresh_symbol, df_fcst_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+        )
+        df['FCST_THRESH_SYMBOL'] = df_fcst_thresh_symbol
+        df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_fcst_thresh_letter]
+        requested_fcst_thresh_value = [
+            str(item)[2:] for item in requested_fcst_thresh_letter
+        ]
+        df = df[df['FCST_THRESH_SYMBOL'].isin(requested_fcst_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_fcst_thresh_symbol)[
+                ~np.isin(requested_fcst_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        requested_fcst_thresh_symbol = (
+            np.array(requested_fcst_thresh_symbol)[
+                np.isin(requested_fcst_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} fcst thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} fcst threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model)
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL', 'LEAD_HOURS']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    if str(line_type).upper() == 'CTC':
+        df_aggregated = df_groups.sum()
+    else:
+        df_aggregated = df_groups.mean()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    df_aggregated = df_aggregated.reindex(
+        pd.MultiIndex.from_product(
+            [
+                np.unique(df_aggregated.index.get_level_values('MODEL')), 
+                np.unique(df_aggregated.index.get_level_values('LEAD_HOURS'))
+            ], 
+            names=['MODEL','LEAD_HOURS']
+        ), 
+        fill_value=np.nan
+    )
+    df_agg_no_nan_rows = ~df_aggregated.isna().any(axis=1)
+    max_leads = [
+        df_aggregated[df_agg_no_nan_rows].iloc[
+            df_aggregated[df_agg_no_nan_rows]
+            .index.get_level_values('MODEL') == model
+        ].index.get_level_values('LEAD_HOURS').max() for model in model_list
+    ]
+    remove_rows_by_lead = []
+    for m, model in enumerate(model_list):
+        df_model_group = df_aggregated.iloc[
+            df_aggregated.index.get_level_values('MODEL') == model
+        ]
+        rows_with_nans = df_model_group.index.get_level_values('LEAD_HOURS')[
+            df_model_group.isna().any(axis=1)
+        ]
+        remove_rows_by_lead_m = [
+            int(lead) for lead in rows_with_nans if lead < max_leads[m]
+        ]
+        remove_rows_by_lead = np.concatenate(
+            (remove_rows_by_lead, remove_rows_by_lead_m)
+        )
+    if delete_intermed_data:
+        df_aggregated = df_aggregated.drop(index=np.unique(remove_rows_by_lead), level=1)
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+   
+    units = df['FCST_UNITS'].tolist()[0]
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'PROB_MXUPHL25_A24_GEHWT':
+        units = 'decimal'
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR','SPREAD',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    coef, const = (None, None)
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        var_long_name_key = df['FCST_VAR'].tolist()[0]
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m', 'gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif str(var_long_name_key).upper() == 'TMP' and level[0] == 'P':
+            unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        if unit_convert:
+            if metric2_name is not None:
+                if (str(metric1_name).upper() in metrics_using_var_units
+                        and str(metric2_name).upper() in metrics_using_var_units):
+                    coef, const = (
+                        reference.unit_conversions[units]['formula'](
+                            None,
+                            return_terms=True
+                        )
+                    )
+            elif str(metric1_name).upper() in metrics_using_var_units:
+                coef, const = (
+                    reference.unit_conversions[units]['formula'](
+                        None,
+                        return_terms=True
+                    )
+                )
+    # Calculate desired metric
+    metric_long_names = []
+    for stat in [metric1_name, metric2_name]:
+        if stat:
+            stat_output = plot_util.calculate_stat(
+                logger, df_aggregated, str(stat).lower(), [coef, const]
+            )
+            df_aggregated[str(stat).upper()] = stat_output[0]
+            metric_long_names.append(stat_output[2])
+            if confidence_intervals:
+                ci_output = df_groups.apply(
+                    lambda x: plot_util.calculate_bootstrap_ci(
+                        logger, bs_method, x, str(stat).lower(), bs_nrep, 
+                        ci_lev, bs_min_samp, [coef, const]
+                    )
+                )
+                if any(ci_output['STATUS'] == 1):
+                    logger.warning(f"Failed attempt to compute bootstrap"
+                                   + f" confidence intervals.  Sample size"
+                                   + f" for one or more groups is too small."
+                                   + f" Minimum sample size can be changed"
+                                   + f" in settings.py.")
+                    logger.warning(f"Confidence intervals will not be"
+                                   + f" plotted.")
+                    confidence_intervals = False
+                    continue
+                ci_output = ci_output.reset_index(level=2, drop=True)
+                ci_output = (
+                    ci_output
+                    .reindex(df_aggregated.index)
+                    #.reindex(ci_output.index)
+                )
+                df_aggregated[str(stat).upper()+'_BLERR'] = ci_output[
+                    'CI_LOWER'
+                ].values
+                df_aggregated[str(stat).upper()+'_BUERR'] = ci_output[
+                    'CI_UPPER'
+                ].values
+    
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    if metric2_name is not None:
+        df_aggregated[str(metric2_name).upper()] = (
+            df_aggregated[str(metric2_name).upper()]
+        ).astype(float).tolist()
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index='LEAD_HOURS', dropna=False
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index='LEAD_HOURS'
+        )
+    #pivot_metric1 = pivot_metric1.dropna() 
+    if metric2_name is not None:
+        pivot_metric2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+            index='LEAD_HOURS', dropna=False
+        )
+        #pivot_metric2 = pivot_metric2.dropna() 
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index='LEAD_HOURS'
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index='LEAD_HOURS'
+        )
+        if metric2_name is not None:
+            pivot_ci_lower2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+                columns='MODEL', index='LEAD_HOURS'
+            )
+            pivot_ci_upper2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+                columns='MODEL', index='LEAD_HOURS'
+            )
+    # Reindex pivot table with full list of lead hours, introducing NaNs 
+    x_vals_pre = pivot_metric1.index.tolist()
+    lead_time_incr = np.diff(x_vals_pre)
+    if lead_time_incr.size == 0:
+        min_incr = 1
+    else:
+        min_incr = np.min(lead_time_incr)
+    incrs = [1,6,12,24]
+    incr_idx = np.digitize(min_incr, incrs)
+    if incr_idx < 1:
+        incr_idx = 1
+    incr = incrs[incr_idx-1]
+    if (metric2_name and (pivot_metric1.empty or pivot_metric2.empty)):
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    elif not metric2_name and pivot_metric1.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name}"
+            + f" stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected=False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model')!=-1):
+                    need_to_rename = models_sharing_colors[
+                        np.flatnonzero(np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1)[0]
+                    ]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model'+str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+    # Plot data
+    logger.info("Begin plotting ...")
+    if confidence_intervals:
+        indices_in_common1 = list(set.intersection(*map(
+            set, 
+            [
+                pivot_metric1.index, 
+                pivot_ci_lower1.index, 
+                pivot_ci_upper1.index
+            ]
+        )))
+        pivot_metric1 = pivot_metric1[pivot_metric1.index.isin(indices_in_common1)]
+        pivot_ci_lower1 = pivot_ci_lower1[pivot_ci_lower1.index.isin(indices_in_common1)]
+        pivot_ci_upper1 = pivot_ci_upper1[pivot_ci_upper1.index.isin(indices_in_common1)]
+        if sample_equalization:
+            pivot_counts = pivot_counts[pivot_counts.index.isin(indices_in_common1)]
+        if metric2_name is not None:
+            indices_in_common2 = list(set.intersection(*map(
+                set, 
+                [
+                    pivot_metric2.index, 
+                    pivot_ci_lower2.index, 
+                    pivot_ci_upper2.index
+                ]
+            )))
+            pivot_metric2 = pivot_metric2[pivot_metric2.index.isin(indices_in_common2)]
+            pivot_ci_lower2 = pivot_ci_lower2[pivot_ci_lower2.index.isin(indices_in_common2)]
+            pivot_ci_upper2 = pivot_ci_upper2[pivot_ci_upper2.index.isin(indices_in_common2)]
+    x_vals1 = pivot_metric1.index
+    if metric2_name is not None:
+        x_vals2 = pivot_metric2.index
+    y_min = y_min_limit
+    y_max = y_max_limit
+    if obs_thresh and '' not in obs_thresh:
+        obs_thresh_labels = np.unique(df['OBS_THRESH_VALUE'])
+        obs_thresh_argsort = np.argsort(obs_thresh_labels.astype(float))
+        requested_obs_thresh_argsort = np.argsort(
+            [float(item) for item in requested_obs_thresh_value]
+        )
+        obs_thresh_labels = [obs_thresh_labels[i] for i in obs_thresh_argsort]
+        requested_obs_thresh_labels = [
+            requested_obs_thresh_value[i] for i in requested_obs_thresh_argsort
+        ]
+    if fcst_thresh and '' not in fcst_thresh:
+        fcst_thresh_labels = np.unique(df['FCST_THRESH_VALUE'])
+        fcst_thresh_argsort = np.argsort(fcst_thresh_labels.astype(float))
+        requested_fcst_thresh_argsort = np.argsort(
+            [float(item) for item in requested_fcst_thresh_value]
+        )
+        fcst_thresh_labels = [fcst_thresh_labels[i] for i in fcst_thresh_argsort]
+        requested_fcst_thresh_labels = [
+            requested_fcst_thresh_value[i] for i in requested_fcst_thresh_argsort
+        ]
+    plot_reference = [False, False]
+    ref_metrics = ['OBAR']
+    if str(metric1_name).upper() in ref_metrics:
+        plot_reference[0] = True
+        pivot_reference1 = pivot_metric1
+        reference1 = pivot_reference1.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower1 = pivot_ci_lower1.mean(axis=1)
+            reference_ci_upper1 = pivot_ci_upper1.mean(axis=1)
+        if not np.any((pivot_reference1.T/reference1).T == 1.):
+            logger.warning(
+                f"{str(metric1_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[0] = False
+    if metric2_name is not None and str(metric2_name).upper() in ref_metrics:
+        plot_reference[1] = True
+        pivot_reference2 = pivot_metric2
+        reference2 = pivot_reference2.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower2 = pivot_ci_lower2.mean(axis=1)
+            reference_ci_upper2 = pivot_ci_upper2.mean(axis=1)
+        if not np.any((pivot_reference2.T/reference2).T == 1.):
+            logger.warning(
+                f"{str(metric2_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[1] = False
+    if np.any(plot_reference):
+        plotted_reference = [False, False]
+        if confidence_intervals:
+            plotted_reference_CIs = [False, False]
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms
+    )[0]
+    if metric2_name is not None:
+        if np.any(plot_reference):
+            ref_color_dict = model_colors.get_color_dict('obs')
+            handles = []
+            labels = []
+            line_settings = ['solid','dashed']
+            metric_names = [metric1_name, metric2_name]
+            for p, rbool in enumerate(plot_reference):
+                if rbool:
+                    handles += [
+                        f('', ref_color_dict['color'], line_settings[p], 5., 0, 'white')
+                    ]
+                else:
+                    handles += [
+                        f('', 'black', line_settings[p], 5., 0, 'white')
+                    ]
+                labels += [
+                    str(metric_names[p]).upper()
+                ]
+        else:
+            handles = [
+                f('', 'black', line_setting, 5., 0, 'white')
+                for line_setting in ['solid','dashed']
+            ]
+            labels = [
+                str(metric_name).upper()
+                for metric_name in [metric1_name, metric2_name]
+            ]
+    else:
+        handles = []
+        labels = []
+    if np.all([val==1 for val in pivot_metric1.count(axis=1)]):
+        connect_points = True
+    else:
+        connect_points = False
+    n_mods = 0
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        y_vals_metric1 = pivot_metric1[str(model_list[m])].values
+        y_vals_metric1_mean = np.nanmean(y_vals_metric1)
+        if metric2_name is not None:
+            y_vals_metric2 = pivot_metric2[str(model_list[m])].values
+            y_vals_metric2_mean = np.nanmean(y_vals_metric2)
+        if confidence_intervals:
+            y_vals_ci_lower1 = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper1 = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            if metric2_name is not None:
+                y_vals_ci_lower2 = pivot_ci_lower2[
+                    str(model_list[m])
+                ].values
+                y_vals_ci_upper2 = pivot_ci_upper2[
+                    str(model_list[m])
+                ].values
+        if not y_lim_lock:
+            if metric2_name is not None:
+                y_vals_both_metrics = np.concatenate((y_vals_metric1, y_vals_metric2))
+                if np.any(y_vals_both_metrics != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics)
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics)
+            else:
+                if np.any(y_vals_metric1 != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_metric1[y_vals_metric1 != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_metric1[y_vals_metric1 != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_metric1)
+                    y_vals_metric_max = np.nanmax(y_vals_metric1)
+            if n_mods == 0:
+                y_mod_min = y_vals_metric_min
+                y_mod_max = y_vals_metric_max
+                n_mods+=1
+            else:
+                if math.isinf(y_mod_min):
+                    y_mod_min = y_vals_metric_min
+                else:
+                    y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
+                if math.isinf(y_mod_max):
+                    y_mod_max = y_vals_metric_max
+                else:
+                    y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])
+            if (y_vals_metric_min > y_min_limit 
+                    and y_vals_metric_min <= y_mod_min):
+                y_min = y_vals_metric_min
+            if (y_vals_metric_max < y_max_limit 
+                    and y_vals_metric_max >= y_mod_max):
+                y_max = y_vals_metric_max
+        if np.abs(y_vals_metric1_mean) < 1E4:
+            metric1_mean_fmt_string = f' {y_vals_metric1_mean:.2f}'
+        else:
+            metric1_mean_fmt_string = f' {y_vals_metric1_mean:.2E}'
+        if plot_reference[0]:
+            if not plotted_reference[0]:
+                ref_color_dict = model_colors.get_color_dict('obs')
+                if connect_points:
+                    x_vals1_plot = x_vals1[~np.isnan(reference1)]
+                    y_vals1_plot = reference1[~np.isnan(reference1)]
+                else:
+                    x_vals1_plot = x_vals1
+                    y_vals1_plot = reference1
+                plt.plot(
+                    x_vals1_plot.tolist(), y_vals1_plot, 
+                    marker=ref_color_dict['marker'], 
+                    c=ref_color_dict['color'], mew=2., mec='white', 
+                    figure=fig, ms=ref_color_dict['markersize'], ls='solid', 
+                    lw=ref_color_dict['linewidth']
+                )
+                plotted_reference[0] = True
+        else:
+            if connect_points:
+                x_vals1_plot = x_vals1[~np.isnan(y_vals_metric1)]
+                y_vals1_plot = y_vals_metric1[~np.isnan(y_vals_metric1)]
+            else:
+                x_vals1_plot = x_vals1
+                y_vals1_plot = y_vals_metric1
+            plt.plot(
+                x_vals1_plot.tolist(), y_vals1_plot, 
+                marker=mod_setting_dicts[m]['marker'], 
+                c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='solid', 
+                lw=mod_setting_dicts[m]['linewidth']
+            )
+        if metric2_name is not None:
+            if np.abs(y_vals_metric2_mean) < 1E4:
+                metric2_mean_fmt_string = f' {y_vals_metric2_mean:.2f}'
+            else:
+                metric2_mean_fmt_string = f' {y_vals_metric2_mean:.2E}'
+            if plot_reference[1]:
+                if not plotted_reference[1]:
+                    if connect_points:
+                        x_vals2_plot = x_vals2[~np.isnan(reference2)]
+                        y_vals2_plot = reference2[~np.isnan(reference2)]
+                    else:
+                        x_vals2_plot = x_vals2
+                        y_vals2_plot = reference2
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.plot(
+                        x_vals2_plot.tolist(), y_vals2_plot, 
+                        marker=ref_color_dict['marker'], 
+                        c=ref_color_dict['color'], mew=2., mec='white', 
+                        figure=fig, ms=ref_color_dict['markersize'], ls='dashed', 
+                        lw=ref_color_dict['linewidth']
+                    )
+                    plotted_reference[1] = True
+            else:
+                if connect_points:
+                    x_vals2_plot = x_vals2[~np.isnan(y_vals_metric2)]
+                    y_vals2_plot = y_vals_metric2[~np.isnan(y_vals_metric2)]
+                else:
+                    x_vals2_plot = x_vals2
+                    y_vals2_plot = y_vals_metric2
+                plt.plot(
+                    x_vals2_plot.tolist(), y_vals2_plot, 
+                    marker=mod_setting_dicts[m]['marker'], 
+                    c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                    figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='dashed',
+                    lw=mod_setting_dicts[m]['linewidth']
+                )
+        if confidence_intervals:
+            if plot_reference[0]:
+                if not plotted_reference_CIs[0]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.errorbar(
+                        x_vals1.tolist(), reference1, 
+                        yerr=[np.abs(reference_ci_lower1), reference_ci_upper1], 
+                        fmt='none', ecolor=ref_color_dict['color'], 
+                        elinewidth=ref_color_dict['linewidth'],
+                        capsize=10., capthick=ref_color_dict['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+                    plotted_reference_CIs[0] = True
+            else:
+                plt.errorbar(
+                    x_vals1.tolist(), y_vals_metric1, 
+                    yerr=[np.abs(y_vals_ci_lower1), y_vals_ci_upper1], 
+                    fmt='none', ecolor=mod_setting_dicts[m]['color'], 
+                    elinewidth=mod_setting_dicts[m]['linewidth'],
+                    capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                    alpha=.70, zorder=0
+                )
+            if metric2_name is not None:
+                if plot_reference[1]:
+                    if not plotted_reference_CIs[1]:
+                        ref_color_dict = model_colors.get_color_dict('obs')
+                        plt.errorbar(
+                            x_vals2.tolist(), reference2, 
+                            yerr=[np.abs(reference_ci_lower2), reference_ci_upper2], 
+                            fmt='none', ecolor=ref_color_dict['color'], 
+                            elinewidth=ref_color_dict['linewidth'],
+                            capsize=10., capthick=ref_color_dict['linewidth'],
+                            alpha=.70, zorder=0
+                        )
+                        plotted_reference_CIs[1] = True
+                else:
+                    plt.errorbar(
+                        x_vals2.tolist(), y_vals_metric2, 
+                        yerr=[np.abs(y_vals_ci_lower2), y_vals_ci_upper2], 
+                        fmt='none', ecolor=mod_setting_dicts[m]['color'], 
+                        elinewidth=mod_setting_dicts[m]['linewidth'],
+                        capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+        handles+=[
+            f(
+                mod_setting_dicts[m]['marker'], mod_setting_dicts[m]['color'],
+                'solid', mod_setting_dicts[m]['linewidth'], 
+                mod_setting_dicts[m]['markersize'], 'white'
+            )
+        ]
+        if display_averages:
+            if metric2_name is not None:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string},'
+                    + f' {metric2_mean_fmt_string})'
+                ]
+            else:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string})'
+                ]
+        else:
+            labels+=[f'{model_plot_name}']
+
+    # Zero line
+    plt.axhline(y=0, color='black', linestyle='--', linewidth=1, zorder=0) 
+    metrics_with_axline_at_1 = [
+        'FBIAS','RSD'
+    ]
+    if (str(metric1_name).upper() in metrics_with_axline_at_1 
+            or str(metric2_name).upper() in metrics_with_axline_at_1):
+        plt.axhline(y=1, color='black', linestyle='--', linewidth=1, zorder=0)
+
+    # Configure axis ticks
+    if not x_lim_lock:
+        if metric2_name is not None:
+            xticks_min = np.min([x_vals1.tolist()[0], x_vals2.tolist()[0]])
+            xticks_max = np.max([x_vals1.tolist()[-1], x_vals2.tolist()[-1]])
+        else:
+            xticks_min = x_vals1.tolist()[0]
+            xticks_max = x_vals1.tolist()[-1]
+    else:
+        xticks_min = x_min_limit
+        xticks_max = x_max_limit
+    xticks = [
+        x_val for x_val in np.arange(xticks_min, xticks_max+incr, incr)
+    ] 
+    xtick_labels = [str(xtick) for xtick in xticks]
+    if len(xticks) < 48:
+        show_xtick_every = 1
+    else:
+        show_xtick_every = 2
+    xtick_labels_with_blanks = ['' for item in xtick_labels]
+    for i, item in enumerate(xtick_labels[::int(show_xtick_every)]):
+         xtick_labels_with_blanks[int(show_xtick_every)*i] = item
+    x_buffer_size = .015
+    ax.set_xlim(
+        xticks_min-incr*x_buffer_size, xticks_max+incr*x_buffer_size
+    )
+    y_range_categories = np.array([
+        [np.power(10.,y), 2.*np.power(10.,y)] 
+        for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+    ]).flatten()
+    round_to_nearest_categories = y_range_categories/20.
+    if math.isinf(y_min):
+        y_min = y_min_limit
+    if math.isinf(y_max):
+        y_max = y_max_limit
+    y_range = y_max-y_min
+    round_to_nearest =  round_to_nearest_categories[
+        np.digitize(y_range, y_range_categories[:-1])
+    ]
+    ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
+    ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
+    if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
+        ylim_min = float(
+            np.format_float_scientific(ylim_min, unique=False, precision=3)
+        )
+    yticks = np.arange(ylim_min, ylim_max+round_to_nearest, round_to_nearest)
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    units = df['FCST_UNITS'].tolist()[0]
+    if unit_convert:
+        if fcst_thresh and '' not in fcst_thresh:
+            fcst_thresh_labels = [float(tlab) for tlab in fcst_thresh_labels]
+            fcst_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    fcst_thresh_labels,
+                    rounding=True
+                )
+            )
+            fcst_thresh_labels = [str(tlab) for tlab in fcst_thresh_labels]
+        if obs_thresh and '' not in obs_thresh:
+            obs_thresh_labels = [float(tlab) for tlab in obs_thresh_labels]
+            obs_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    obs_thresh_labels,
+                    rounding=True
+                )
+            )
+            obs_thresh_labels = [str(tlab) for tlab in obs_thresh_labels]
+        units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    if metric2_name is not None:
+        metric1_string, metric2_string = metric_long_names
+        if (str(metric1_name).upper() in metrics_using_var_units
+                and str(metric2_name).upper() in metrics_using_var_units):
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string} and {metric2_string}'
+    else:
+        metric1_string = metric_long_names[0]
+        if str(metric1_name).upper() in metrics_using_var_units:
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string}'
+    ax.set_ylim(ylim_min, ylim_max)
+    ax.set_ylabel(ylabel)
+    ax.set_xlabel(xlabel) 
+    ax.set_xticklabels(xtick_labels_with_blanks)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', axis='y', pad=15
+    )
+    majticks = [i for i, item in enumerate(xtick_labels_with_blanks) if item]
+    for mt in majticks:
+        ax.xaxis.get_major_ticks()[mt].tick1line.set_markersize(8)
+
+    ax.legend(
+        handles, labels, loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=4, frameon=True, numpoints=2, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    #fig.subplots_adjust(bottom=.2, wspace=0, hspace=0)
+    fig.subplots_adjust(bottom=.15, wspace=0, hspace=0)
+    fig.subplots_adjust(top=0.85) 
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.5, linestyle='--', 
+        linewidth=.5, zorder=0
+    )
+
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        for count, xval in zip(counts, x_vals1.tolist()):
+            if not isinstance(count, str):
+                count = str(int(count))
+            ax.annotate(
+                f'{count}', xy=(xval,1.), 
+                xycoords=('data', 'axes fraction'), xytext=(0,18),
+                textcoords='offset points', va='top', fontsize=16,
+                color='dimgrey', ha='center'
+            )
+        ax.annotate(
+            '#SAMPLES', xy=(0.,1.), xycoords='axes fraction',
+            xytext=(-50, 21), textcoords='offset points', va='top', 
+            fontsize=11, color='dimgrey', ha='center'
+        )
+        #fig.subplots_adjust(top=.9)
+        fig.subplots_adjust(top=.85)
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = ''
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = ''
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'ML'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level_num}MB_'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'SB'
+        else:
+            level_string = ''
+            level_savename = ''
+    #Binbin add pres, anom
+    elif str(verif_type).lower() in ['sfc', 'conus_sfc', 'polar_sfc', 'mrms', 'metar', 'pres', 'anom']:
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = ''
+                else:
+                    level_string = 'Surface '
+                    level_savename = 'SFC_'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM_'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level_num}M_'
+        elif 'L' in str(level) or 'A' in str(level):
+            level_string = ''
+            level_savename = ''
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}_'
+    elif str(verif_type).lower() in ['ccpa']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'{level_num}H_'
+        else:
+            level_string = f''
+            level_savename = f''
+    else:
+        level_string = f'{level}'
+        level_savename = f'{level}_'
+    if var_savename == 'ICEC_Z0_mean':
+        level_string = ''
+    if var_savename == 'TMP_Z0_mean':
+        level_string = 'Sea Surface '
+    if metric2_name is not None:
+        title1 = f'{metric1_string} and {metric2_string}'
+    else:
+        title1 = f'{metric1_string}'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    fcst_thresh_on = (fcst_thresh and '' not in fcst_thresh)
+    obs_thresh_on = (obs_thresh and '' not in obs_thresh)
+    if metric1_string == 'Brier Score':
+        fcst_thresh_on = False
+        obs_thresh_on = False
+    if fcst_thresh_on:
+        fcst_thresholds_phrase = ', '.join([
+            f'{opt}{fcst_thresh_label}' 
+            for fcst_thresh_label in fcst_thresh_labels
+        ])
+        fcst_thresholds_save_phrase = ''.join([
+            f'{opt_letter}{fcst_thresh_label}' 
+            for fcst_thresh_label in requested_fcst_thresh_labels
+        ])
+    if obs_thresh_on:
+        obs_thresholds_phrase = ', '.join([
+            f'obs{opt}{obs_thresh_label}' 
+            for obs_thresh_label in obs_thresh_labels
+        ])
+        obs_thresholds_save_phrase = ''.join([
+            f'obs{opt_letter}{obs_thresh_label}'
+            for obs_thresh_label in requested_obs_thresh_labels
+        ])
+    if fcst_thresh_on:
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({fcst_thresholds_phrase} '
+                      + f'{units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({fcst_thresholds_phrase} '
+                      + f'unitless), {domain_string}')
+    elif obs_thresh_on:
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({obs_thresholds_phrase} '
+                      + f'{units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({obs_thresholds_phrase} '
+                      + f'unitless), {domain_string}')
+    else:
+        if units:
+            title2 = f'{level_string}{var_long_name} ({units}), {domain_string}'
+        else:
+            title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    if sample_equalization:
+        #title_pad=40
+        title_pad=30
+    else:
+        title_pad=None
+    ax.set_title(title_center, loc=plotter.title_loc, pad=title_pad)
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction', 
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.), xycoords='axes fraction', 
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'lead_average_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(level_savename).lower()}'
+                 + f'{str(var_savename).lower()}_{str(metric1_name).lower()}')
+    if metric2_name is not None:
+        save_name+=f'_{str(metric2_name).lower()}'
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    if fcst_thresh_on:
+        save_name+=f'_{str(fcst_thresholds_save_phrase).lower()}'
+    elif obs_thresh_on:
+        save_name+=f'_{str(obs_thresholds_save_phrase).lower()}'
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+    
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: {X_MIN_LIMIT}")
+    logger.debug(f"X_MAX_LIMIT: {X_MAX_LIMIT}")
+    logger.debug(f"X_LIM_LOCK: {X_LIM_LOCK}")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    if len(METRICS) == 1:
+        metrics = (METRICS[0], None)
+    elif len(METRICS) > 1:
+        metrics = METRICS[:2]
+    else:
+        e = (f"FATAL ERROR: Received no list of metrics.  Check that, for the METRICS"
+             + f" setting, a comma-separated string of at least one metric is"
+             + f" provided")
+        logger.error(e)
+        raise ValueError(e)
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e)
+    if (str(INTERP).upper()
+            not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e)
+    for metric in metrics:
+        if metric is not None:
+            if (str(metric).lower()
+                    not in case_specs['plot_stats_list']
+                    .replace(' ','').split(',')):
+                e = (f"FATAL ERROR: The requested metric is not valid for the"
+                     + f" requested case type ({VERIF_CASETYPE}) and"
+                     + f" line_type ({LINE_TYPE}): {metric}")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e)
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            fcst_okay = (
+                fcst_thresh in var_specs['fcst_var_thresholds'] 
+            )
+            obs_okay = (
+                obs_thresh in var_specs['obs_var_thresholds'] 
+            )
+            if (fcst_okay and obs_okay):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            fcst_okay = (
+                fcst_thresh in var_specs['fcst_var_thresholds']
+            )
+            obs_okay = (
+                obs_thresh in var_specs['obs_var_thresholds']
+            )
+            if (fcst_okay and obs_okay):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for l, fcst_level in enumerate(FCST_LEVELS):
+            if len(FCST_LEVELS) != len(OBS_LEVELS):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e)
+            if (FCST_LEVELS[l] not in var_specs['fcst_var_levels'] 
+                    or OBS_LEVELS[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid: "
+                        + f"{requested_var}/{fcst_level}")
+                logger.warning(e)
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the requested"
+                         + f" case type ({VERIF_CASETYPE}) and line_type"
+                         + f" ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    date_hours, FLEADS, requested_var, fcst_var_names, obs_var_names, 
+                    MODELS, domain, INTERP, MET_VERSION, clear_prune_dir
+                )
+                if df is None:
+                    continue
+                df_metric = df
+                plot_lead_average(
+                    df_metric, logger, date_range, MODELS, num=num, 
+                    flead=FLEADS, level=fcst_level, fcst_thresh=fcst_thresh, 
+                    obs_thresh=obs_thresh,
+                    metric1_name=metrics[0], metric2_name=metrics[1], 
+                    date_type=DATE_TYPE, y_min_limit=Y_MIN_LIMIT, 
+                    y_max_limit=Y_MAX_LIMIT, y_lim_lock=Y_LIM_LOCK, 
+                    x_min_limit=X_MIN_LIMIT, x_max_limit=X_MAX_LIMIT, 
+                    x_lim_lock=X_LIM_LOCK, xlabel=f'Forecast Lead Hour', 
+                    verif_type=VERIF_TYPE, line_type=LINE_TYPE, 
+                    date_hours=date_hours, save_dir=SAVE_DIR, 
+                    eval_period=EVAL_PERIOD, display_averages=display_averages, 
+                    save_header=URL_HEADER, plot_group=plot_group, 
+                    confidence_intervals=CONFIDENCE_INTERVALS, 
+                    interp_pts=INTERP_PNTS, bs_nrep=bs_nrep, 
+                    bs_method=bs_method, ci_lev=ci_lev, 
+                    bs_min_samp=bs_min_samp, 
+                    sample_equalization=sample_equalization,
+                    plot_logo_left=plot_logo_left, 
+                    plot_logo_right=plot_logo_right, 
+                    path_logo_left=path_logo_left, 
+                    path_logo_right=path_logo_right,
+                    zoom_logo_left=zoom_logo_left,
+                    zoom_logo_right=zoom_logo_right,
+                    delete_intermed_data=delete_intermed_data
+                )
+                num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = list(filter(None, check_STATS(os.environ['STATS']).replace(' ','').split(',')))
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+    X_MIN_LIMIT = toggle.plot_settings['x_min_limit']
+    X_MAX_LIMIT = toggle.plot_settings['x_max_limit']
+    X_LIM_LOCK = toggle.plot_settings['x_lim_lock']
+
+
+    # configure CIs
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_method = toggle.plot_settings['bs_method']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove 
+    # samples used to aggregate each statistic if the samples are not shared 
+    # by all models.  Required to display sample sizes 
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    delete_intermed_data = toggle.plot_settings['delete_intermed_data']
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    FCST_LEVELS = [str(level) for level in FCST_LEVELS]
+    OBS_LEVELS = [str(level) for level in OBS_LEVELS]
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/performance_diagram.py
+++ b/ush/cam/ush_refs_plot_py/performance_diagram.py
@@ -1,0 +1,1423 @@
+#! /usr/bin/env python3
+
+
+###############################################################################
+#
+# Name:          performance_diagram.py
+# Contact(s):    Marcel Caron
+# Developed:     Nov. 22, 2021 by Marcel Caron 
+# Last Modified: Jun. 3, 2022 by Marcel Caron             
+# Title:         Line plot of verification metric as a function of 
+#                forecast threshold
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                varying by forecast threshold, which represents the x-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+
+
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(24., 14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def get_bias_label_position(bias_value, radius):
+    x = np.sqrt(np.power(radius, 2)/(np.power(bias_value, 2)+1))
+    y = np.sqrt(np.power(radius, 2) - np.power(x, 2))
+    return (x, y)
+
+def plot_performance_diagram(df: pd.DataFrame, logger: logging.Logger, 
+                      date_range: tuple, model_list: list, num: int = 0, 
+                      level: str = '500', flead='all', thresh: list = ['<20'], 
+                      metric1_name: str = 'SRATIO', metric2_name: str = 'POD', 
+                      metric3_name: str = 'CSI', date_type: str = 'VALID', 
+                      date_hours: list = [0,6,12,18], verif_type: str = 'pres', 
+                      line_type: str = 'CTC', save_dir: str = '.', dpi: int = 100, 
+                      confidence_intervals: bool = False, interp_pts: list = [], 
+                      bs_nrep: int = 5000, 
+                      bs_method: str = 'MATCHED_PAIRS', ci_lev: float = .95, 
+                      bs_min_samp: int = 30, eval_period: str = 'TEST', 
+                      display_averages: bool = True, save_header: str = '', 
+                      plot_group: str = 'sfc_upper',
+                      sample_equalization: bool = True,
+                      plot_logo_left: bool = False,
+                      plot_logo_right: bool = False, path_logo_left: str = '.',
+                      path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                      zoom_logo_right: float = 1.):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+
+    if (str(metric1_name).upper() != 'SRATIO' 
+            or str(metric2_name).upper() != 'POD' 
+            or str(metric3_name).upper() != 'CSI'):
+        w1 = (f"The performance diagram may not plot correctly unless the"
+              + f" order of metrics provided is \'SRATIO\', \'POD\', and"
+              + f" \'CSI\'.")
+        w2 = (f"The order provided is \'{metric1_name}\', \'{metric2_name}\',"
+              + f" and \'{metric3_name}\'.")
+        w3 = "Continuing ..."
+        logger.warning(w1)
+        logger.warning(w2)
+        logger.warning(w3)
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    if str(line_type).upper() == 'CTC' and np.array(thresh).size == 0:
+        logger.warning(f"Empty list of thresholds. Continuing onto next"
+                       + f" plot...")
+        logger.info("========================================")
+        return None
+
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
+            frange_save_phrase = f'{flead[0]}_TO_F{flead[-1]}'
+        frange_string = f'Forecast Hour{frange_phrase}'
+        frange_save_string = f'F{frange_save_phrase}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        frange_string = (f'Forecast Hours {flead[0]:02d}'+u'\u2013'
+                         + f'{flead[1]:02d}')
+        frange_save_string = f'F{flead[0]:02d}-F{flead[1]:02d}'
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        frange_string = f'Forecast Hour {flead:02d}'
+        frange_save_string = f'F{flead:02d}'
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads."
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(intep_pts, np.int):
+            interp_pts_string = f'(Wifth {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    requested_thresh_symbol, requested_thresh_letter = list(
+        zip(*[plot_util.format_thresh(t) for t in thresh])
+    )
+    symbol_found = False
+    for opt in ['>=', '>', '==','!=','<=', '<']: 
+        if any(opt in t for t in requested_thresh_symbol):
+            if all(opt in t for t in requested_thresh_symbol):
+                symbol_found = True
+                opt_letter = requested_thresh_letter[0][:2]
+                break
+            else:
+                e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                    + f" thresholds.")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+    if not symbol_found:
+        e = "FATAL ERROR: None of the requested thresholds contain a valid symbol."
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+
+    df_thresh_symbol, df_thresh_letter = list(
+        zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+    )
+    df['FCST_THRESH_SYMBOL'] = df_thresh_symbol
+    df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_thresh_letter]
+    requested_thresh_value = [
+        str(item)[2:] for item in requested_thresh_letter
+    ]
+    df = df[df['FCST_THRESH_SYMBOL'].isin(requested_thresh_symbol)]
+    thresholds_removed = (
+        np.array(requested_thresh_symbol)[
+            ~np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+        ]
+    )
+    requested_thresh_symbol = (
+        np.array(requested_thresh_symbol)[
+            np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+        ]
+    )
+    if thresholds_removed.size > 0:
+        thresholds_removed_string = ', '.join(thresholds_removed)
+        if len(thresholds_removed) > 1:
+            warning_string = (f"{thresholds_removed_string} thresholds were"
+                              + f" not found and will not be plotted.")
+        else:
+            warning_string = (f"{thresholds_removed_string} threshold was"
+                              + f" not found and will not be plotted.")
+        logger.warning(warning_string)
+        logger.warning("Continuing ...")
+
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model)
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL','FCST_THRESH_VALUE']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    df_aggregated = df_groups.sum()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    # Remove data if they exist for some but not all models at some value of 
+    # the indep. variable. Otherwise plot_util.calculate_stat will throw an 
+    # error
+    df_split = [df_aggregated.xs(str(model)) for model in model_list]
+    df_reduced = reduce(
+        lambda x,y: pd.merge(
+            x, y, on='FCST_THRESH_VALUE', how='inner'
+        ), 
+        df_split
+    )
+    df_aggregated = df_aggregated[
+        df_aggregated.index.get_level_values('FCST_THRESH_VALUE')
+        .isin(df_reduced.index)
+    ]
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    # Calculate desired metric
+    metric_long_names = []
+    for metric_name in [metric1_name, metric2_name, metric3_name]:
+        stat_output = plot_util.calculate_stat(
+            logger, df_aggregated, str(metric_name).lower(), [None, None]
+        )
+        df_aggregated[str(metric_name).upper()] = stat_output[0]
+        metric_long_names.append(stat_output[2])
+        if confidence_intervals:
+            ci_output = df_groups.apply(
+                lambda x: plot_util.calculate_bootstrap_ci(
+                    logger, bs_method, x, str(metric_name).lower(), bs_nrep,
+                    ci_lev, bs_min_samp, [None, None]
+                )
+            )
+            if any(ci_output['STATUS'] == 1):
+                logger.warning(f"Failed attempt to compute bootstrap"
+                               + f" confidence intervals.  Sample size"
+                               + f" for one or more groups is too small."
+                               + f" Minimum sample size can be changed"
+                               + f" in settings.py.")
+                logger.warning(f"Confidence intervals will not be"
+                               + f" plotted.")
+                confidence_intervals = False
+                continue
+            ci_output = ci_output.reset_index(level=2, drop=True)
+            ci_output = (
+                ci_output
+                .reindex(df_aggregated.index)
+                .reindex(ci_output.index)
+            )
+            df_aggregated[str(metric_name).upper()+'_BLERR'] = ci_output[
+                'CI_LOWER'
+            ].values
+            df_aggregated[str(metric_name).upper()+'_BUERR'] = ci_output[
+                'CI_UPPER'
+            ].values
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    df_aggregated[str(metric2_name).upper()] = (
+        df_aggregated[str(metric2_name).upper()]
+    ).astype(float).tolist()
+    df_aggregated[str(metric3_name).upper()] = (
+        df_aggregated[str(metric3_name).upper()]
+    ).astype(float).tolist()
+
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index='FCST_THRESH_VALUE'
+    )
+    pivot_metric2 = pd.pivot_table(
+        df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+        index='FCST_THRESH_VALUE'
+    )
+    pivot_metric3 = pd.pivot_table(
+        df_aggregated, values=str(metric3_name).upper(), columns='MODEL', 
+        index='FCST_THRESH_VALUE'
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index='FCST_THRESH_VALUE'
+        )
+    pivot_metric1 = pivot_metric1.dropna() 
+    pivot_metric2 = pivot_metric2.dropna() 
+    pivot_metric3 = pivot_metric3.dropna() 
+    all_thresh_idx = np.unique(
+        np.concatenate([
+            pivot_metric1.index, 
+            pivot_metric2.index, 
+            pivot_metric3.index
+        ])
+    )
+    all_model_col = np.unique(
+        np.concatenate([
+            pivot_metric1.columns,
+            pivot_metric2.columns,
+            pivot_metric3.columns
+        ])
+    )
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_lower2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_upper2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        all_ci_thresh_idx = np.unique(
+            np.concatenate([
+                pivot_ci_lower1.index,
+                pivot_ci_upper1.index,
+                pivot_ci_lower2.index,
+                pivot_ci_upper2.index
+            ])
+        )
+        
+    for thresh_idx in all_thresh_idx:
+        if np.any([
+                thresh_idx not in pivot_metric.index for pivot_metric 
+                in [pivot_metric1, pivot_metric2, pivot_metric3]]):
+            pivot_metric1.drop(
+                labels=thresh_idx, inplace=True, errors='ignore'
+            )
+            pivot_metric2.drop(
+                labels=thresh_idx, inplace=True, errors='ignore'
+            )
+            pivot_metric3.drop(
+                labels=thresh_idx, inplace=True, errors='ignore'
+            )
+            if sample_equalization:
+                pivot_counts.drop(
+                    labels=thresh_idx, inplace=True, errors='ignore'
+                )
+    if confidence_intervals:
+        for ci_thresh_idx in all_ci_thresh_idx:
+            if np.any([
+                    ci_thresh_idx not in pivot_metric.index for pivot_metric
+                    in [pivot_metric1, pivot_metric2, pivot_metric3]]):
+                pivot_ci_lower1.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper1.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+                pivot_ci_lower2.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper2.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+    models_in_pivot_metric = []
+    for model_col in all_model_col:
+        if np.any([
+                model_col not in pivot_metric.columns for pivot_metric
+                in [pivot_metric1, pivot_metric2, pivot_metric3]]):
+            pivot_metric1.drop(
+                columns=model_col, inplace=True, errors='ignore'
+            )
+            pivot_metric2.drop(
+                columns=model_col, inplace=True, errors='ignore'
+            )
+            pivot_metric3.drop(
+                columns=model_col, inplace=True, errors='ignore'
+            )
+            if sample_equalization:
+                pivot_counts.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+            if confidence_intervals:
+                pivot_ci_lower1.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper1.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+                pivot_ci_lower2.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper2.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+        else:
+            models_in_pivot_metric.append(model_col)
+    cols_to_keep = [
+        str(model)
+        in models_in_pivot_metric 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were all NaNs and will not be"
+            + f" plotted."
+        )
+    if pivot_metric1.empty or pivot_metric2.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any threshold. "
+        )
+        logger.warning(
+            f"This may occur if no forecast or observed events were counted "
+            + f"at any threshold for any model, so that all performance "
+            + f"statistics are undefined. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        print(
+            "Continuing due to missing data.  Check the log file for details."
+        )
+        return None
+
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected = False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model'
+                    )!=-1):
+                    need_to_rename = models_sharing_colors[np.flatnonzero(
+                        np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1
+                    )[0]]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model' + str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+
+    # Plot data
+    logger.info("Begin plotting ...")
+    gray_colors = [
+        '#ffffff',
+        '#f5f5f5',
+        '#ececec',
+        '#dfdfdf',
+        '#cbcbcb',
+        '#b2b2b2',
+        '#8e8e8e',
+        '#6f6f6f',
+        '#545454',
+        '#3f3f3f',
+    ]
+
+    cmap = colors.ListedColormap(gray_colors)
+    grid_ticks = np.arange(0.001, 1.001, 0.001)
+    sr_g, pod_g = np.meshgrid(grid_ticks, grid_ticks)
+    bias = pod_g / sr_g
+    csi = 1.0 / (1.0 / sr_g + 1.0 / pod_g - 1.0)
+    bias_contour_vals = [
+        0.1, 0.2, 0.4, 0.6, 0.8, 1., 1.2, 1.5, 2., 3., 5., 10.
+    ]
+    b_contour = plt.contour(
+        sr_g, pod_g, bias, bias_contour_vals, 
+        colors='gray', linestyles='dashed'
+    )
+    csi_contour = plt.contourf(
+        sr_g, pod_g, csi, np.arange(0., 1.1, 0.1), cmap=cmap, extend='neither'
+    )
+    plt.clabel(
+        b_contour, fmt='%1.1f', 
+        manual=[
+            get_bias_label_position(bias_value, .75) 
+            for bias_value in bias_contour_vals
+        ]
+    )
+    y_min = 0.
+    y_max = 1.
+    thresh_labels = pivot_metric1.index
+    thresh_argsort = np.argsort(thresh_labels.astype(float))
+    requested_thresh_argsort = np.argsort([
+        float(item) for item in requested_thresh_value
+    ])
+    thresh_labels = [thresh_labels[i] for i in thresh_argsort]
+    requested_thresh_labels = [
+        requested_thresh_value[i] for i in requested_thresh_argsort
+    ]
+    thresh_markers = [
+        ('o',12),('P',14),('^',14),('X',14),('s',12),('D',12),('v',14),
+        ('p',14),('<',14),('d',14),(r'$\spadesuit$',14),('>',14),
+        (r'$\clubsuit$',14)
+    ]
+    if len(thresh_labels)+len(model_list) > 12:
+        e = (f"The plot legend may be cut off.  Consider reducing the number"
+             + f" of models or thresholds and rerunning the plotting job.")
+        logger.warning(e)
+        logger.warning("Continuing ...")
+    if len(thresh_labels) > len(thresh_markers):
+        e = (f"FATAL ERROR: Too many thresholds were requested.  Only {len(thresh_markers)}"
+             + f" or fewer thresholds may be plotted.")
+        logger.error(e)
+        logger.error("Quitting ...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    units = df['FCST_UNITS'].tolist()[0]
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'PROB_MXUPHL25_A24_GEHWT':
+        units = 'decimal'
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m', 'gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        if unit_convert:
+            thresh_labels = [float(tlab) for tlab in thresh_labels]
+            thresh_labels = reference.unit_conversions[units]['formula'](
+                thresh_labels,
+                rounding=True
+            )
+            thresh_diff_categories = np.array([
+                [np.power(10., y)]
+                for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+            ]).flatten()
+            precision_scale_indiv_mult = [
+                thresh_diff_categories[item]
+                for item in np.digitize(thresh_labels, thresh_diff_categories)
+            ]
+            precision_scale_collective_mult = 100/min(precision_scale_indiv_mult)
+            precision_scale = np.multiply(
+                precision_scale_indiv_mult, precision_scale_collective_mult
+            )
+            thresh_labels = [
+                f'{np.round(tlab)/precision_scale[t]}'
+                for t, tlab in enumerate(
+                    np.multiply(thresh_labels, precision_scale)
+                )
+            ]
+            units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms)[0]
+    handles = [
+        f(
+            thresh_markers[i][0], 'white','solid',0.,thresh_markers[i][1], 
+            'black'
+        ) for i, item in enumerate(thresh_labels)
+    ]
+    labels = [
+        f'{opt}{thresh_label} {units}'
+        for thresh_label in thresh_labels
+    ]
+    
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        counts = [
+            str(int(count)) if not isinstance(count,str) else count 
+            for count in counts
+        ]
+        labels = [
+            label+f' ({counts[l]})' 
+            for l, label in enumerate(labels)
+        ]
+    
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        x_vals = [
+            pivot_metric1[str(model_list[m])].values[i] 
+            for i in thresh_argsort
+        ]
+        y_vals = [
+            pivot_metric2[str(model_list[m])].values[i] 
+            for i in thresh_argsort
+        ]
+        mosaic_vals = pivot_metric3[str(model_list[m])].values
+        x_mean = np.nanmean(x_vals)
+        y_mean = np.nanmean(y_vals)
+        mosaic_mean = np.nanmean(mosaic_vals)
+        if confidence_intervals:
+            x_vals_ci_lower = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            x_vals_ci_upper = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            y_vals_ci_lower = pivot_ci_lower2[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper = pivot_ci_upper2[
+                str(model_list[m])
+            ].values
+        if display_averages:
+            metric_mean_fmt_string = (f'{model_plot_name} ({x_mean:.2f},'
+                                      + f' {y_mean:.2f}, {mosaic_mean:.2f})')
+        else:
+            metric_mean_fmt_string = f'{model_plot_name}'
+        plt.plot(
+            x_vals, y_vals, marker='None', c=mod_setting_dicts[m]['color'], 
+            mew=2., mec='white', figure=fig, ms=0, 
+            ls=mod_setting_dicts[m]['linestyle'], 
+            lw=mod_setting_dicts[m]['linewidth']
+        )
+        for i, item in enumerate(x_vals):
+            plt.scatter(
+                x_vals[i], y_vals[i], marker=thresh_markers[i][0], 
+                c=mod_setting_dicts[m]['color'], linewidths=2., 
+                edgecolors='white', figure=fig, s=thresh_markers[i][1]**2,
+                zorder=10
+            )
+        if confidence_intervals:
+            pc = plotter.get_error_boxes(
+                x_vals, y_vals, [x_vals_ci_lower, x_vals_ci_upper],
+                [y_vals_ci_lower, y_vals_ci_upper], 
+                ec=mod_setting_dicts[m]['color'],
+                ls=mod_setting_dicts[m]['linestyle'], lw=2.
+            )
+            ax.add_collection(pc)
+        handles+=[
+            f(
+                '', mod_setting_dicts[m]['color'], 
+                mod_setting_dicts[m]['linestyle'], 
+                2*mod_setting_dicts[m]['linewidth'], 0, 'white'
+            )
+        ]
+        labels+=[f'{metric_mean_fmt_string}']
+
+    # Configure axis ticks
+    xticks_min = 0.
+    xticks_max = 1.
+    incr = .1
+    xticks = [
+        x_val for x_val in np.arange(xticks_min, xticks_max+incr, incr)
+    ] 
+    xtick_labels = [f'{xtick:.1f}' for xtick in xticks]
+    x_buffer_size = .015
+    ax.set_xlim(
+        xticks_min-incr*x_buffer_size, xticks_max+incr*x_buffer_size
+    )
+    yticks_min = 0.
+    yticks_max = 1.
+    yticks = [
+        y_val for y_val in np.arange(yticks_min, yticks_max+incr, incr)
+    ] 
+    ytick_labels = [f'{ytick:.1f}' for ytick in yticks]
+    y_buffer_size = .015
+    ax.set_ylim(
+        yticks_min-incr*y_buffer_size, yticks_max+incr*y_buffer_size
+    )
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR','SPREAD',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    ax.set_ylabel(f'{metric_long_names[1]}')
+    ax.set_xlabel(f'{metric_long_names[0]}') 
+    ax.set_xticklabels(xtick_labels)
+    ax.set_yticklabels(ytick_labels)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', pad=15
+    )
+
+    ax.legend(
+        handles, labels, loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=5, frameon=True, numpoints=1, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.35, linestyle='--', 
+        linewidth=.5, c='black', zorder=0
+    )
+
+    #fig.subplots_adjust(bottom=.2, right=.77, left=.23, wspace=0, hspace=0)
+    fig.subplots_adjust(bottom=.15, right=.77, left=.23, wspace=0, hspace=0)
+    fig.subplots_adjust(top=0.85)
+    cax = fig.add_axes([.775, .2, .01, .725])
+    cbar_ticks = [0.,.1,.2,.3,.4,.5,.6,.7,.8,.9,1.]
+    cb = plt.colorbar(
+        csi_contour, orientation='vertical', cax=cax, ticks=cbar_ticks,
+        spacing='uniform', drawedges=True
+    )
+    cb.dividers.set_color('black')
+    cb.dividers.set_linewidth(2)
+    cb.ax.tick_params(
+        labelsize=8, labelright=True, labelleft=False, right=False
+    )
+    cb.ax.set_yticklabels(
+        [f'{cbar_tick:.1f}' for cbar_tick in cbar_ticks], 
+        fontdict={'fontsize': 12}
+    )
+    cax.hlines([0, 1], 0, 1, colors='black', linewidth=4)
+    cb.set_label(f'{metric_long_names[2]}')
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = ''
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = ''
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'ML'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level_num}MB_'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'SB'
+        else:
+            level_string = ''
+            level_savename = ''
+    elif (str(verif_type).lower() 
+            in ['sfc', 'conus_sfc', 'polar_sfc', 'mrms', 'metar']):
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = ''
+                else:
+                    level_string = 'Surface '
+                    level_savename = 'SFC_'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM_'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level_num}M_'
+        elif 'L' in str(level) or 'A' in str(level):
+            level_string = ''
+            level_savename = ''
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}_'
+    elif str(verif_type).lower() in ['ccpa']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'{level_num}H_'
+        else:
+            level_string = f''
+            level_savename = f''
+    else:
+        level_string = f'{level} '
+        level_savename = f'{level}_'
+    if var_savename == 'ICEC_Z0_mean':
+        level_string = ''
+    thresholds_phrase = ', '.join([
+        f'{opt}{thresh_label}' for thresh_label in thresh_labels
+    ])
+    thresholds_save_phrase = ''.join([
+        f'{opt_letter}{thresh_label}' 
+        for thresh_label in requested_thresh_labels
+    ])
+    thresholds_string = f'Forecast Thresholds {thresholds_phrase}'
+    title1 = f'Performance Diagram'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    if not units:
+        title2 = (f'{level_string}{var_long_name} (unitless), {domain_string}')
+    else:
+        title2 = (f'{level_string}{var_long_name} ({units}), {domain_string}')
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}, {frange_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    ax.set_title(title_center, loc=plotter.title_loc) 
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left*.8)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.07), xycoords='axes fraction',
+                xybox=(0, 3), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right*.8)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.07), xycoords='axes fraction',
+                xybox=(0, 3), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'performance_diagram_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(level_savename).lower()}'
+                 + f'{str(var_savename).lower()}')
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    save_name+=f'_{str(frange_save_string).lower()}_'
+    save_name+=f'_{str(thresholds_save_phrase).lower()}'
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: Ignored for performance diagrams")
+    logger.debug(f"X_MAX_LIMIT: Ignored for performance diagrams")
+    logger.debug(f"X_LIM_LOCK: Ignored for performance_diagrams")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    metrics = METRICS
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e)
+    if (str(INTERP).upper()
+           not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    for metric in metrics:
+        if (str(metric).lower()
+                not in case_specs['plot_stats_list']
+                .replace(' ','').split(',')):
+            e = (f"FATAL ERROR: The requested metric is not valid for the"
+                 + f" requested case type ({VERIF_CASETYPE}) and"
+                 + f" line_type ({LINE_TYPE}): {metric}")
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e+"\nQuitting ...")
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds'] 
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds'] 
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for l, fcst_level in enumerate(FCST_LEVELS):
+            if len(FCST_LEVELS) != len(OBS_LEVELS):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+            if (FCST_LEVELS[l] not in var_specs['fcst_var_levels'] 
+                    or OBS_LEVELS[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid:"
+                     + f" {requested_var}/{fcst_level}")
+                logger.warning(e)
+                logger.warning("Continuing ...")
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the"
+                         + f" requested case type ({VERIF_CASETYPE}) and"
+                         + f" line_type ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    date_hours, FLEADS, requested_var, fcst_var_names, 
+                    obs_var_names, MODELS, domain, INTERP, MET_VERSION, 
+                    clear_prune_dir
+                )
+                if df is None:
+                    continue
+                for metric in metrics:
+                    if (str(metric).lower()
+                            not in case_specs['plot_stats_list']
+                            .replace(' ','').split(',')):
+                        e = (f"The requested metric is not valid for the"
+                             + f" requested case type ({VERIF_CASETYPE}) and"
+                             + f" line_type ({LINE_TYPE}): {metric}")
+                        logger.warning(e)
+                        logger.warning("Continuing ...")
+                        continue
+                df_metric = df
+                plot_performance_diagram(
+                    df_metric, logger, date_range, MODELS, num=num, 
+                    flead=FLEADS, level=fcst_level, thresh=fcst_thresh, 
+                    metric1_name=metrics[0], metric2_name=metrics[1],
+                    metric3_name=metrics[2], date_type=DATE_TYPE,  
+                    verif_type=VERIF_TYPE, line_type=LINE_TYPE, 
+                    date_hours=date_hours, save_dir=SAVE_DIR, 
+                    eval_period=EVAL_PERIOD, 
+                    display_averages=display_averages, save_header=URL_HEADER,
+                    plot_group=plot_group, 
+                    confidence_intervals=CONFIDENCE_INTERVALS, 
+                    interp_pts=INTERP_PNTS,
+                    bs_nrep=bs_nrep, bs_method=bs_method, ci_lev=ci_lev, 
+                    bs_min_samp=bs_min_samp,
+                    sample_equalization=sample_equalization,
+                    plot_logo_left=plot_logo_left,
+                    plot_logo_right=plot_logo_right,
+                    path_logo_left=path_logo_left,
+                    path_logo_right=path_logo_right,
+                    zoom_logo_left=zoom_logo_left,
+                    zoom_logo_right=zoom_logo_right
+                )
+                num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = check_STATS(os.environ['STATS']).replace(' ','').split(',')[:3]
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+
+
+    # Still need to configure CIs (doesn't work yet)
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    bs_method = toggle.plot_settings['bs_method']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove
+    # samples used to aggregate each statistic if the samples are not shared
+    # by all models.  Required to display sample sizes
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    FCST_LEVELS = [str(level) for level in FCST_LEVELS]
+    OBS_LEVELS = [str(level) for level in OBS_LEVELS]
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/plot_util.py
+++ b/ush/cam/ush_refs_plot_py/plot_util.py
@@ -1,0 +1,2229 @@
+#! /usr/bin/env python3
+
+import pickle
+import os
+import sys
+import datetime as datetime
+import time
+import numpy as np
+import pandas as pd
+import warnings
+warnings.filterwarnings('ignore')
+"""!@namespace plot_util
+   @brief Provides utility functions for METplus plotting use case
+"""
+
+def get_date_arrays(date_type, date_beg, date_end,
+                    fcst_valid_hour, fcst_init_hour,
+                    obs_valid_hour, obs_init_hour,
+                    lead):
+   '''! Create arrays of requested dates plotting and 
+        dates expected to be in MET .stat files
+
+        Args:
+           date_type                - string of describing the treatment
+                                      of dates, either VALID or INIT
+           date_beg                 - string of beginning date,
+                                      either blank or %Y%m%d format
+           date_end                 - string of end date,
+                                      either blank or %Y%m%d format
+           fcst_valid_hour          - string of forecast valid hour(s)
+                                      information, blank or in %H%M%S
+           fcst_init_hour           - string of forecast init hour(s)
+                                      information, blank or in %H%M%S
+           obs_valid_hour           - string of observation valid hour(s)
+                                      information, blank or in %H%M%S
+           obs_init_hour            - string of observation hour(s)
+                                      information, blank or in %H%M%S
+           lead                     - string of forecast lead, in %H%M%S
+                                      format
+        Returns
+           plot_time_dates          - array of ordinal dates based on user 
+                                      provided information
+           expected_stat_file_dates - array of dates that are expected to
+                                      be found in the MET .stat files
+                                      based on user provided information,
+                                      formatted as %Y%m%d_%H%M%S
+   '''
+   lead_hour_seconds = int(int(lead[:-4])%24) * 3600
+   lead_min_seconds = int(lead[-4:-2]) * 60
+   lead_seconds = int(lead[-2:])
+   valid_init_time_info = {
+      'fcst_valid_time': list(filter(None, fcst_valid_hour.split(', '))),
+      'fcst_init_time': list(filter(None, fcst_init_hour.split(', '))),
+      'obs_valid_time': list(filter(None, obs_valid_hour.split(', '))),
+      'obs_init_time': list(filter(None, obs_init_hour.split(', '))),
+   }
+   # Extract missing information, if possible
+   for type in ['fcst', 'obs']:
+      valid_time_list = valid_init_time_info[type+'_valid_time']
+      init_time_list = valid_init_time_info[type+'_init_time']
+      if (len(valid_time_list) == 0
+            and len(init_time_list) > 0):
+         for itime in init_time_list:
+            itime_hour_seconds = int(int(itime[0:2])%24) * 3600
+            itime_min_seconds = int(itime[2:4]) * 60
+            itime_seconds = int(itime[4:])
+            offset = datetime.timedelta(seconds=lead_hour_seconds
+                                                + lead_min_seconds
+                                                + lead_seconds
+                                                + itime_hour_seconds
+                                                + itime_min_seconds
+                                                + itime_seconds)
+            tot_sec = offset.total_seconds()
+            valid_hour = int(tot_sec//3600)
+            valid_min = int((tot_sec%3600) // 60)
+            valid_sec = int((tot_sec%3600)%60)
+            valid_time = (
+               str(valid_hour).zfill(2)
+               +str(valid_min).zfill(2)
+               +str(valid_sec).zfill(2)
+            )
+            valid_init_time_info[type+'_valid_time'].append(valid_time)
+      if (len(init_time_list) == 0
+            and len(valid_time_list) > 0):
+         for vtime in valid_time_list:
+            vtime_hour_seconds = int(int(vtime[0:2])%24) * 3600
+            vtime_min_seconds = int(vtime[2:4]) * 60
+            vtime_seconds = int(vtime[4:])
+            offset = datetime.timedelta(seconds=lead_hour_seconds
+                                                + lead_min_seconds
+                                                + lead_seconds
+                                                - vtime_hour_seconds
+                                                - vtime_min_seconds
+                                                - vtime_seconds)
+            tot_sec = offset.total_seconds()
+            init_hour = int(tot_sec//3600)
+            init_min = int((tot_sec%3600) // 60)
+            init_sec = int((tot_sec%3600)%60)
+            init_time = (
+               str(init_hour).zfill(2)
+               +str(init_min).zfill(2)
+               +str(init_sec).zfill(2)
+            )
+            valid_init_time_info[type+'_init_time'].append(init_time)
+   for type in ['valid', 'init']:
+      fcst_time_list = valid_init_time_info['fcst_'+type+'_time']
+      obs_time_list = valid_init_time_info['obs_'+type+'_time']
+      if len(fcst_time_list) == 0:
+         if len(obs_time_list) > 0:
+            valid_init_time_info['fcst_'+type+'_time'] = (
+               valid_init_time_info['obs_'+type+'_time']
+            )
+      if len(obs_time_list) == 0:
+         if len(fcst_time_list) > 0:
+            valid_init_time_info['obs_'+type+'_time'] = (
+               valid_init_time_info['fcst_'+type+'_time']
+            )
+   date_info = {}
+   for type in ['fcst_'+date_type.lower(),
+                'obs_'+date_type.lower()]:
+      time_list = valid_init_time_info[type+'_time']
+      if len(time_list) != 0:
+         time_beg = min(time_list)
+         time_end = max(time_list)
+         if time_beg == time_end or len(time_list) == 1:
+            delta_t = datetime.timedelta(seconds=86400)
+         else:
+            delta_t_list = []
+            for t in range(len(time_list)):
+               if time_list[t] == time_end:
+                  delta_t_list.append(
+                     (
+                        datetime.datetime.strptime('235959','%H%M%S')
+                        - (datetime.datetime.strptime(time_list[t],
+                                                      '%H%M%S'))
+                     )
+                     + datetime.timedelta(seconds=1)
+                  )
+               else:
+                  delta_t_list.append(
+                     datetime.datetime.strptime(time_list[t+1],
+                                                '%H%M%S')
+                     - datetime.datetime.strptime(time_list[t],
+                                                  '%H%M%S')
+                  )
+            delta_t_array = np.array(delta_t_list)
+            if np.all(delta_t_array == delta_t_array[0]):
+               delta_t = delta_t_array[0]
+            else:
+               delta_t = np.min(delta_t_array)
+         beg = datetime.datetime.strptime(
+            date_beg+time_beg, '%Y%m%d%H%M%S'
+         )
+         end = datetime.datetime.strptime(
+            date_end+time_end, '%Y%m%d%H%M%S'
+         )
+         dates = np.arange(
+            beg, end+delta_t,
+            delta_t
+         ).astype(datetime.datetime)
+      else:
+         dates = []
+      date_info[type+'_dates'] = dates
+   # Build opposite dates
+   if date_type == 'VALID':
+      oppo_date_type = 'INIT'
+   elif date_type == 'INIT':
+      oppo_date_type = 'VALID'
+   lead_timedelta = datetime.timedelta(
+      seconds=(int(int(lead[:-4])) * 3600 + lead_min_seconds
+               + lead_seconds)
+   )
+   if oppo_date_type == 'INIT':
+      lead_timedelta = -1 * lead_timedelta
+   for type in ['fcst', 'obs']:
+      date_info[type+'_'+oppo_date_type.lower()+'_dates'] = (
+         date_info[type+'_'+date_type.lower()+'_dates'] + lead_timedelta
+      )
+   # Use fcst_*_dates for dates
+   # this makes the assumption that
+   # fcst_*_dates and obs_*_dates
+   # are the same, and they should be for
+   # most cases
+   dates = date_info['fcst_'+date_type.lower()+'_dates']
+   fv_dates = date_info['fcst_valid_dates']
+   plot_time_dates = []
+   expected_stat_file_dates = []
+   for date in dates:
+      dt = date.time()
+      seconds = (dt.hour * 60 + dt.minute) * 60 + dt.second
+      plot_time_dates.append(dates.toordinal() + seconds/86400.)
+   # MET .stat files saves valid_dates in file
+   fv_dates = date_info['fcst_valid_dates']
+   expected_stat_file_dates = []
+   for fv_date in fv_dates:
+      expected_stat_file_dates.append(fv_date.strftime('%Y%m%d_%H%M%S'))
+   return plot_time_dates, expected_stat_file_dates
+
+def format_thresh(thresh):
+   """! Format thresholds for file naming
+      Args:
+         thresh         - string of the threshold(s)
+
+      Return:
+         thresh_symbol  - string of the threshold(s)
+                          with symbols
+         thresh_letters - string of the threshold(s)
+                          with letters
+   """
+   thresh_list = thresh.split(' ')
+   thresh_symbol = ''
+   thresh_letter = ''
+   for thresh in thresh_list:
+      if thresh == '':
+         continue
+      thresh_value = thresh
+      for opt in ['>=', '>', '==', '!=', '<=', '<',
+                  'ge', 'gt', 'eq', 'ne', 'le', 'lt']:
+         if opt in thresh_value:
+            thresh_opt = opt
+            thresh_value = thresh_value.replace(opt, '')
+      if thresh_opt in ['>', 'gt']:
+         thresh_symbol+='>'+thresh_value
+         thresh_letter+='gt'+thresh_value
+      elif thresh_opt in ['>=', 'ge']:
+         thresh_symbol+='>='+thresh_value
+         thresh_letter+='ge'+thresh_value
+      elif thresh_opt in ['<', 'lt']:
+         thresh_symbol+='<'+thresh_value
+         thresh_letter+='lt'+thresh_value
+      elif thresh_opt in ['<=', 'le']:
+         thresh_symbol+='<='+thresh_value
+         thresh_letter+='le'+thresh_value
+      elif thresh_opt in ['==', 'eq']:
+         thresh_symbol+='=='+thresh_value
+         thresh_letter+='eq'+thresh_value
+      elif thresh_opt in ['!=', 'ne']:
+         thresh_symbol+='!='+thresh_value
+         thresh_letter+='ne'+thresh_value
+   return thresh_symbol, thresh_letter
+
+def get_stat_file_base_columns(met_version):
+   """! Get the standard MET .stat file columns based on
+        version number
+
+           Args:
+              met_version            - string of MET version
+                                       number being used to
+                                       run stat_analysis
+
+           Returns:
+              stat_file_base_columns - list of the standard
+                                       columns shared among the 
+                                       different line types
+   """
+   met_version = float(met_version)
+   if met_version < 8.1:
+      stat_file_base_columns = [
+         'VERSION', 'MODEL', 'DESC', 'FCST_LEAD', 'FCST_VALID_BEG',
+         'FCST_VALID_END', 'OBS_LEAD', 'OBS_VALID_BEG', 'OBS_VALID_END',
+         'FCST_VAR', 'FCST_LEV', 'OBS_VAR', 'OBS_LEV', 'OBTYPE', 'VX_MASK',
+         'INTERP_MTHD', 'INTERP_PNTS', 'FCST_THRESH', 'OBS_THRESH', 
+         'COV_THRESH', 'ALPHA', 'LINE_TYPE'
+      ]
+   else:
+      stat_file_base_columns = [
+         'VERSION', 'MODEL', 'DESC', 'FCST_LEAD', 'FCST_VALID_BEG', 
+         'FCST_VALID_END', 'OBS_LEAD', 'OBS_VALID_BEG', 'OBS_VALID_END', 
+         'FCST_VAR', 'FCST_UNITS', 'FCST_LEV', 'OBS_VAR', 'OBS_UNITS', 
+         'OBS_LEV', 'OBTYPE', 'VX_MASK', 'INTERP_MTHD', 'INTERP_PNTS',
+         'FCST_THRESH', 'OBS_THRESH', 'COV_THRESH', 'ALPHA', 'LINE_TYPE'
+      ]
+   return stat_file_base_columns
+
+def get_stat_file_line_type_columns(logger, met_version, line_type):
+   """! Get the MET .stat file columns for line type based on 
+      version number
+         Args:
+            met_version - string of MET version number 
+                          being used to run stat_analysis
+            line_type   - string of the line type of the MET
+                          .stat file being read
+         Returns:
+            stat_file_line_type_columns - list of the line
+                                          type columns
+   """
+   met_version = float(met_version)
+   if line_type == 'SL1L2':
+      if met_version >= 6.0:
+         stat_file_line_type_columns = [
+            'TOTAL', 'FBAR', 'OBAR', 'FOBAR', 'FFBAR', 'OOBAR', 'MAE'
+         ]
+   elif line_type == 'SAL1L2':
+      if met_version >= 6.0:
+         stat_file_line_type_columns = [
+            'TOTAL', 'FABAR', 'OABAR', 'FOABAR', 'FFABAR', 'OOABAR', 'MAE'
+         ]
+   elif line_type == 'VL1L2':
+      if met_version >= 12.0:
+         stat_file_line_type_columns = [
+            'TOTAL', 'UFBAR', 'VFBAR', 'UOBAR', 'VOBAR', 'UVFOBAR',
+            'UVFFBAR', 'UVOOBAR', 'F_SPEED_BAR', 'O_SPEED_BAR', 'TOTAL_DIR',
+            'DIR_ME', 'DIR_MAE', 'DIR_MSE'
+         ]
+      elif met_version >= 7.0:
+         stat_file_line_type_columns = [
+            'TOTAL', 'UFBAR', 'VFBAR', 'UOBAR', 'VOBAR', 'UVFOBAR',
+            'UVFFBAR', 'UVOOBAR', 'F_SPEED_BAR', 'O_SPEED_BAR'
+         ]
+      elif met_version <= 6.1:
+         stat_file_line_type_columns = [
+            'TOTAL', 'UFBAR', 'VFBAR', 'UOBAR', 'VOBAR', 'UVFOBAR',
+            'UVFFBAR', 'UVOOBAR'
+         ]
+   elif line_type == 'VAL1L2':
+       if met_version >= 12.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'UFABAR', 'VFABAR', 'UOABAR', 'VOABAR', 'UVFOABAR', 
+            'UVFFABAR', 'UVOOABAR', 'FA_SPEED_BAR', 'OA_SPEED_BAR', 
+            'TOTAL_DIR', 'DIRA_ME', 'DIRA_MAE', 'DIRA_MSE'
+         ]
+       elif met_version >= 11.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'UFABAR', 'VFABAR', 'UOABAR', 'VOABAR', 'UVFOABAR', 
+            'UVFFABAR', 'UVOOABAR', 'FA_SPEED_BAR', 'OA_SPEED_BAR'
+         ]
+       elif met_version >= 6.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'UFABAR', 'VFABAR', 'UOABAR', 'VOABAR', 'UVFOABAR', 
+            'UVFFABAR', 'UVOOABAR'
+         ]
+   elif line_type == 'VCNT':
+       if met_version >= 12.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'FBAR', 'FBAR_BCL', 'FBAR_BCU', 'OBAR', 'OBAR_BCL', 
+            'OBAR_BCU', 'FS_RMS', 'FS_RMS_BCL', 'FS_RMS_BCU', 'OS_RMS',
+            'OS_RMS_BCL', 'OS_RMS_BCU', 'MSVE', 'MSVE_BCL', 'MSVE_BCU',
+            'RMSVE', 'RMSVE_BCL', 'RMSVE_BCU', 'FSTDEV', 'FSTDEV_BCL',
+            'FSTDEV_BCU', 'OSTDEV', 'OSTDEV_BCL', 'OSTDEV_BCU', 'FDIR', 
+            'FDIR_BCL', 'FDIR_BCU', 'ODIR', 'ODIR_BCL', 'ODIR_BCU', 
+            'FBAR_SPEED', 'FBAR_SPEED_BCL', 'FBAR_SPEED_BCU', 'OBAR_SPEED', 
+            'OBAR_SPEED_BCL', 'OBAR_SPEED_BCU', 'VDIFF_SPEED', 
+            'VDIFF_SPEED_BCL', 'VDIFF_SPEED_BCU', 'VDIFF_DIR',
+            'VDIFF_DIR_BCL', 'VDIFF_DIR_BCU', 'SPEED_ERR', 'SPEED_ERR_BCL',
+            'SPEED_ERR_BCU', 'SPEED_ABSERR', 'SPEED_ABSERR_BCL',
+            'SPEED_ABSERR_BCU', 'DIR_ERR', 'DIR_ERR_BCL', 'DIR_ERR_BCU',
+            'DIR_ABSERR', 'DIR_ABSERR_BCL', 'DIR_ABSERR_BCU', 'ANOM_CORR',
+            'ANOM_CORR_NCL', 'ANOM_CORR_NCU', 'ANOM_CORR_BCL', 'ANOM_CORR_BCU',
+            'ANOM_CORR_UNCNR', 'ANOM_CORR_UNCNTR_BCL', 'ANOM_CORR_UNCNTR_BCU',
+            'TOTAL_DIR', 'DIR_ME', 'DIR_ME_BCL', 'DIR_ME_BCU', 'DIR_MAE', 
+            'DIR_MAE_BCL', 'DIR_MAE_BCU', 'DIR_MSE', 'DIR_MSE_BCL', 
+            'DIR_MSE_BCU', 'DIR_RMSE', 'DIR_RMSE_BCL', 'DIR_RMSE_BCU'
+         ]
+       elif met_version >= 11.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'FBAR', 'FBAR_BCL', 'FBAR_BCU', 'OBAR', 'OBAR_BCL', 
+            'OBAR_BCU', 'FS_RMS', 'FS_RMS_BCL', 'FS_RMS_BCU', 'OS_RMS',
+            'OS_RMS_BCL', 'OS_RMS_BCU', 'MSVE', 'MSVE_BCL', 'MSVE_BCU',
+            'RMSVE', 'RMSVE_BCL', 'RMSVE_BCU', 'FSTDEV', 'FSTDEV_BCL',
+            'FSTDEV_BCU', 'OSTDEV', 'OSTDEV_BCL', 'OSTDEV_BCU', 'FDIR', 
+            'FDIR_BCL', 'FDIR_BCU', 'ODIR', 'ODIR_BCL', 'ODIR_BCU', 
+            'FBAR_SPEED', 'FBAR_SPEED_BCL', 'FBAR_SPEED_BCU', 'OBAR_SPEED', 
+            'OBAR_SPEED_BCL', 'OBAR_SPEED_BCU', 'VDIFF_SPEED', 
+            'VDIFF_SPEED_BCL', 'VDIFF_SPEED_BCU', 'VDIFF_DIR',
+            'VDIFF_DIR_BCL', 'VDIFF_DIR_BCU', 'SPEED_ERR', 'SPEED_ERR_BCL',
+            'SPEED_ERR_BCU', 'SPEED_ABSERR', 'SPEED_ABSERR_BCL',
+            'SPEED_ABSERR_BCU', 'DIR_ERR', 'DIR_ERR_BCL', 'DIR_ERR_BCU',
+            'DIR_ABSERR', 'DIR_ABSERR_BCL', 'DIR_ABSERR_BCU', 'ANOM_CORR',
+            'ANOM_CORR_NCL', 'ANOM_CORR_NCU', 'ANOM_CORR_BCL', 'ANOM_CORR_BCU',
+            'ANOM_CORR_UNCNT', 'ANOM_CORR_UNCNTR_BCL', 'ANOM_CORR_UNCNTR_BCU'
+         ]
+       elif met_version >= 7.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'FBAR', 'FBAR_NCL', 'FBAR_NCU', 'OBAR', 'OBAR_NCL', 
+            'OBAR_NCU', 'FS_RMS', 'FS_RMS_NCL', 'FS_RMS_NCU', 'OS_RMS',
+            'OS_RMS_NCL', 'OS_RMS_NCU', 'MSVE', 'MSVE_NCL', 'MSVE_NCU',
+            'RMSVE', 'RMSVE_NCL', 'RMSVE_NCU', 'FSTDEV', 'FSTDEV_NCL',
+            'FSTDEV_NCU', 'OSTDEV', 'OSTDEV_NCL', 'OSTDEV_NCU', 'FDIR', 
+            'FDIR_NCL', 'FDIR_NCU', 'ODIR', 'ODIR_NCL', 'ODIR_NCU', 
+            'FBAR_SPEED', 'FBAR_SPEED_NCL', 'FBAR_SPEED_NCU', 'OBAR_SPEED', 
+            'OBAR_SPEED_NCL', 'OBAR_SPEED_NCU', 'VDIFF_SPEED', 
+            'VDIFF_SPEED_NCL', 'VDIFF_SPEED_NCU', 'VDIFF_DIR',
+            'VDIFF_DIR_NCL', 'VDIFF_DIR_NCU', 'SPEED_ERR', 'SPEED_ERR_NCL',
+            'SPEED_ERR_NCU', 'SPEED_ABSERR', 'SPEED_ABSERR_NCL',
+            'SPEED_ABSERR_NCU', 'DIR_ERR', 'DIR_ERR_NCL', 'DIR_ERR_NCU',
+            'DIR_ABSERR', 'DIR_ABSERR_NCL', 'DIR_ABSERR_NCU'
+         ]
+       else:
+          logger.error("FATAL ERROR: VCNT is not a valid LINE_TYPE in METV"+met_version)
+          exit(1)
+   elif line_type == 'CTC':
+       if met_version >= 11.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'FY_OY', 'FY_ON', 'FN_OY', 'FN_ON', 'EC_VALUE'
+         ]
+       elif met_version >= 6.0:
+          stat_file_line_type_columns = [
+            'TOTAL', 'FY_OY', 'FY_ON', 'FN_OY', 'FN_ON'
+         ]
+   elif line_type == 'NBRCNT':
+      if met_version >= 6.0:
+         stat_file_line_type_columns = [
+            'TOTAL', 'FBS', 'FBS_BCL', 'FBS_BCU', 'FSS', 'FSS_BCL', 'FSS_BCU',
+            'AFSS', 'AFSS_BCL', 'AFSS_BCU', 'UFSS', 'UFSS_BCL', 'UFSS_BCU',
+            'F_RATE', 'F_RATE_BCL', 'F_RATE_BCU',
+            'O_RATE', 'O_RATE_BCL', 'O_RATE_BCU'
+         ]
+   elif line_type == 'ECNT':
+      if met_version >= 12.0:
+         stat_file_line_type_columns = [
+             'TOTAL', 'N_ENS', 'CRPS', 'CRPSS', 'IGN', 'ME', 'RMSE', 'SPREAD',
+             'ME_OERR', 'RMSE_OERR', 'SPREAD_OERR', 'SPREAD_PLUS_OERR',
+             'CRPSCL', 'CRPS_EMP', 'CRPSCL_EMP', 'CRPSS_EMP',
+             'CRPS_EMP_FAIR', 'SPREAD_MD', 'MAE', 'MAE_OERR', 'BIAS_RATIO',
+             'N_GE_OBS', 'ME_GE_OBS', 'N_LT_OBS', 'ME_LT_OBS', 'IGN_CONV_OERR',
+             'IGN_CORR_OERR'
+         ] 
+      elif met_version >= 11.0:
+         stat_file_line_type_columns = [
+             'TOTAL', 'N_ENS', 'CRPS', 'CRPSS', 'IGN', 'ME', 'RMSE', 'SPREAD',
+             'ME_OERR', 'RMSE_OERR', 'SPREAD_OERR', 'SPREAD_PLUS_OERR',
+             'CRPSCL', 'CRPS_EMP', 'CRPSCL_EMP', 'CRPSS_EMP',
+             'CRPS_EMP_FAIR', 'SPREAD_MD', 'MAE', 'MAE_OERR', 'BIAS_RATIO',
+             'N_GE_OBS', 'ME_GE_OBS', 'N_LT_OBS', 'ME_LT_OBS'
+         ] 
+      else:
+         stat_file_line_type_columns = [
+            'TOTAL', 'N_ENS', 'CRPS', 'CRPSS', 'IGN', 'ME', 'RMSE', 'SPREAD',
+            'ME_OERR', 'RMSE_OERR', 'SPREAD_OERR', 'SPREAD_PLUS_OERR',
+            'CRPSCL', 'CRPS_EMP', 'CRPSCL_EMP', 'CRPSS_EMP'
+         ]
+   elif line_type == 'PSTD':
+      if met_version >= 6.0:
+         stat_file_line_type_columns = [
+            'TOTAL', 'N_THRESH', 'BASER', 'BASER_NCL', 'BASER_NCU', 'RELIABILITY',
+            'RESOLUTION', 'UNCERTAINTY', 'ROC_AUC', 'BRIER', 'BRIER_NCL', 'BRIER_NCU',
+            'BRIERCL', 'BRIERCL_NCL', 'BRIERCL_NCU', 'BSS', 'BSS_SMPL',
+            'THRESH_1', 'THRESH_2', 'THRESH_3', 'THRESH_4', 'THRESH_5', 'THRESH_6',
+            'THRESH_7', 'THRESH_8', 'THRESH_9', 'THRESH_10', 'THRESH_11'
+         ]
+   return stat_file_line_type_columns
+
+def get_clevels(data, spacing):
+   """! Get contour levels for plotting differences
+        or bias (centered on 0)
+           Args:
+              data    - array of data to be contoured
+              spacing - float for spacing for power function,
+                        value of 1.0 gives evenly spaced
+                        contour intervals
+           Returns:
+              clevels - array of contour levels
+   """
+   if np.abs(np.nanmin(data)) > np.nanmax(data):
+      cmax = np.abs(np.nanmin(data))
+      cmin = np.nanmin(data)
+   else:
+      cmax = np.nanmax(data)
+      cmin = -1 * np.nanmax(data)
+   if cmax > 100:
+      cmax = cmax - (cmax * 0.2)
+      cmin = cmin + (cmin * 0.2)
+   elif cmax > 10:
+      cmax = cmax - (cmax * 0.1)
+      cmin = cmin + (cmin * 0.1)
+   if cmax > 1:
+      cmin = round(cmin-1,0)
+      cmax = round(cmax+1,0)
+   else:
+      cmin = round(cmin-.1,1)
+      cmax = round(cmax+.1,1)
+   steps = 6
+   span = cmax
+   dx = 1. / (steps-1)
+   pos = np.array([0 + (i*dx)**spacing*span for i in range(steps)],
+                   dtype=float)
+   neg = np.array(pos[1:], dtype=float) * -1
+   clevels = np.append(neg[::-1], pos)
+   return clevels
+
+def calculate_average(logger, average_method, stat, model_dataframe,
+                      model_stat_values):
+   """! Calculate average of dataset
+      Args:
+         logger               - logging file
+         average_method       - string of the method to
+                                use to calculate the average
+         stat                 - string of the statistic the
+                                average is being taken for
+         model_dataframe      - dataframe of model .stat
+                                columns
+         model_stat_values    - array of statistic values
+      Returns:
+         average_array        - array of average value(s)
+   """
+   average_array = np.empty_like(model_stat_values[:,0])
+   if average_method == 'MEAN':
+      for l in range(len(model_stat_values[:, 0])):
+         average_array[l] = np.ma.mean(model_stat_values[l,:])
+   elif average_method == 'MEDIAN':
+      for l in range(len(model_stat_values[:,0])):
+         logger.info(np.ma.median(model_stat_values[l,:]))
+         average_array[l] = np.ma.median(model_stat_values[l,:])
+   elif average_method == 'AGGREGATION':
+      ndays = model_dataframe.shape[0]
+      model_dataframe_aggsum = (
+         model_dataframe.groupby('model_plot_name').agg(['sum'])
+      )
+      model_dataframe_aggsum.columns = (
+         calculate_stat(logger, model_dataframe_aggsum/ndays, stat)
+      )
+      for l in range(len(avg_array[:,0])):
+         average_array[l] = avg_array[l]
+   else:
+      logger.error("FATAL ERROR: Invalid entry for MEAN_METHOD, "
+                   +"use MEAN, MEDIAN, or AGGREGATION")
+      sys.exit(1)
+   return average_array
+
+def calculate_ci(logger, ci_method, modelB_values, modelA_values, total_days,
+                 stat, average_method, randx):
+   """! Calculate confidence intervals between two sets of data
+      Args:
+         logger         - logging file
+         ci_method      - string of the method to use to
+                          calculate the confidence intervals
+         modelB_values  - array of values
+         modelA_values  - array of values
+         total_days     - float of total number of days 
+                          being considered, sample size
+         stat           - string of the statistic the
+                          confidence intervals are being
+                          calculated for
+         average_method - string of the method to 
+                          use to calculate the average
+         randx          - 2D array of random numbers [0,1)
+
+      Returns:
+         intvl          - float of the confidence interval
+   """
+   if ci_method == 'EMC':
+      modelB_modelA_diff = modelB_values - modelA_values
+      ndays = total_days - np.ma.count_masked(modelB_modelA_diff)
+      modelB_modelA_diff_mean = modelB_modelA_diff.mean()
+      modelB_modelA_std = np.sqrt(
+         ((modelB_modelA_diff - modelB_modelA_diff_mean)**2).mean()
+      )
+      if ndays >= 80:
+         intvl = 1.960*modelB_modelA_std/np.sqrt(ndays-1)
+      elif ndays >= 40 and ndays < 80:
+         intvl = 2.000*modelB_modelA_std/np.sqrt(ndays-1)
+      elif ndays >= 20 and ndays < 40:
+         intvl = 2.042*modelB_modelA_std/np.sqrt(ndays-1)
+      elif ndays < 20 and ndays > 0:
+         intvl = 2.228*modelB_modelA_std/np.sqrt(ndays-1)
+      elif ndays == 0:
+         intvl = '--'
+   elif ci_method == 'EMC_MONTE_CARLO':
+      ntest, ntests = 1, 10000
+      dates = []
+      for idx_val in modelB_values.index.values:
+         dates.append(idx_val[1])
+      ndays = len(dates)
+      rand1_data_index = pd.MultiIndex.from_product(
+         [['rand1'], np.arange(1, ntests+1, dtype=int), dates],
+         names=['model_plot_name', 'ntest', 'dates']
+      )
+      rand2_data_index = pd.MultiIndex.from_product(
+         [['rand2'], np.arange(1, ntests+1, dtype=int), dates],
+         names=['model_plot_name', 'ntest', 'dates']
+      )
+      rand1_data = pd.DataFrame(
+         np.nan, index = rand1_data_index, 
+         columns=modelB_values.columns
+      )
+      rand2_data = pd.DataFrame(
+         np.nan, index=rand2_data_index,
+         columns=modelB_values.columns
+      )
+      ncolumns = len(modelB_values.columns)
+      rand1_data_values = np.empty([ntests, ndays, ncolumns])
+      rand2_data_values = np.empty([ntests, ndays, ncolumns])
+      randx_ge0_idx = np.where(randx - 0.5 >= 0)
+      randx_lt0_idx = np.where(randx - 0.5 < 0)
+      rand1_data_values[randx_ge0_idx[0], randx_ge0_idx[1],:] = (
+         modelA_values.iloc[randx_ge0_idx[1],:]
+      )
+      rand2_data_values[randx_ge0_idx[0], randx_ge0_idx[1],:] = (
+         modelB_values.iloc[randx_ge0_idx[1],:]
+      )
+      rand1_data_values[randx_lt0_idx[0], randx_lt0_idx[1],:] = (
+         modelB_values.iloc[randx_lt0_idx[1],:]
+      )
+      rand2_data_values[randx_lt0_idx[0], randx_lt0_idx[1],:] = (
+         modelA_values.iloc[randx_lt0_idx[1],:]
+      )
+      ntest = 1
+      while ntest <= ntests:
+         rand1_data.loc[('rand1', ntest)] = rand1_data_values[ntest-1,:,:]
+         rand2_data.loc[('rand2', ntest)] = rand2_data_values[ntest-1,:,:]
+         ntest+=1
+      intvl = np.nan
+      rand1_stat_values, rand1_stat_values_array, stat_plot_name = (
+         calculate_stat(logger, rand1_data, stat)
+      )
+      rand2_stat_values, rand2_stat_values_array, stat_plot_name = (
+         calculate_stat(logger, rand2_data, stat)
+      )
+      rand1_average_array = (
+         calculate_average(logger, average_method, stat, rand1_data, 
+                           rand1_stat_values_array[0,0,:,:])
+      )
+      rand2_average_array = (
+         calculate_average(logger, average_method, stat, rand2_data,
+                           rand2_stat_values_array[0,0,:,:])
+      )
+      scores_diff = rand2_average_array - rand1_average_array
+      scores_diff_mean = np.sum(scores_diff)/ntests
+      scores_diff_var = np.sum((scores_diff-scores_diff_mean)**2)
+      scores_diff_std = np.sqrt(scores_diff_var/(ntests-1))
+      intvl = 1.96*scores_diff_std
+      
+   else:
+      logger.error("FATAL ERROR: Invalid entry for MAKE_CI_METHOD, "
+                   +"use EMC, EMC_MONTE_CARLO")
+      sys.exit(1)
+   return intvl
+
+def get_stat_plot_name(logger, stat):
+   """! Get the formalized name of the statistic being plotted
+      Args:
+         stat           - string of the simple statistic
+                          name being plotted
+      Returns:
+         stat_plot_name - string of the formal statistic
+                          name being plotted
+   """
+   if stat == 'bias':
+      stat_plot_name = 'Bias'
+   elif stat == 'rmse':
+      stat_plot_name = 'Root Mean Square Error'
+   elif stat == 'bcrmse':
+      stat_plot_name = 'Bias-Corrected Root Mean Square Error'
+   elif stat == 'msess':
+      stat_plot_name = "Murphy's Mean Square Error Skill Score"
+   elif stat == 'rsd':
+      stat_plot_name = 'Ratio of the Standard Deviation'
+   elif stat == 'rmse_md':
+      stat_plot_name = 'Root Mean Square Error from Mean Error'
+   elif stat == 'rmse_pv':
+      stat_plot_name = 'Root Mean Square Error from Pattern Variation'
+   elif stat == 'pcor':
+      stat_plot_name = 'Pattern Correlation'
+   elif stat == 'acc':
+      stat_plot_name = 'Anomaly Correlation Coefficient'
+   elif stat == 'fbar':
+      stat_plot_name = 'Forecast Averages'
+   elif stat == 'obar':
+      stat_plot_name = 'Observation Averages'
+   elif stat == 'fbar_obar':
+      stat_plot_name = 'Forecast and Observation Averages'
+   elif stat == 'fss':
+      stat_plot_name = 'Fractions Skill Score'
+   elif stat == 'afss':
+      stat_plot_name = 'Asymptotic Fractions Skill Score'
+   elif stat == 'ufss':
+      stat_plot_name = 'Uniform Fractions Skill Score'
+   elif stat == 'speed_err':
+      stat_plot_name = (
+         'Difference in Average FCST and OBS Wind Vector Speeds'
+      )
+   elif stat == 'dir_err':
+      stat_plot_name = (
+         'Difference in Average FCST and OBS Wind Vector Direction'
+      )
+   elif stat == 'rmsve':
+      stat_plot_name = 'Root Mean Square Difference Vector Error'
+   elif stat == 'vdiff_speed':
+      stat_plot_name = 'Difference Vector Speed'
+   elif stat == 'vdiff_dir':
+      stat_plot_name = 'Difference Vector Direction'
+   elif stat == 'fbar_obar_speed':
+      stat_plot_name = 'Average Wind Vector Speed'
+   elif stat == 'fbar_obar_dir':
+      stat_plot_name = 'Average Wind Vector Direction'
+   elif stat == 'fbar_speed':
+      stat_plot_name = 'Average Forecast Wind Vector Speed'
+   elif stat == 'fbar_dir':
+      stat_plot_name = 'Average Forecast Wind Vector Direction'
+   elif stat == 'orate':
+      stat_plot_name = 'Observation Rate'
+   elif stat == 'baser':
+      stat_plot_name = 'Base Rate'
+   elif stat == 'frate':
+      stat_plot_name = 'Forecast Rate'
+   elif stat == 'orate_frate':
+      stat_plot_name = 'Observation and Forecast Rates'
+   elif stat == 'baser_frate':
+      stat_plot_name = 'Base and Forecast Rates'
+   elif stat == 'accuracy':
+      stat_plot_name = 'Accuracy'
+   elif stat == 'fbias':
+      stat_plot_name = 'Frequency Bias'
+   elif stat == 'pod':
+      stat_plot_name = 'Probability of Detection'
+   elif stat == 'hrate':
+      stat_plot_name = 'Hit Rate'
+   elif stat == 'pofd':
+      stat_plot_name = 'Probability of False Detection'
+   elif stat == 'farate':
+      stat_plot_name = 'False Alarm Rate'
+   elif stat == 'podn':
+      stat_plot_name = 'Probability of Detection of the Non-Event'
+   elif stat == 'faratio':
+      stat_plot_name = 'False Alarm Ratio'
+   elif stat == 'sratio':
+      stat_plot_name = 'Success Ratio (1-FAR)'
+   elif stat == 'csi':
+      stat_plot_name = 'Critical Success Index'
+   elif stat == 'ts':
+      stat_plot_name = 'Threat Score'
+   elif stat == 'gss':
+      stat_plot_name = 'Gilbert Skill Score'
+   elif stat == 'ets':
+      stat_plot_name = 'Equitable Threat Score'
+   elif stat == 'hk':
+      stat_plot_name = 'Hanssen-Kuipers Discriminant'
+   elif stat == 'tss':
+      stat_plot_name = 'True Skill Score'
+   elif stat == 'pss':
+      stat_plot_name = 'Peirce Skill Score'
+   elif stat == 'hss':
+      stat_plot_name = 'Heidke Skill Score'
+   elif stat == 'crps':
+      stat_plot_name = 'Continuous Ranked Probability Score'
+   elif stat == 'crpss':
+      stat_plot_name = 'Continuous Ranked Probability Skill Score'
+   elif stat == 'spread':
+      stat_plot_name = 'Spread'
+   elif stat == 'me':
+      stat_plot_name = 'Mean Error (Bias)'
+   elif stat == 'mae':
+      stat_plot_name = 'Mean Absolute Error'
+   elif stat == 'bs':
+      stat_plot_name = 'Brier Score'
+   elif stat == 'roc_area':
+      stat_plot_name = 'ROC Area'
+   elif stat == 'bss':
+      stat_plot_name = 'Brier Skill Score'
+   elif stat == 'bss_smpl':
+      stat_plot_name = 'Brier Skill Score'
+   else:
+      logger.error("FATAL ERROR: "+stat+" is not a valid option")
+      sys.exit(1)
+   return stat_plot_name
+
+def calculate_bootstrap_ci(logger, bs_method, model_data, stat, nrepl, level, 
+                           bs_min_samp, conversion):
+   """! Calculate the upper and lower bound bootstrap statistic from the 
+        data from the read in MET .stat file(s)
+
+        Args:
+           bs_method         - string of the method to use to
+                               calculate the bootstrap confidence intervals
+           model_data        - Dataframe containing the model(s)
+                               information from the MET .stat
+                               files
+           stat              - string of the simple statistic
+                               name being plotted
+           nrepl             - integer of resamples that create the bootstrap
+                               distribution
+           level             - float confidence level (0.-1.) of the 
+                               confidence interval
+           bs_min_samp       - minimum number of samples allowed for 
+                               confidence intervals to be computed
+
+        Returns:
+           stat_values       - Dataframe of the statistic values lower and
+                               upper bounds
+           status            - integer to provide the parent script with 
+                               information about the outcome of the bootstrap 
+                               resampling
+   """
+   status=0
+   model_data.reset_index(inplace=True)
+   model_data_columns = model_data.columns.values.tolist()
+   if model_data_columns == [ 'TOTAL' ]:
+      logger.warning("Empty model_data dataframe")
+      line_type = 'NULL'
+      if (stat == 'fbar_obar' or stat == 'orate_frate'
+            or stat == 'baser_frate'):
+         stat_values = model_data.loc[:][['TOTAL']]
+         stat_values_fbar = model_data.loc[:]['TOTAL']
+         stat_values_obar = model_data.loc[:]['TOTAL']
+      else:
+         stat_values = model_data.loc[:]['TOTAL']
+   else:
+      if np.any(conversion):
+          bool_convert = True
+      else:
+          bool_convert = False
+      if all(elem in model_data_columns for elem in
+            ['FBAR', 'OBAR', 'MAE']):
+         line_type = 'SL1L2'
+         total = model_data.loc[:]['TOTAL']
+         fbar = model_data.loc[:]['FBAR']
+         obar = model_data.loc[:]['OBAR']
+         fobar = model_data.loc[:]['FOBAR']
+         ffbar = model_data.loc[:]['FFBAR']
+         oobar = model_data.loc[:]['OOBAR']
+         if bool_convert:
+             coef, const = conversion
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
+             fobar = (
+                np.power(coef, 2)*fobar
+                + coef*const*fbar_og
+                + coef*const*obar_og
+                + np.power(const, 2)
+             )
+             ffbar = (
+                np.power(coef, 2)*ffbar
+                + 2.*coef*const*fbar_og
+                + np.power(const, 2)
+             )
+             oobar = (
+                np.power(coef, 2)*oobar
+                + 2.*coef*const*obar_og
+                + np.power(const, 2)
+             )
+      elif all(elem in model_data_columns for elem in 
+            ['FABAR', 'OABAR', 'MAE']):
+         line_type = 'SAL1L2'
+         total = model_data.loc[:]['TOTAL']
+         fabar = model_data.loc[:]['FABAR']
+         oabar = model_data.loc[:]['OABAR']
+         foabar = model_data.loc[:]['FOABAR']
+         ffabar = model_data.loc[:]['FFABAR']
+         ooabar = model_data.loc[:]['OOABAR']
+         if bool_convert:
+             coef, const = conversion
+             fabar = coef*fabar
+             oabar = coef*oabar
+             foabar = (
+                np.power(coef, 2)*foabar
+             )
+             ffabar = (
+                np.power(coef, 2)*ffabar
+             )
+             ooabar = (
+                np.power(coef, 2)*ooabar
+             )
+      elif all(elem in model_data_columns for elem in
+            ['UFBAR', 'VFBAR']):
+         line_type = 'VL1L2'
+         total = model_data.loc[:]['TOTAL']
+         ufbar = model_data.loc[:]['UFBAR']
+         vfbar = model_data.loc[:]['VFBAR']
+         uobar = model_data.loc[:]['UOBAR']
+         vobar = model_data.loc[:]['VOBAR']
+         uvfobar = model_data.loc[:]['UVFOBAR']
+         uvffbar = model_data.loc[:]['UVFFBAR']
+         uvoobar = model_data.loc[:]['UVOOBAR']
+         if bool_convert:
+             coef, const = conversion
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
+             uvfobar = (
+                np.power(coef, 2)*uvfobar
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og)
+                + np.power(const, 2)
+             )
+             uvffbar = (
+                np.power(coef, 2)*uvffbar
+                + 2.*coef*const*(ufbar_og + vfbar_og)
+                + np.power(const, 2)
+             )
+             uvoobar = (
+                np.power(coef, 2)*uvoobar
+                + 2.*coef*const*(uobar_og + vobar_og)
+                + np.power(const, 2)
+             )
+      elif all(elem in model_data_columns for elem in 
+            ['UFABAR', 'VFABAR']):
+         line_type = 'VAL1L2'
+         total = model_data.loc[:]['TOTAL']
+         ufabar = model_data.loc[:]['UFABAR']
+         vfabar = model_data.loc[:]['VFABAR']
+         uoabar = model_data.loc[:]['UOABAR']
+         voabar = model_data.loc[:]['VOABAR']
+         uvfoabar = model_data.loc[:]['UVFOABAR']
+         uvffabar = model_data.loc[:]['UVFFABAR']
+         uvooabar = model_data.loc[:]['UVOOABAR']
+         if bool_convert:
+             coef, const = conversion
+             ufabar = coef*ufabar
+             vfabar = coef*vfabar
+             uoabar = coef*uoabar
+             voabar = coef*voabar
+             uvfoabar = (
+                np.power(coef, 2)*uvfoabar
+             )
+             uvffabar = (
+                np.power(coef, 2)*uvffabar
+             )
+             uvooabar = (
+                np.power(coef, 2)*uvooabar
+             )
+      elif all(elem in model_data_columns for elem in
+            ['VDIFF_SPEED', 'VDIFF_DIR']):
+         line_type = 'VCNT'
+         total = model_data.loc[:]['TOTAL']
+         fbar = model_data.loc[:]['FBAR']
+         obar = model_data.loc[:]['OBAR']
+         fs_rms = model_data.loc[:]['FS_RMS']
+         os_rms = model_data.loc[:]['OS_RMS']
+         msve = model_data.loc[:]['MSVE']
+         rmsve = model_data.loc[:]['RMSVE']
+         fstdev = model_data.loc[:]['FSTDEV']
+         ostdev = model_data.loc[:]['OSTDEV']
+         fdir = model_data.loc[:]['FDIR']
+         odir = model_data.loc[:]['ODIR']
+         fbar_speed = model_data.loc[:]['FBAR_SPEED']
+         obar_speed = model_data.loc[:]['OBAR_SPEED']
+         vdiff_speed = model_data.loc[:]['VDIFF_SPEED']
+         vdiff_dir = model_data.loc[:]['VDIFF_DIR']
+         speed_err = model_data.loc[:]['SPEED_ERR']
+         dir_err = model_data.loc[:]['DIR_ERR']
+         if bool_convert:
+             logger.error(
+                f"FATAL ERROR: Cannot convert columns for line_type \"{line_type}\""
+             )
+             exit(1)
+      elif all(elem in model_data_columns for elem in
+            ['FY_OY', 'FN_ON']):
+         line_type = 'CTC'
+         total = model_data.loc[:]['TOTAL']
+         fy_oy = model_data.loc[:]['FY_OY']
+         fy_on = model_data.loc[:]['FY_ON']
+         fn_oy = model_data.loc[:]['FN_OY']
+         fn_on = model_data.loc[:]['FN_ON']
+      elif all(elem in model_data_columns for elem in
+            ['FBS','FSS','AFSS','UFSS','F_RATE','O_RATE']):
+         line_type = 'NBRCNT'
+         total = model_data.loc[:]['TOTAL']
+         fbs = model_data.loc[:]['FBS']
+         fss = model_data.loc[:]['FSS']
+         afss = model_data.loc[:]['AFSS']
+         ufss = model_data.loc[:]['UFSS']
+         frate = model_data.loc[:]['F_RATE']
+         orate = model_data.loc[:]['O_RATE']
+      #new add for ECNT:
+      elif all(elem in model_data_columns for elem in   
+            ['CRPS', 'CRPSS', 'RMSE', 'SPREAD', 'ME', 'MAE']):                     
+         line_type = 'ECNT'
+         total  = model_data.loc[:]['TOTAL']
+         crps   = model_data.loc[:]['CRPS']
+         crpss  = model_data.loc[:]['CRPSS']
+         rmse   = model_data.loc[:]['RMSE']
+         spread = model_data.loc[:]['SPREAD']
+         me = model_data.loc[:]['ME']
+         mae = model_data.loc[:]['MAE']
+         if bool_convert:
+             coef, const = conversion
+             rmse = coef*rmse
+             spread = coef*spread
+             me = coef*me
+             mae = np.abs(coef)*mae
+      else:
+         logger.error("FATAL ERROR: Could not recognize line type from columns")
+         sys.exit(1)
+   if str(bs_method).upper() == 'MATCHED_PAIRS':
+      if total.sum() < bs_min_samp:
+         logger.warning(f"Sample too small for bootstrapping. (Matched pairs"
+                        + f" sample size: {total.sum()}; minimum sample"
+                        + f" size: {bs_min_samp}")
+         status = 1
+         return pd.DataFrame(
+            dict(CI_LOWER=[np.nan], CI_UPPER=[np.nan], STATUS=[status])
+         )
+      lower_pctile = 100.*((1.-level)/2.)
+      upper_pctile = 100.-lower_pctile
+      if line_type == 'CTC':
+         fy_oy_all = fy_oy.sum()
+         fy_on_all = fy_on.sum()
+         fn_oy_all = fn_oy.sum()
+         fn_on_all = fn_on.sum()
+         total_all = total.sum()
+         ctc_all = np.array([fy_oy_all, fy_on_all, fn_oy_all, fn_on_all])
+         prob_ctc_all = ctc_all/total_all.astype(float)
+         # sample over events in the aggregated contingency table
+         fy_oy_samp,fy_on_samp,fn_oy_samp,fn_on_samp = np.random.multinomial(
+            total_all, 
+            prob_ctc_all, 
+            size=nrepl
+         ).T
+      elif line_type == 'SL1L2':
+         fo_matched_est = []
+         fvar = ffbar-fbar*fbar
+         ovar = oobar-obar*obar
+         focovar = fobar-fbar*obar
+         for i, _ in enumerate(total):
+            fo_matched_est_i = np.random.multivariate_normal(
+               [fbar[i], obar[i]], 
+               [[fvar[i],focovar[i]],[focovar[i],ovar[i]]], 
+               size=int(total[i])
+            )
+            fo_matched_est.append(fo_matched_est_i)
+         fo_matched_est = np.vstack(fo_matched_est)
+         fbar_est_mean = fo_matched_est[:,0].mean()
+         obar_est_mean = fo_matched_est[:,1].mean()
+         fobar_est_mean = np.mean(np.prod(fo_matched_est, axis=1))
+         ffbar_est_mean = np.mean(fo_matched_est[:,0]*fo_matched_est[:,0])
+         oobar_est_mean = np.mean(fo_matched_est[:,1]*fo_matched_est[:,1])
+         max_mem_per_array = 32 # MB
+         max_array_size = max_mem_per_array*1E6/8
+         batch_size = int(max_array_size/len(fo_matched_est))
+         fbar_est_samples = []
+         obar_est_samples = []
+         fobar_est_samples = []
+         ffbar_est_samples = []
+         oobar_est_samples = []
+         # attempt to bootstrap in batches to save time
+         # if sampling array is too large for batches, traditional bootstrap
+         if batch_size <= 1:
+            for _ in range(nrepl):
+               fo_matched_indices = np.random.choice(
+                  len(fo_matched_est), 
+                  size=fo_matched_est.size, 
+                  replace=True
+               )
+               f_est_bs, o_est_bs = fo_matched_est[fo_matched_indices].T
+               fbar_est_samples.append(f_est_bs.mean())
+               obar_est_samples.append(o_est_bs.mean())
+               fobar_est_samples.append(np.mean(f_est_bs*o_est_bs))
+               ffbar_est_samples.append(np.mean(f_est_bs*f_est_bs))
+               oobar_est_samples.append(np.mean(o_est_bs*o_est_bs))
+            fbar_est_samp = np.array(fbar_est_samples)
+            obar_est_samp = np.array(obar_est_samples)
+            fobar_est_samp = np.array(fobar_est_samples)
+            ffbar_est_samp = np.array(ffbar_est_samples)
+            oobar_est_samp = np.array(oobar_est_samples)
+         else:
+            rep_arr = np.arange(0,nrepl)
+            for b in range(0, nrepl, batch_size):
+               curr_batch_size = len(rep_arr[b:b+batch_size])
+               idxs = [
+                  np.random.choice(
+                     len(fo_matched_est), 
+                     size=fo_matched_est.size, 
+                     replace=True
+                  ) 
+                  for _ in range(curr_batch_size)
+               ]
+               f_est_bs, o_est_bs = [
+                  np.take(fo_matched_est.T[i], idxs) for i in [0,1]
+               ]
+               fbar_est_samples.append(f_est_bs.mean(axis=1))
+               obar_est_samples.append(o_est_bs.mean(axis=1))
+               fobar_est_samples.append((f_est_bs*o_est_bs).mean(axis=1))
+               ffbar_est_samples.append((f_est_bs*f_est_bs).mean(axis=1))
+               oobar_est_samples.append((o_est_bs*o_est_bs).mean(axis=1))
+            fbar_est_samp = np.concatenate((fbar_est_samples))
+            obar_est_samp = np.concatenate((obar_est_samples))
+            fobar_est_samp = np.concatenate((fobar_est_samples))
+            ffbar_est_samp = np.concatenate((ffbar_est_samples))
+            oobar_est_samp = np.concatenate((oobar_est_samples))
+      else:
+         logger.error("FATAL ERROR: "+line_type+" is not currently a valid option")
+         sys.exit(1)
+   elif str(bs_method).upper() == 'FORECASTS':
+      if total.size < bs_min_samp:
+         logger.warning(f"Sample too small for bootstrapping. (Forecasts"
+                        + f" sample size: {total.size}; minimum sample"
+                        + f" size: {bs_min_samp}")
+         status = 1
+         return pd.DataFrame(
+            dict(CI_LOWER=[np.nan], CI_UPPER=[np.nan], STATUS=[status])
+         )
+      lower_pctile = 100.*((1.-level)/2.)
+      upper_pctile = 100.-lower_pctile
+      if line_type == 'CTC':
+         ctc = np.array([fy_oy, fy_on, fn_oy, fn_on])
+         fy_oy_samp, fy_on_samp, fn_oy_samp, fn_on_samp = [
+            [] for item in range(4)
+         ]
+         for _ in range(nrepl):
+            ctc_bs = ctc.T[
+               np.random.choice(
+                  range(len(ctc.T)), 
+                  size=len(ctc.T), 
+                  replace=True
+               )
+            ].sum(axis=0)
+            fy_oy_samp.append(ctc_bs[0])
+            fy_on_samp.append(ctc_bs[1])
+            fn_oy_samp.append(ctc_bs[2])
+            fn_on_samp.append(ctc_bs[3])
+         fy_oy_samp = np.array(fy_oy_samp)
+         fy_on_samp = np.array(fy_on_samp)
+         fn_oy_samp = np.array(fn_oy_samp)
+         fn_on_samp = np.array(fn_on_samp)
+      elif line_type == 'SL1L2':
+         fbar_est_mean = fbar.mean()
+         obar_est_mean = obar.mean()
+         fobar_est_mean = fobar.mean()
+         ffbar_est_mean = ffbar.mean()
+         oobar_est_mean = oobar.mean()
+         max_mem_per_array = 32 # MB
+         max_array_size = max_mem_per_array*1E6/8
+         batch_size = int(max_array_size/len(fbar))
+         fbar_samples = []
+         obar_samples = []
+         fobar_samples = []
+         ffbar_samples = []
+         oobar_samples = []
+         # attempt to bootstrap in batches to save time
+         # if sampling array is too large for batches, traditional bootstrap
+         if batch_size <= 1:
+            for _ in range(nrepl):
+               idx = np.random.choice(
+                  len(fbar), 
+                  size=fbar.size, 
+                  replace=True
+               )
+               fbar_bs, obar_bs, fobar_bs, ffbar_bs, oobar_bs = [
+                  summary_stat[idx].T 
+                  for summary_stat in [fbar, obar, fobar, ffbar, oobar]
+               ]
+               fbar_samples.append(fbar_bs.mean())
+               obar_samples.append(obar_bs.mean())
+               fobar_samples.append(fobar_bs.mean())
+               ffbar_samples.append(ffbar_bs.mean())
+               oobar_samples.append(oobar_bs.mean())
+            fbar_est_samp = np.array(fbar_samples)
+            obar_est_samp = np.array(obar_samples)
+            fobar_est_samp = np.array(fobar_samples)
+            ffbar_est_samp = np.array(ffbar_samples)
+            oobar_est_samp = np.array(oobar_samples)
+         else:
+            rep_arr = np.arange(0,nrepl)
+            for b in range(0, nrepl, batch_size):
+               curr_batch_size = len(rep_arr[b:b+batch_size])
+               idxs = [
+                  np.random.choice(
+                     len(fbar), 
+                     size=fbar.size, 
+                     replace=True
+                  ) 
+                  for _ in range(curr_batch_size)
+               ]
+               fbar_bs, obar_bs, fobar_bs, ffbar_bs, oobar_bs = [
+                  np.take(np.array(summary_stat), idxs) 
+                  for s, summary_stat in enumerate([fbar, obar, fobar, ffbar, oobar])
+               ]
+               fbar_samples.append(fbar_bs.mean(axis=1))
+               obar_samples.append(obar_bs.mean(axis=1))
+               fobar_samples.append(fobar_bs.mean(axis=1))
+               ffbar_samples.append(ffbar_bs.mean(axis=1))
+               oobar_samples.append(oobar_bs.mean(axis=1))
+            fbar_est_samp = np.concatenate((fbar_samples))
+            obar_est_samp = np.concatenate((obar_samples))
+            fobar_est_samp = np.concatenate((fobar_samples))
+            ffbar_est_samp = np.concatenate((ffbar_samples))
+            oobar_est_samp = np.concatenate((oobar_samples))
+      elif line_type == 'NBRCNT':
+         fbs_est_mean = fbs.mean()
+         fss_est_mean = fss.mean()
+         afss_est_mean = afss.mean()
+         ufss_est_mean = ufss.mean()
+         frate_est_mean = frate.mean()
+         orate_est_mean = orate.mean()
+         max_mem_per_array = 32 # MB
+         max_array_size = max_mem_per_array*1E6/8
+         batch_size = int(max_array_size/len(fbs))
+         fbs_samples = []
+         fss_samples = []
+         afss_samples = []
+         ufss_samples = []
+         frate_samples = []
+         orate_samples = []
+         # attempt to bootstrap in batches to save time
+         # if sampling array is too large for batches, traditional bootstrap
+         if batch_size <= 1:
+            for _ in range(nrepl):
+               idx = np.random.choice(
+                  len(fbs),
+                  size=fbs.size,
+                  replace=True
+               )
+               fbs_bs, fss_bs, afss_bs, ufss_bs, frate_bs, orate_bs = [
+                  summary_stat[idx].T
+                  for summary_stat in [fbs, fss, afss, ufss, frate, orate]
+               ]
+               fbs_samples.append(fbs_bs.mean())
+               fss_samples.append(fss_bs.mean())
+               afss_samples.append(afss_bs.mean())
+               ufss_samples.append(ufss_bs.mean())
+               frate_samples.append(frate_bs.mean())
+               orate_samples.append(orate_bs.mean())
+            fbs_est_samp = np.array(fbs_samples)
+            fss_est_samp = np.array(fss_samples)
+            afss_est_samp = np.array(afss_samples)
+            ufss_est_samp = np.array(ufss_samples)
+            frate_est_samp = np.array(frate_samples)
+            orate_est_samp = np.array(orate_samples)
+         else:
+            rep_arr = np.arange(0,nrepl)
+            for b in range(0, nrepl, batch_size):
+               curr_batch_size = len(rep_arr[b:b+batch_size])
+               idxs = [
+                  np.random.choice(
+                     len(fbs),
+                     size=fbs.size,
+                     replace=True
+                  )
+                  for _ in range(curr_batch_size)
+               ]
+               fbs_bs, fss_bs, afss_bs, ufss_bs, frate_bs, orate_bs = [
+                  np.take(np.array(summary_stat), idxs)
+                  for s, summary_stat in enumerate([fbs, fss, afss, ufss, frate, orate])
+               ]
+               fbs_samples.append(fbs_bs.mean(axis=1))
+               fss_samples.append(fss_bs.mean(axis=1))
+               afss_samples.append(afss_bs.mean(axis=1))
+               ufss_samples.append(ufss_bs.mean(axis=1))
+               frate_samples.append(frate_bs.mean(axis=1))
+               orate_samples.append(orate_bs.mean(axis=1))
+            fbs_est_samp = np.concatenate((fbs_samples))
+            fss_est_samp = np.concatenate((fss_samples))
+            afss_est_samp = np.concatenate((afss_samples))
+            ufss_est_samp = np.concatenate((ufss_samples))
+            frate_est_samp = np.concatenate((frate_samples))
+      elif line_type == 'ECNT': 
+         crps_est_mean = crps.mean()
+         crpss_est_mean = crpss.mean()
+         rmse_est_mean = rmse.mean()
+         spread_est_mean = spread.mean()
+         me_est_mean = me.mean()
+         max_mem_per_array = 32 # MB
+         max_array_size = max_mem_per_array*1E6/8
+         batch_size = int(max_array_size/len(fbar))
+         crps_samples = []
+         crpss_samples = []
+         rmse_samples = []
+         spread_samples = []
+         me_samples = []
+
+         if batch_size <= 1:
+            for _ in range(nrepl):
+               idx = np.random.choice(
+                  len(crps),
+                  size=crps.size,
+                  replace=True
+               )
+               crps_bs, crpss_bs, rmse_bs, spread_bs, me_bs = [
+                  summary_stat[idx].T
+                  for summary_stat in [crps, crpss, rmse, spread, me]
+               ]
+               crps_samples.append(crps_bs.mean())
+               crpss_samples.append(crpss_bs.mean())
+               rmse_samples.append(rmse_bs.mean())
+               ocrpss_samples.append(ocrpss_bs.mean())
+            crps_est_samp = np.array(crps_samples)
+            crpss_est_samp = np.array(crpss_samples)
+            rmse_est_samp = np.array(rmse_samples)
+            spread_est_samp = np.array(spread_samples)
+            me_est_samp = np.array(me_samples)
+         else:
+            rep_arr = np.arange(0,nrepl)
+            for b in range(0, nrepl, batch_size):
+               curr_batch_size = len(rep_arr[b:b+batch_size])
+               idxs = [
+                  np.random.choice(
+                     len(crps),
+                     size=crps.size,
+                     replace=True
+                  )
+                  for _ in range(curr_batch_size)
+               ]
+               crps_bs, crpss_bs, rmse_bs, spread_bs, me_bs = [
+                  np.take(np.array(summary_stat), idxs)
+                  for s, summary_stat in enumerate([crps, crpss, rmse, spread, me])
+               ]
+               crps_samples.append(crps_bs.mean(axis=1))
+               crpss_samples.append(crpss_bs.mean(axis=1))
+               rmse_samples.append(rmse_bs.mean(axis=1))
+               spread_samples.append(spread_bs.mean(axis=1))
+               me_samples.append(me_bs.mean(axis=1))
+            crps_est_samp = np.concatenate((crps_samples))
+            crpss_est_samp = np.concatenate((crpss_samples))
+            rmse_est_samp = np.concatenate((rmse_samples))
+            spread_est_samp = np.concatenate((spread_samples))
+            me_est_samp = np.concatenate((me_samples))
+      else:
+         logger.error("FATAL ERROR: "+line_type+" is not currently a valid option")
+         sys.exit(1)
+   else:
+      logger.error("FATAL ERROR: "+bs_method+" is not a valid option")
+      sys.exit(1)
+   if stat == 'bias':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            stat_values_mean = np.mean(fbar_est_mean) - np.mean(obar_est_mean)
+            stat_values = fbar_est_samp - obar_est_samp
+         elif line_type == 'CTC':
+            stat_values = (fy_oy_samp + fy_on_samp)/(fy_oy_samp + fn_oy_samp)
+   elif stat == 'rmse':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            stat_values_pre_mean = np.sqrt(
+               ffbar_est_mean + oobar_est_mean - 2*fobar_est_mean
+            )
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = np.sqrt(
+               ffbar_est_samp + oobar_est_samp - 2*fobar_est_samp
+            )
+         if line_type == 'ECNT':
+            stat_values_pre_mean = rmse_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = rmse_est_samp
+   elif stat == 'crps':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'ECNT':
+            stat_values_pre_mean = crps_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = crps_est_samp
+   elif stat == 'crpss':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'ECNT':
+            stat_values_pre_mean = crpss_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = crpss_est_samp
+   elif stat == 'spread':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'ECNT':
+            stat_values_pre_mean = spread_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = spread_est_samp
+   elif stat == 'me':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'ECNT':
+            stat_values_pre_mean = me_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = me_est_samp
+
+   elif stat == 'bcrmse':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            var_f_mean = (
+               np.mean(ffbar_est_mean) 
+               - np.mean(fbar_est_mean)*np.mean(fbar_est_mean)
+            )
+            var_o_mean = (
+               np.mean(oobar_est_mean) 
+               - np.mean(obar_est_mean)*np.mean(obar_est_mean)
+            )
+            covar_mean = (
+               np.mean(fobar_est_mean) 
+               - np.mean(fbar_est_mean)*np.mean(obar_est_mean)
+            )
+            stat_values_mean = np.sqrt(var_f_mean+var_o_mean-2*covar_mean)
+            var_f = ffbar_est_samp - fbar_est_samp*fbar_est_samp
+            var_o = oobar_est_samp - obar_est_samp*obar_est_samp
+            covar = fobar_est_samp - fbar_est_samp*obar_est_samp
+            stat_values = np.sqrt(var_f+var_o-2*covar)
+   elif stat == 'msess':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            mse_mean = ffbar_est_mean + oobar_est_mean - 2*fobar_est_mean
+            var_o_mean = oobar_est_mean - obar_est_mean*obar_est_mean
+            stat_values_pre_mean = 1 - mse_mean/var_o_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            mse = ffbar_est_samp + oobar_est_samp - 2*fobar_est_samp
+            var_o = oobar_est_samp - obar_est_samp*obar_est_samp
+            stat_values = 1 - mse/var_o
+   elif stat == 'rsd':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            var_f_mean = ffbar_est_mean - fbar_est_mean*fbar_est_mean
+            var_o_mean = oobar_est_mean - obar_est_mean*obar_est_mean
+            stat_values_pre_mean = np.sqrt(var_f_mean)/np.sqrt(var_o_mean)
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            var_f = ffbar_est_samp - fbar_est_samp*fbar_est_samp
+            var_o = oobar_est_samp - obar_est_samp*obar_est_samp
+            stat_values = np.sqrt(var_f)/np.sqrt(var_o)
+   elif stat == 'rmse_md':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            stat_values_pre_mean = np.sqrt((fbar_est_mean-obar_est_mean)**2)
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = np.sqrt((fbar_est_samp-obar_est_samp)**2)
+   elif stat == 'rmse_pv':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            var_f_mean = ffbar_est_mean - fbar_est_mean**2
+            var_o_mean = oobar_est_mean - obar_est_mean**2
+            covar_mean = fobar_est_mean - fbar_est_mean*obar_est_mean
+            R_mean = covar_mean/np.sqrt(var_f_mean*var_o_mean)
+            stat_values_pre_mean = np.sqrt(
+               var_f_mean 
+               + var_o_mean 
+               - 2*np.sqrt(var_f_mean*var_o_mean)*R_mean
+            )
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            var_f = ffbar_est_samp - fbar_est_samp**2
+            var_o = oobar_est_samp - obar_est_samp**2
+            covar = fobar_est_samp - fbar_est_samp*obar_est_samp
+            R = covar/np.sqrt(var_f*var_o)
+            stat_values = np.sqrt(var_f + var_o - 2*np.sqrt(var_f*var_o)*R)
+   elif stat == 'pcor':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            var_f_mean = ffbar_est_mean - fbar_est_mean*fbar_est_mean
+            var_o_mean = oobar_est_mean - obar_est_mean*obar_est_mean
+            covar_mean = fobar_est_mean - fbar_est_mean*obar_est_mean
+            stat_values_pre_mean = covar_mean/np.sqrt(var_f_mean*var_o_mean)
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            var_f = ffbar_est_samp - fbar_est_samp*fbar_est_samp
+            var_o = oobar_est_samp - obar_est_samp*obar_est_samp
+            covar = fobar_est_samp - fbar_est_samp*obar_est_samp
+            stat_values = covar/np.sqrt(var_f*var_o)
+   elif stat == 'acc':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SAL1L2':
+            var_f_mean = ffabar_est_mean - fabar_est_mean*fabar_est_mean
+            var_o_mean = ooabar_est_mean - oabar_est_mean*oabar_est_mean
+            covar_mean = foabar_est_mean - fabar_est_mean*oabar_est_mean
+            stat_values_pre_mean = covar_mean/np.sqrt(var_f_mean*var_o_mean)
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            var_f = ffabar_est_samp - fabar_est_samp*fabar_est_samp
+            var_o = ooabar_est_samp - oabar_est_samp*oabar_est_samp
+            covar = foabar_est_samp - fabar_est_samp*oabar_est_samp
+            stat_values = covar_samp/np.sqrt(var_f_samp*var_o_samp)
+   elif stat == 'fbar':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            stat_values_pre_mean = fbar_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = fbar_est_samp
+   elif stat == 'obar':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'SL1L2':
+            stat_values_pre_mean = obar_est_mean
+            stat_values_mean = np.mean(stat_values_pre_mean)
+            stat_values = obar_est_samp
+   if stat == 'fss':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'NBRCNT':
+            stat_values_mean = np.mean(fss_est_mean)
+            stat_values = fss_est_samp
+   if stat == 'afss':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'NBRCNT':
+            stat_values_mean = np.mean(afss_est_mean)
+            stat_values = afss_est_samp
+   if stat == 'ufss':
+      if str(bs_method).upper() in ['MATCHED_PAIRS','FORECASTS']:
+         if line_type == 'NBRCNT':
+            stat_values_mean = np.mean(ufss_est_mean)
+            stat_values = ufss_est_samp
+   elif stat == 'orate' or stat == 'baser':
+      if line_type == 'CTC':
+         total_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)+np.sum(fn_on)
+         )
+         stat_values_mean = (np.sum(fy_oy)+np.sum(fn_oy))/total_mean
+         total = (fy_oy_samp + fy_on_samp + fn_oy_samp + fn_on_samp)
+         stat_values = (fy_oy_samp + fn_oy_samp)/total
+      elif line_type == 'NBRCNT':
+            stat_values_mean = np.mean(orate)
+            stat_values = orate_est_samp
+   elif stat == 'frate':
+      if line_type == 'CTC':
+         total_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)+np.sum(fn_on)
+         )
+         stat_values_mean = (np.sum(fy_oy)+np.sum(fy_on))/total_mean
+         total = (fy_oy_samp + fy_on_samp + fn_oy_samp + fn_on_samp)
+         stat_values = (fy_oy_samp + fy_on_samp)/total
+      elif line_type == 'NBRCNT':
+            stat_values_mean = np.mean(frate)
+            stat_values = frate_est_samp
+   elif stat == 'orate_frate' or stat == 'baser_frate':
+      if line_type == 'CTC':
+         total_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)+np.sum(fn_on)
+         )
+         stat_values_fbar_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)
+         )/total_mean
+         stat_values_obar_mean = (
+            np.sum(fy_oy)+np.sum(fn_oy)
+         )/total_mean
+         stat_values_mean = pd.concat(
+            [stat_values_fbar_mean, stat_values_obar_mean]
+         )
+         total = (fy_oy_samp + fy_on_samp + fn_oy_samp + fn_on_samp)
+         stat_values_fbar = (fy_oy_samp + fy_on_samp)/total
+         stat_values_obar = (fy_oy_samp + fn_oy_samp)/total
+         stat_values = pd.concat(
+            [stat_values_fbar, stat_values_obar], axis=1
+         )
+   elif stat == 'accuracy':
+      if line_type == 'CTC':
+         total_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)+np.sum(fn_on)
+         )
+         stat_values_mean = (
+            np.sum(fy_oy)+np.sum(fn_on)
+         )/total_mean
+         total = (fy_oy_samp + fy_on_samp + fn_oy_samp + fn_on_samp)
+         stat_values = (fy_oy_samp + fn_on_samp)/total
+   elif stat == 'fbias':
+      if line_type == 'CTC':
+         stat_values_mean = (
+            (np.sum(fy_oy)+np.sum(fy_on))
+            /(np.sum(fy_oy)+np.sum(fn_oy))
+         )
+         stat_values = (fy_oy_samp + fy_on_samp)/(fy_oy_samp + fn_oy_samp)
+   elif stat == 'pod' or stat == 'hrate':
+      if line_type == 'CTC':
+         stat_values_mean = np.sum(fy_oy)/(np.sum(fy_oy)+np.sum(fn_oy))
+         stat_values = fy_oy_samp/(fy_oy_samp + fn_oy_samp)
+   elif stat == 'pofd' or stat == 'farate':
+      if line_type == 'CTC':
+         stat_values_mean = np.sum(fy_on)/(np.sum(fy_on)+np.sum(fn_on))
+         stat_values = fy_on_samp/(fy_on_samp + fn_on_samp)
+   elif stat == 'podn':
+      if line_type == 'CTC':
+         stat_values_mean = np.sum(fn_on)/(np.sum(fy_on)+np.sum(fn_on))
+         stat_values = fn_on_samp/(fy_on_samp + fn_on_samp)
+   elif stat == 'faratio':
+      if line_type == 'CTC':
+         stat_values_mean = np.sum(fy_on)/(np.sum(fy_on)+np.sum(fy_oy))
+         stat_values = fy_on_samp/(fy_on_samp + fy_oy_samp)
+   elif stat == 'sratio':
+      if line_type == 'CTC':
+         stat_values_mean = (
+            1. - (np.sum(fy_on)/(np.sum(fy_on)+np.sum(fy_oy)))
+         )
+         stat_values = 1. - (fy_on_samp/(fy_on_samp + fy_oy_samp))
+   elif stat == 'csi' or stat == 'ts':
+      if line_type == 'CTC':
+         stat_values_mean = (
+            np.sum(fy_oy)
+            /(np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy))
+         )
+         stat_values = fy_oy_samp/(fy_oy_samp + fy_on_samp + fn_oy_samp)
+   elif stat == 'gss' or stat == 'ets':
+      if line_type == 'CTC':
+         total_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)+np.sum(fn_on)
+         )
+         C_mean = (
+            (np.sum(fy_oy)+np.sum(fy_on))
+            *(np.sum(fy_oy)+np.sum(fn_oy))
+         )/total_mean
+         stat_values_mean = (
+            (np.sum(fy_oy)-C_mean)
+            /(np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)-C_mean)
+         )
+         total = (fy_oy_samp + fy_on_samp + fn_oy_samp + fn_on_samp)
+         C = ((fy_oy_samp + fy_on_samp)*(fy_oy_samp + fn_oy_samp))/total
+         stat_values = (
+            (fy_oy_samp - C)/(fy_oy_samp + fy_on_samp + fn_oy_samp - C)
+         )
+   elif stat == 'hk' or stat == 'tss' or stat == 'pss':
+      if line_type == 'CTC':
+         stat_values_mean = (
+            (np.sum(fy_oy)*np.sum(fn_on)-np.sum(fy_on)*np.sum(fn_oy))
+            /(
+               (np.sum(fy_oy)+np.sum(fn_oy))
+               *(np.sum(fy_on)+np.sum(fn_on))
+            )
+         )
+         stat_values = (
+            ((fy_oy_samp*fn_on_samp)-(fy_on_samp*fn_oy_samp))
+            /((fy_oy_samp+fn_oy_samp)*(fy_on_samp+fn_on_samp))
+         )
+   elif stat == 'hss':
+      if line_type == 'CTC':
+         total_mean = (
+            np.sum(fy_oy)+np.sum(fy_on)+np.sum(fn_oy)+np.sum(fn_on)
+         )
+         Ca_mean = (
+            (np.sum(fy_oy)+np.sum(fy_on))
+            *(np.sum(fy_oy)+np.sum(fn_oy))
+         )
+         Cb_mean = (
+            (np.sum(fn_oy)+np.sum(fn_on))
+            *(np.sum(fy_on)+np.sum(fn_on))
+         )
+         C_mean = (Ca_mean + Cb_mean)/total_mean
+         stat_values_mean = (
+            (np.sum(fy_oy)+np.sum(fn_on)-C_mean)
+            /(total_mean-C_mean)
+         )
+         total = (fy_oy_samp + fy_on_samp + fn_oy_samp + fn_on_samp)
+         Ca = (fy_oy_samp+fy_on_samp)*(fy_oy_samp+fn_oy_samp)
+         Cb = (fn_oy_samp+fn_on_samp)*(fy_on_samp+fn_on_samp)
+         C = (Ca + Cb)/total
+         stat_values = (fy_oy_samp + fn_on_samp - C)/(total - C)
+   else:
+      logger.error("FATAL ERROR: "+stat+" is not a valid option")
+      sys.exit(1)
+   stat_deltas = stat_values-stat_values_mean
+   stat_ci_lower = np.nanpercentile(stat_deltas, lower_pctile)
+   stat_ci_upper = np.nanpercentile(stat_deltas, upper_pctile)
+   return pd.DataFrame(
+      dict(CI_LOWER=[stat_ci_lower], CI_UPPER=[stat_ci_upper], STATUS=[status])
+   )
+
+def calculate_stat(logger, model_data, stat, conversion):
+   """! Calculate the statistic from the data from the
+        read in MET .stat file(s)
+
+        Args:
+           model_data        - Dataframe containing the model(s)
+                               information from the MET .stat
+                               files
+           stat              - string of the simple statistic
+                               name being plotted
+
+        Returns:
+           stat_values       - Dataframe of the statistic values
+           stat_plot_name    - string of the formal statistic
+                               name being plotted
+   """
+   model_data_columns = model_data.columns.values.tolist()
+   if model_data_columns == [ 'TOTAL' ]:
+      logger.warning("Empty model_data dataframe")
+      line_type = 'NULL'
+      if (stat == 'fbar_obar' or stat == 'orate_frate'
+            or stat == 'baser_frate'):
+         stat_values = model_data.loc[:][['TOTAL']]
+         stat_values_fbar = model_data.loc[:]['TOTAL']
+         stat_values_obar = model_data.loc[:]['TOTAL']
+      else:
+         stat_values = model_data.loc[:]['TOTAL']
+   else:
+      if np.any(conversion):
+          bool_convert = True
+      else:
+          bool_convert = False
+      if all(elem in model_data_columns for elem in
+            ['FBAR', 'OBAR', 'MAE']):
+         line_type = 'SL1L2'
+         fbar = model_data.loc[:]['FBAR']
+         obar = model_data.loc[:]['OBAR']
+         fobar = model_data.loc[:]['FOBAR']
+         ffbar = model_data.loc[:]['FFBAR']
+         oobar = model_data.loc[:]['OOBAR']
+         mae   = model_data.loc[:]['MAE']
+         if bool_convert:
+             coef, const = conversion
+             fbar_og = fbar
+             obar_og = obar
+             fbar = coef*fbar_og+const
+             obar = coef*obar_og+const
+             fobar = (
+                np.power(coef, 2)*fobar
+                + coef*const*fbar_og
+                + coef*const*obar_og
+                + np.power(const, 2)
+             )
+             ffbar = (
+                np.power(coef, 2)*ffbar
+                + 2.*coef*const*fbar_og
+                + np.power(const, 2)
+             )
+             oobar = (
+                np.power(coef, 2)*oobar
+                + 2.*coef*const*obar_og
+                + np.power(const, 2)
+             )
+      elif all(elem in model_data_columns for elem in 
+            ['FABAR', 'OABAR', 'MAE']):
+         line_type = 'SAL1L2'
+         fabar = model_data.loc[:]['FABAR']
+         oabar = model_data.loc[:]['OABAR']
+         foabar = model_data.loc[:]['FOABAR']
+         ffabar = model_data.loc[:]['FFABAR']
+         ooabar = model_data.loc[:]['OOABAR']
+         if bool_convert:
+             coef, const = conversion
+             fabar = coef*fabar
+             oabar = coef*oabar
+             foabar = (
+                np.power(coef, 2)*foabar
+             )
+             ffabar = (
+                np.power(coef, 2)*ffabar
+             )
+             ooabar = (
+                np.power(coef, 2)*ooabar
+             )
+      elif all(elem in model_data_columns for elem in
+            ['UFBAR', 'VFBAR']):
+         line_type = 'VL1L2'
+         ufbar = model_data.loc[:]['UFBAR']
+         vfbar = model_data.loc[:]['VFBAR']
+         uobar = model_data.loc[:]['UOBAR']
+         vobar = model_data.loc[:]['VOBAR']
+         uvfobar = model_data.loc[:]['UVFOBAR']
+         uvffbar = model_data.loc[:]['UVFFBAR']
+         uvoobar = model_data.loc[:]['UVOOBAR']
+         if bool_convert:
+             coef, const = conversion
+             ufbar_og = ufbar
+             vfbar_og = vfbar
+             uobar_og = uobar
+             vobar_og = vobar
+             ufbar = coef*ufbar_og+const
+             vfbar = coef*vfbar_og+const
+             uobar = coef*uobar_og+const
+             vobar = coef*vobar_og+const
+             uvfobar = (
+                np.power(coef, 2)*uvfobar
+                + coef*const*(ufbar_og + uobar_og + vfbar_og + vobar_og)
+                + np.power(const, 2)
+             )
+             uvffbar = (
+                np.power(coef, 2)*uvffbar
+                + 2.*coef*const*(ufbar_og + vfbar_og)
+                + np.power(const, 2)
+             )
+             uvoobar = (
+                np.power(coef, 2)*uvoobar
+                + 2.*coef*const*(uobar_og + vobar_og)
+                + np.power(const, 2)
+             )
+      elif all(elem in model_data_columns for elem in 
+            ['UFABAR', 'VFABAR']):
+         line_type = 'VAL1L2'
+         ufabar = model_data.loc[:]['UFABAR']
+         vfabar = model_data.loc[:]['VFABAR']
+         uoabar = model_data.loc[:]['UOABAR']
+         voabar = model_data.loc[:]['VOABAR']
+         uvfoabar = model_data.loc[:]['UVFOABAR']
+         uvffabar = model_data.loc[:]['UVFFABAR']
+         uvooabar = model_data.loc[:]['UVOOABAR']
+         if bool_convert:
+             coef, const = conversion
+             ufabar = coef*ufabar
+             vfabar = coef*vfabar
+             uoabar = coef*uoabar
+             voabar = coef*voabar
+             uvfoabar = (
+                np.power(coef, 2)*uvfoabar
+             )
+             uvffabar = (
+                np.power(coef, 2)*uvffabar
+             )
+             uvooabar = (
+                np.power(coef, 2)*uvooabar
+             )
+      elif all(elem in model_data_columns for elem in
+            ['VDIFF_SPEED', 'VDIFF_DIR']):
+         line_type = 'VCNT'
+         fbar = model_data.loc[:]['FBAR']
+         obar = model_data.loc[:]['OBAR']
+         fs_rms = model_data.loc[:]['FS_RMS']
+         os_rms = model_data.loc[:]['OS_RMS']
+         msve = model_data.loc[:]['MSVE']
+         rmsve = model_data.loc[:]['RMSVE']
+         fstdev = model_data.loc[:]['FSTDEV']
+         ostdev = model_data.loc[:]['OSTDEV']
+         fdir = model_data.loc[:]['FDIR']
+         odir = model_data.loc[:]['ODIR']
+         fbar_speed = model_data.loc[:]['FBAR_SPEED']
+         obar_speed = model_data.loc[:]['OBAR_SPEED']
+         vdiff_speed = model_data.loc[:]['VDIFF_SPEED']
+         vdiff_dir = model_data.loc[:]['VDIFF_DIR']
+         speed_err = model_data.loc[:]['SPEED_ERR']
+         dir_err = model_data.loc[:]['DIR_ERR']
+         if bool_convert:
+             logger.error(
+                f"FATAL ERROR: Cannot convert column units for line_type \"{line_type}\""
+             )
+             exit(1)
+      elif all(elem in model_data_columns for elem in
+            ['FY_OY', 'FN_ON']):
+         line_type = 'CTC'
+         total = model_data.loc[:]['TOTAL']
+         fy_oy = model_data.loc[:]['FY_OY']
+         fy_on = model_data.loc[:]['FY_ON']
+         fn_oy = model_data.loc[:]['FN_OY']
+         fn_on = model_data.loc[:]['FN_ON']
+      elif all(elem in model_data_columns for elem in
+            ['FBS','FSS','AFSS','UFSS','F_RATE','O_RATE']):
+         line_type = 'NBRCNT'
+         total = model_data.loc[:]['TOTAL']
+         fbs = model_data.loc[:]['FBS']
+         fss = model_data.loc[:]['FSS']
+         afss = model_data.loc[:]['AFSS']
+         ufss = model_data.loc[:]['UFSS']
+         frate = model_data.loc[:]['F_RATE']
+         orate = model_data.loc[:]['O_RATE']
+      elif all(elem in model_data_columns for elem in
+            ['CRPS', 'CRPSS', 'RMSE', 'SPREAD', 'ME', 'MAE']):
+         line_type = 'ECNT'
+         total  = model_data.loc[:]['TOTAL']
+         crps   = model_data.loc[:]['CRPS']
+         crpss  = model_data.loc[:]['CRPSS']
+         rmse   = model_data.loc[:]['RMSE']
+         spread = model_data.loc[:]['SPREAD']
+         me     = model_data.loc[:]['ME']
+         mae    = model_data.loc[:]['MAE']
+         if bool_convert:
+             coef, const = conversion
+             rmse = coef*rmse
+             spread = coef*spread
+             me = coef*me
+             mae = np.abs(coef)*mae
+      elif all(elem in model_data_columns for elem in
+            ['ROC_AUC', 'BRIER', 'BSS', 'BSS_SMPL']):
+         line_type = 'PSTD'
+         total  = model_data.loc[:]['TOTAL']
+         roc_area =  model_data.loc[:]['ROC_AUC']
+         bs =  model_data.loc[:]['BRIER']
+         bss =  model_data.loc[:]['BSS']
+         bss_smpl =  model_data.loc[:]['BSS_SMPL']
+      else:
+         logger.error("FATAL ERROR: Could not recognize line type from columns")
+         sys.exit(1)
+   stat_plot_name = get_stat_plot_name(logger, stat)
+   if stat == 'bias':
+      if line_type == 'SL1L2':
+         stat_values = fbar - obar
+      elif line_type == 'VL1L2':
+         stat_values = np.sqrt(uvffbar) - np.sqrt(uvoobar)
+      elif line_type == 'VCNT':
+         stat_values = fbar - obar
+      elif line_type == 'CTC':
+         stat_values = (fy_oy + fy_on)/(fy_oy + fn_oy)
+   elif stat == 'rmse':
+      if line_type == 'SL1L2':
+         stat_values = np.sqrt(ffbar + oobar - 2*fobar)
+      elif line_type == 'VL1L2':
+         stat_values = np.sqrt(uvffbar + uvoobar - 2*uvfobar)
+      elif line_type == 'ECNT':
+         stat_values = rmse
+   elif stat == 'crps':
+      if line_type == 'ECNT':
+        stat_values = crps
+   elif stat == 'crpss':
+      if line_type == 'ECNT':
+        stat_values = crpss
+   elif stat == 'spread':
+      if line_type == 'ECNT':
+        stat_values = spread
+   elif stat == 'me':
+      if line_type == 'ECNT':
+        stat_values = me
+   elif stat == 'mae':
+      if line_type == 'SL1L2':
+        stat_values = mae
+      elif line_type == 'ECNT':
+        stat_values = mae
+   elif stat == 'bs':
+      if line_type == 'PSTD':
+        stat_values = bs
+   elif stat == 'bss':
+      if line_type == 'PSTD':
+        stat_values = bss
+   elif stat == 'bss_smpl':
+      if line_type == 'PSTD':
+        stat_values = bss_smpl
+   elif stat == 'roc_area':
+      if line_type == 'PSTD':
+        stat_values = roc_area
+   elif stat == 'bcrmse':
+      if line_type == 'SL1L2':
+         var_f = ffbar - fbar*fbar
+         var_o = oobar - obar*obar
+         covar = fobar - fbar*obar
+         stat_values = np.sqrt(var_f + var_o - 2*covar)
+      elif line_type == 'VL1L2':
+         var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+         var_o = uvoobar - uobar*uobar - vobar*vobar
+         covar = uvfobar - ufbar*uobar - vfbar*vobar
+         stat_values = np.sqrt(var_f + var_o - 2*covar)
+   elif stat == 'msess':
+      if line_type == 'SL1L2':
+         mse = ffbar + oobar - 2*fobar
+         var_o = oobar - obar*obar
+         stat_values = 1 - mse/var_o
+      elif line_type == 'VL1L2':
+         mse = uvffbar + uvoobar - 2*uvfobar
+         var_o = uvoobar - uobar*uobar - vobar*vobar
+         stat_values = 1 - mse/var_o
+   elif stat == 'rsd':
+      if line_type == 'SL1L2':
+         var_f = ffbar - fbar*fbar
+         var_o = oobar - obar*obar
+         stat_values = np.sqrt(var_f)/np.sqrt(var_o)
+      elif line_type == 'VL1L2':
+         var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+         var_o = uvoobar - uobar*uobar - vobar*vobar
+         stat_values = np.sqrt(var_f)/np.sqrt(var_o)
+      elif line_type == 'VCNT':
+         stat_values = fstdev/ostdev
+   elif stat == 'rmse_md':
+      if line_type == 'SL1L2':
+         stat_values = np.sqrt((fbar-obar)**2)
+      elif line_type == 'VL1L2':
+         stat_values = np.sqrt((ufbar - uobar)**2 + (vfbar - vobar)**2)
+   elif stat == 'rmse_pv':
+      if line_type == 'SL1L2':
+         var_f = ffbar - fbar**2
+         var_o = oobar - obar**2
+         covar = fobar - fbar*obar
+         R = covar/np.sqrt(var_f*var_o)
+         stat_values = np.sqrt(var_f + var_o - 2*np.sqrt(var_f*var_o)*R)
+      elif line_type == 'VL1L2':
+         var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+         var_o = uvoobar - uobar*uobar - vobar*vobar
+         covar = uvfobar - ufbar*uobar - vfbar*vobar
+         R = covar/np.sqrt(var_f*var_o)
+         stat_values = np.sqrt(var_f + var_o - 2*np.sqrt(var_f*var_o)*R)
+   elif stat == 'pcor':
+      if line_type == 'SL1L2':
+         var_f = ffbar - fbar*fbar
+         var_o = oobar - obar*obar
+         covar = fobar - fbar*obar
+         stat_values = covar/np.sqrt(var_f*var_o)
+      elif line_type == 'VL1L2':
+         var_f = uvffbar - ufbar*ufbar - vfbar*vfbar
+         var_o = uvoobar - uobar*uobar - vobar*vobar
+         covar = uvfobar - ufbar*uobar - vfbar*vobar
+         stat_values = covar/np.sqrt(var_f*var_o)
+   elif stat == 'acc':
+      if line_type == 'SAL1L2':
+         var_f = ffabar - fabar*fabar
+         var_o = ooabar - oabar*oabar
+         covar = foabar - fabar*oabar
+         stat_values = covar/np.sqrt(var_f*var_o)
+      if line_type == 'VAL1L2':
+         stat_values = uvfoabar/np.sqrt(uvffabar*uvooabar)
+   elif stat == 'fbar':
+      if line_type == 'SL1L2':
+         stat_values = fbar
+      elif line_type == 'VL1L2':
+         stat_values = np.sqrt(uvffbar)
+      elif line_type == 'VCNT':
+         stat_values = fbar
+   elif stat == 'obar':
+      if line_type == 'SL1L2':
+         stat_values = obar
+      elif line_type == 'VL1L2':
+         stat_values = np.sqrt(uvoobar)
+      elif line_type == 'VCNT':
+         stat_values = obar
+   elif stat == 'fbar_obar':
+      if line_type == 'SL1L2':
+         stat_values = model_data.loc[:][['FBAR', 'OBAR']]
+         stat_values_fbar = model_data.loc[:]['FBAR']
+         stat_values_obar = model_data.loc[:]['OBAR']
+      elif line_type == 'VL1L2':
+         stat_values = model_data.loc[:][['UVFFBAR', 'UVOOBAR']]
+         stat_values_fbar = np.sqrt(model_data.loc[:]['UVFFBAR'])
+         stat_values_obar = np.sqrt(model_data.loc[:]['UVOOBAR'])
+      elif line_type == 'VCNT':
+         stat_values = model_data.loc[:][['FBAR', 'OBAR']]
+         stat_values_fbar = model_data.loc[:]['FBAR']
+         stat_values_obar = model_data.loc[:]['OBAR']
+   elif stat == 'speed_err':
+      if line_type == 'VCNT':
+         stat_values = speed_err
+   elif stat == 'dir_err':
+      if line_type == 'VCNT':
+         stat_values = dir_err
+   elif stat == 'rmsve':
+      if line_type == 'VCNT':
+         stat_values = rmsve
+   elif stat == 'vdiff_speed':
+      if line_type == 'VCNT':
+         stat_values = vdiff_speed
+   elif stat == 'vdiff_dir':
+      if line_type == 'VCNT':
+         stat_values = vdiff_dir
+   elif stat == 'fbar_obar_speed':
+      if line_type == 'VCNT':
+         stat_values = model_data.loc[:][('FBAR_SPEED', 'OBAR_SPEED')]
+   elif stat == 'fbar_obar_dir':
+      if line_type == 'VCNT':
+         stat_values = model_data.loc[:][('FDIR', 'ODIR')]
+   elif stat == 'fbar_speed':
+      if line_type == 'VCNT':
+         stat_values = fbar_speed
+   elif stat == 'fbar_dir':
+      if line_type == 'VCNT':
+         stat_values = fdir
+   elif stat == 'orate' or stat == 'baser':
+      if line_type == 'CTC':
+         stat_values = (fy_oy + fn_oy)/total
+      elif line_type == 'NBRCNT':
+         stat_values = orate
+   elif stat == 'frate':
+      if line_type == 'CTC':
+         stat_values = (fy_oy + fy_on)/total
+      elif line_type == 'NBRCNT':
+         stat_values = frate
+   elif stat == 'fss':
+      if line_type == 'NBRCNT':
+         stat_values = fss
+   elif stat == 'afss':
+      if line_type == 'NBRCNT':
+         stat_values = afss
+   elif stat == 'ufss':
+      if line_type == 'NBRCNT':
+         stat_values = ufss
+   elif stat == 'orate_frate' or stat == 'baser_frate':
+      if line_type == 'CTC':
+         stat_values_fbar = (fy_oy + fy_on)/total
+         stat_values_obar = (fy_oy + fn_oy)/total
+         stat_values = pd.concat(
+            [stat_values_fbar, stat_values_obar], axis=1
+         )
+   elif stat == 'accuracy':
+      if line_type == 'CTC':
+         stat_values = (fy_oy + fn_on)/total
+   elif stat == 'fbias':
+      if line_type == 'CTC':
+         stat_values = (fy_oy + fy_on)/(fy_oy + fn_oy)
+   elif stat == 'pod' or stat == 'hrate':
+      if line_type == 'CTC':
+         stat_values = fy_oy/(fy_oy + fn_oy)
+   elif stat == 'pofd' or stat == 'farate':
+      if line_type == 'CTC':
+         stat_values = fy_on/(fy_on + fn_on)
+   elif stat == 'podn':
+      if line_type == 'CTC':
+         stat_values = fn_on/(fy_on + fn_on)
+   elif stat == 'faratio':
+      if line_type == 'CTC':
+         stat_values = fy_on/(fy_on + fy_oy)
+   elif stat == 'sratio':
+      if line_type == 'CTC':
+         stat_values = 1. - (fy_on/(fy_on + fy_oy))
+   elif stat == 'csi' or stat == 'ts':
+      if line_type == 'CTC':
+         stat_values = fy_oy/(fy_oy + fy_on + fn_oy)
+   elif stat == 'gss' or stat == 'ets':
+      if line_type == 'CTC':
+         C = ((fy_oy + fy_on)*(fy_oy + fn_oy))/total
+         stat_values = (fy_oy - C)/(fy_oy + fy_on + fn_oy - C)
+   elif stat == 'hk' or stat == 'tss' or stat == 'pss':
+      if line_type == 'CTC':
+         stat_values = (
+            ((fy_oy*fn_on)-(fy_on*fn_oy))/((fy_oy+fn_oy)*(fy_on+fn_on))
+         )
+   elif stat == 'hss':
+      if line_type == 'CTC':
+         Ca = (fy_oy+fy_on)*(fy_oy+fn_oy)
+         Cb = (fn_oy+fn_on)*(fy_on+fn_on)
+         C = (Ca + Cb)/total
+         stat_values = (fy_oy + fn_on - C)/(total - C)
+   else:
+      logger.error("FATAL ERROR: "+stat+" is not a valid option")
+      sys.exit(1)
+   nindex = stat_values.index.nlevels
+   return stat_values, None, stat_plot_name
+
+def get_lead_avg_file(stat, input_filename, fcst_lead, output_base_dir):
+   lead_avg_filename = stat + '_' + os.path.basename(input_filename) \
+      .replace('_dump_row.stat', '')
+   # if fcst_leadX is in filename, replace it with fcst_lead_avgs
+   # and add .txt to end of filename
+   if f'fcst_lead{fcst_lead}' in lead_avg_filename:
+      lead_avg_filename = (
+         lead_avg_filename.replace(f'fcst_lead{fcst_lead}',
+                                    'fcst_lead_avgs')
+      )
+      lead_avg_filename += '.txt'
+
+   # if not, remove mention of forecast lead and
+   # add fcst_lead_avgs.txt to end of filename
+   elif 'fcst_lead_avgs' not in input_filename:
+      lead_avg_filename = lead_avg_filename.replace(f'fcst_lead{fcst_lead}',
+                                                     '')
+      lead_avg_filename += '_fcst_lead_avgs.txt'
+   lead_avg_file = os.path.join(output_base_dir, 'data',
+                                lead_avg_filename)
+   return lead_avg_file
+
+def get_ci_file(stat, input_filename, fcst_lead, output_base_dir, ci_method):
+   CI_filename = stat + '_' + os.path.basename(input_filename) \
+      .replace('_dump_row.stat', '')
+   # if fcst_leadX is in filename, replace it with fcst_lead_avgs
+   # and add .txt to end of filename
+   if f'fcst_lead{fcst_lead}' in CI_filename:
+      CI_filename = CI_filename.replace(f'fcst_lead{fcst_lead}',
+                                         'fcst_lead_avgs')
+
+   # if not and fcst_lead_avgs isn't already in filename,
+   # remove mention of forecast lead and
+   # add fcst_lead_avgs.txt to end of filename
+   elif 'fcst_lead_avgs' not in CI_filename:
+      CI_filename = CI_filename.replace(f'fcst_lead{fcst_lead}',
+                                      '')
+      CI_filename += '_fcst_lead_avgs'
+   CI_filename += '_CI_' + ci_method + '.txt'
+   CI_file = os.path.join(output_base_dir, 'data',
+                          CI_filename)
+   return CI_file          
+
+def equalize_samples(logger, df, group_by):
+    # columns that will be used to drop duplicate rows across model groups
+    cols_to_check = [
+        key for key in [
+            'LEAD_HOURS', 'VALID', 'INIT', 'FCST_THRESH_SYMBOL', 
+            'FCST_THRESH_VALUE', 'OBS_LEV']
+        if key in df.keys()
+    ]
+    df_groups = df.groupby(group_by)
+    indexes = []
+    # List all of the independent variables that are found in the data
+    unique_indep_vars = np.unique(np.array(list(df_groups.groups.keys())).T[1])
+    for unique_indep_var in unique_indep_vars:
+        # Get all groups, in the form of DataFrames, that include the given 
+        # independent variable
+        dfs = [
+            df_groups.get_group(name)[cols_to_check]
+            for name in list(df_groups.groups.keys()) 
+            if str(name[1]) == str(unique_indep_var)
+        ]
+        # merge all of these DataFrames together according to 
+        # the columns in cols_to_check
+        for i, dfs_i in enumerate(dfs):
+            if i == 0:
+                df_merged = dfs_i
+            else:
+                df_merged = df_merged.merge(
+                    dfs_i, how='inner', indicator=False
+                )
+        # make sure to remove duplicate rows (looking only at the columns in 
+        # cols_to_check) to reduce comp time in the next in the next step
+        match_these = df_merged.drop_duplicates()
+        # Get all the indices for rows in each group that match the merged df
+        for dfs_i in dfs:
+            for idx, row in dfs_i.iterrows():
+                if (
+                        row.to_numpy()[1:].tolist() 
+                        in match_these.to_numpy()[:,1:].tolist()):
+                    indexes.append(idx)
+    # Select the matched rows by index among the rows in the original DataFrame
+    df_equalized = df.loc[indexes]
+    # Remove duplicates again, this time among both the columns 
+    # in cols_to_check and the 'MODEL' column, which avoids, say, models with
+    # repeated data from multiple entities
+    df_equalized = df_equalized.loc[
+        df_equalized[cols_to_check+['MODEL']].drop_duplicates().index
+    ]
+    # Regroup the data and move forward with this groups!
+    df_equalized_groups = df_equalized.groupby(group_by)
+    # Check that groups are indeed equally sized for each independent variable
+    df_groups_sizes = df_equalized_groups.size()
+    df_groups_sizes.index = df_groups_sizes.index.set_levels(
+        df_groups_sizes.index.levels[-1].astype(str), level=-1
+    )
+    data_are_equalized = np.all([
+        np.unique(df_groups_sizes.xs(str(unique_indep_var), level=1)).size == 1
+        for unique_indep_var 
+        in np.unique(np.array(list(df_groups_sizes.keys())).T[1])
+    ])
+    if data_are_equalized:
+        logger.info(
+            "Data were successfully equalized along the independent"
+            + " variable."
+        )
+        return df_equalized, data_are_equalized
+    else:
+        logger.warning(
+            "Data equalization along the independent variable failed."
+        )
+        logger.warning(
+            "This may be a bug in the verif_plotting code. Please contact"
+            + " the verif_plotting code manager about your issue."
+        )
+        logger.warning(
+            "Skipping equalization.  Sample sizes will not be plotted."
+        )
+        return df, data_are_equalized
+
+def get_name_for_listed_items(listed_items, joinchars, prechars, postchars, prechars_last, postchars_last):
+    new_items = []
+    if len(listed_items) == 1:
+        return f"{prechars}{listed_items[0]}{postchars}"
+    elif len(listed_items) == 2:
+        return (f"{prechars}{listed_items[0]}{postchars} {prechars_last}"
+                + f"{prechars}{listed_items[1]}{postchars}{postchars_last}")
+    else:
+        for i, item in enumerate(listed_items):
+            if i == 0:
+                start = item
+            elif i == (len(listed_items)-1):
+                if int(item) == int(listed_items[i-1]):
+                    new_items.append(f"{prechars_last}{prechars}{start}{postchars}{postchars_last}")
+                elif int(item) != int(listed_items[i-1])+1:
+                    if int(start) != int(listed_items[i-1]):
+                        new_items.append(f"{prechars}{start}-{listed_items[i-1]}{postchars}")
+                        new_items.append(f"{prechars_last}{prechars}{item}{postchars}{postchars_last}")
+                    else:
+                        new_items.append(f"{prechars}{listed_items[i-1]}{postchars}")
+                        new_items.append(f"{prechars_last}{prechars}{item}{postchars}{postchars_last}")
+                elif int(start) == int(listed_items[0]):
+                    new_items.append(f"{prechars}{start}-{item}{postchars}")
+                else:
+                    new_items.append(f"{prechars_last}{prechars}{start}-{item}{postchars}{postchars_last}")
+            elif int(item) != int(listed_items[i-1])+1:
+                if int(start) == int(listed_items[i-1]):
+                    new_items.append(f"{prechars}{start}{postchars}")
+                else:
+                    new_items.append(
+                        f"{prechars}{start}-{listed_items[i-1]}{postchars}"
+                    )
+                start=item
+    return joinchars.join(new_items)
+

--- a/ush/cam/ush_refs_plot_py/plotter.py
+++ b/ush/cam/ush_refs_plot_py/plotter.py
@@ -1,0 +1,165 @@
+#! /usr/bin/env python3
+
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Rectangle, PathPatch
+from matplotlib.path import Path
+import numpy as np
+
+class Plotter():
+    def __init__(self, font_weight='bold',   axis_title_weight='bold',  
+                axis_title_size=20,         axis_offset=False,
+                axis_title_pad=15,          axis_label_weight='bold',  
+                axis_label_size=16,         axis_label_pad=10,
+                xtick_label_size=16,        xtick_major_pad=10,        
+                ytick_label_size=16,        ytick_major_pad=10, 
+                fig_subplot_right=.95,      fig_subplot_left=.1,      
+                fig_subplot_top=.925,       fig_subplot_bottom=.075,
+                legend_handle_text_pad=.25, legend_handle_length=1.25, 
+                legend_border_axis_pad=0,   legend_col_space=1.,
+                legend_frame_on=True,       fig_size=(14.,14.),        
+                legend_bbox=(0,1),          legend_font_size=17, 
+                legend_loc='center right',  legend_ncol=1,             
+                title_loc='center'):
+        self.font_weight = font_weight
+        self.axis_title_weight = axis_title_weight
+        self.axis_title_size = axis_title_size
+        self.axis_title_pad = axis_title_pad
+        self.axis_offset = axis_offset
+        self.axis_label_weight = axis_label_weight
+        self.axis_label_size = axis_label_size
+        self.axis_label_pad = axis_label_pad
+        self.xtick_label_size = xtick_label_size
+        self.xtick_major_pad = xtick_major_pad
+        self.ytick_label_size = ytick_label_size
+        self.ytick_major_pad = ytick_major_pad
+        self.fig_subplot_right = fig_subplot_right
+        self.fig_subplot_left = fig_subplot_left
+        self.fig_subplot_top = fig_subplot_top
+        self.fig_subplot_bottom = fig_subplot_bottom
+        self.legend_handle_text_pad = legend_handle_text_pad
+        self.legend_handle_length = legend_handle_length
+        self.legend_border_axis_pad = legend_border_axis_pad
+        self.legend_col_space = legend_col_space
+        self.legend_frame_on = legend_frame_on
+        self.fig_size = fig_size
+        self.legend_bbox = legend_bbox
+        self.legend_fontsize = legend_font_size
+        self.legend_loc = legend_loc
+        self.legend_ncol = legend_ncol
+        self.title_loc = title_loc
+
+    def set_up_plots(self):
+        plt.rcParams['font.weight'] = self.font_weight
+        plt.rcParams['axes.titleweight'] = self.axis_title_weight
+        plt.rcParams['axes.titlesize'] = self.axis_title_size
+        plt.rcParams['axes.titlepad'] = self.axis_title_pad
+        plt.rcParams['axes.labelweight'] = self.axis_label_weight
+        plt.rcParams['axes.labelsize'] = self.axis_label_size
+        plt.rcParams['axes.labelpad'] = self.axis_label_pad
+        plt.rcParams['axes.formatter.useoffset'] = self.axis_offset
+        plt.rcParams['xtick.labelsize'] = self.xtick_label_size
+        plt.rcParams['xtick.major.pad'] = self.xtick_major_pad
+        plt.rcParams['ytick.labelsize'] = self.ytick_label_size
+        plt.rcParams['ytick.major.pad'] = self.ytick_major_pad
+        plt.rcParams['figure.subplot.left'] = self.fig_subplot_left
+        plt.rcParams['figure.subplot.right'] = self.fig_subplot_right
+        plt.rcParams['figure.subplot.top'] = self.fig_subplot_top
+        plt.rcParams['figure.subplot.bottom'] = self.fig_subplot_bottom
+        plt.rcParams['legend.handletextpad'] = self.legend_handle_text_pad
+        plt.rcParams['legend.handlelength'] = self.legend_handle_length
+        plt.rcParams['legend.borderaxespad'] = self.legend_border_axis_pad
+        plt.rcParams['legend.columnspacing'] = self.legend_col_space
+        plt.rcParams['legend.frameon'] = self.legend_frame_on
+      
+    def get_plots(self, num):
+        fig, ax = plt.subplots(1, 1, figsize=self.fig_size, num=num)
+        return fig, ax
+
+    def get_error_boxes(self, xdata, ydata, xerror, yerror, fc='None', 
+                       ec='black', lw=1., ls='solid', alpha=0.75):
+        errorboxes = []
+        xerror = np.array(xerror)
+        yerror = np.array(yerror)
+        for xc, yc, xe, ye in zip(xdata, ydata, xerror.T, yerror.T):
+            rect = Rectangle((xc+xe[0], yc+ye[0]), np.diff(xe), np.diff(ye))
+            errorboxes.append(rect)
+        pc = PatchCollection(
+            errorboxes, facecolor=fc, alpha=alpha, edgecolor=ec, linewidth=lw, 
+            linestyle=ls
+        )
+        return pc
+
+    def get_error_brackets(self, xdata, ydata, xerror, yerror, fc='None', 
+                          ec='black', lw=1., alpha=0.75):
+        errorbrackets = []
+        verts = []
+        codes = []
+        xerror = np.array(xerror)
+        yerror = np.array(yerror)
+        for xc, yc, xe, ye in zip(xdata, ydata, xerror.T, yerror.T):
+            verts += [
+                (xc+xe[1], yc+ye[0]),
+                (xc+xe[0], yc+ye[0]),
+                (xc+xe[0], yc+ye[1]),
+                (xc+xe[1], yc+ye[1])
+            ]
+            codes += [
+                Path.MOVETO,
+                Path.LINETO,
+                Path.LINETO,
+                Path.LINETO,
+            ]
+        path = Path(verts, codes)
+        pp = PathPatch(
+            path, facecolor=fc, alpha=alpha, edgecolor=ec, linewidth=lw
+        )
+        return pp
+
+    def get_logo_location(self, position, x_figsize, y_figsize, dpi):
+        """! Get locations for the logos
+
+            Args:
+                position  - side of image (string, "left" or "right")
+                x_figsize - image size in x direction (float)
+                y_figsize - image size in y_direction (float)
+                dpi       - image dots per inch (float)
+
+            Returns:
+                x_loc - logo position in x direction (float)
+                y_loc - logo position in y_direction (float)
+                alpha - alpha value (float)
+        """
+        alpha = 0.5
+        if x_figsize == 8 and y_figsize == 6:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0.0
+                y_loc = y_figsize * dpi * 0.858
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.9
+                y_loc = y_figsize * dpi * 0.858
+        elif x_figsize == 16 and y_figsize == 8:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0.0
+                y_loc = y_figsize * dpi * 0.89
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.948
+                y_loc = y_figsize * dpi * 0.89
+        elif x_figsize == 16 and y_figsize == 16:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0.0
+                y_loc = y_figsize * dpi * 0.945
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.948
+                y_loc = y_figsize * dpi * 0.945
+        else:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0.0
+                y_loc = y_figsize * dpi * 0.95
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.948
+                y_loc = y_figsize * dpi * 0.95
+        return x_loc, y_loc, alpha
+
+
+

--- a/ush/cam/ush_refs_plot_py/prune_stat_files.py
+++ b/ush/cam/ush_refs_plot_py/prune_stat_files.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python3
+
+'''
+Program Name: prune_stat_files.py
+Contact(s): Marcel Caron, Mallory Row
+Abstract: This script is run by all scripts in EMC_verif-global/scripts/.
+          This prunes the MET .stat files for the
+          specific plotting job to help decrease
+          wall time.
+'''
+
+import glob
+import subprocess
+import os
+import re
+import sys
+import numpy as np
+from datetime import datetime, timedelta as td
+SETTINGS_DIR = os.environ['USH_DIR']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+import string_template_substitution
+
+def daterange(start, end, td):
+   curr = start
+   while curr <= end:
+      yield curr
+      curr+=td
+
+def expand_met_stat_files(met_stat_files, data_dir, output_base_template, RUN_case, 
+                          RUN_type, line_type, vx_mask, var_name, model, 
+                          eval_period, valid):
+    met_stat_files_out = np.concatenate((
+        met_stat_files, 
+        glob.glob(os.path.join(
+            # edit below to define stats archive path. Use '*' as wildcard.
+            data_dir, 
+            string_template_substitution.do_string_sub(
+                output_base_template, 
+                RUN_CASE=str(RUN_case), RUN_CASE_UPPER=str(RUN_case).upper(),
+                RUN_CASE_LOWER=str(RUN_case).lower(), RUN_TYPE=str(RUN_type), 
+                RUN_TYPE_UPPER=str(RUN_type).lower(), 
+                RUN_TYPE_LOWER=str(RUN_type).lower(), LINE_TYPE=str(line_type),
+                LINE_TYPE_UPPER=str(line_type).upper(), 
+                LINE_TYPE_LOWER=str(line_type).lower(),
+                VX_MASK=str(vx_mask), VX_MASK_UPPER=str(vx_mask).upper(),
+                VX_MASK_LOWER=str(vx_mask).lower(), 
+                VAR_NAME=str(var_name), VAR_NAME_UPPER=str(var_name).upper(),
+                VAR_NAME_LOWER=str(var_name).lower(), MODEL=str(model), 
+                MODEL_UPPER=str(model).upper(), MODEL_LOWER=str(model).lower(),
+                EVAL_PERIOD=str(eval_period), 
+                EVAL_PERIOD_UPPER=str(eval_period).upper(),
+                EVAL_PERIOD_LOWER=str(eval_period).lower(),
+                VALID=valid, valid=valid
+            )
+        ))
+    ))
+    return met_stat_files_out
+
+def prune_data(data_dir, prune_dir, tmp_dir, output_base_template, valid_range, 
+               eval_period, RUN_case, RUN_type, line_type, vx_mask, 
+               fcst_var_names, var_name, model_list):
+
+   print("BEGIN: "+os.path.basename(__file__))
+   # Get list of models and loop through
+   for model in model_list:
+      # Get input and output data
+      met_stat_files = []
+      for valid in daterange(valid_range[0], valid_range[1], td(days=1)):
+         met_stat_files = expand_met_stat_files(
+            met_stat_files, data_dir, output_base_template, RUN_case, RUN_type, 
+            line_type, vx_mask, var_name, model, eval_period, valid
+         ) 
+      pruned_data_dir = os.path.join(
+         prune_dir, line_type+'_'+var_name+'_'+vx_mask+'_'+eval_period, tmp_dir
+      )
+      if not os.path.exists(pruned_data_dir):
+         os.makedirs(pruned_data_dir)
+      if len(met_stat_files) == 0:
+         continue
+      with open(met_stat_files[0]) as msf:
+         met_header_cols = msf.readline()
+      all_grep_output = ''
+      if RUN_type == 'anom' and 'HGT' in var_name:
+         print("Pruning "+data_dir+" files for model "+model+", vx_mask "
+               +vx_mask+", variable "+'/'.join(fcst_var_names)+", line_type "+line_type
+               +", interp "+os.environ['INTERP'])
+         filter_cmd = (
+            ' | grep "'+vx_mask
+            +'" | grep "'+'\|'.join(fcst_var_names)
+            +'" | grep "'+line_type
+            +'" | grep "'+os.environ['INTERP']+'"'
+         )
+      else:
+         print("Pruning "+data_dir+" files for model "+model+", vx_mask "
+               +vx_mask+", variable "+'/'.join(fcst_var_names)+", line_type "+line_type)
+         filter_cmd = (
+            ' | grep "'+vx_mask
+            +'" | grep "'+'\|'.join(fcst_var_names)
+            +'" | grep "'+line_type+'"'
+         )
+      # Prune the MET .stat files and write to new file
+      for met_stat_file in met_stat_files:
+         grep = subprocess.run('grep -R "'+model+'" '+met_stat_file+filter_cmd,
+                               shell=True, capture_output=True, encoding="utf8")
+         grep_output = grep.stdout
+
+         all_grep_output = all_grep_output+grep_output
+
+      pruned_met_stat_file = os.path.join(pruned_data_dir,
+                                          model+'.stat')
+      with open(pruned_met_stat_file, 'w') as pmsf:
+         pmsf.write(met_header_cols+all_grep_output)
+   print("END: "+os.path.basename(__file__))

--- a/ush/cam/ush_refs_plot_py/refs_atmos_plots.py
+++ b/ush/cam/ush_refs_plot_py/refs_atmos_plots.py
@@ -1,0 +1,216 @@
+#! /usr/bin/env python3
+
+'''
+Name: refs_atmos_plots.py
+Contact(s): Mallory Row
+Abstract: This script is main driver for the plotting scripts.
+'''
+
+import os
+import sys
+import logging
+import datetime
+import glob
+import subprocess
+import itertools
+import shutil
+from refs_atmos_plots_specs import PlotSpecs
+
+print("BEGIN: "+os.path.basename(__file__))
+
+# Read in environment variables
+DATA = os.environ['DATA']
+NET = os.environ['NET']
+RUN = os.environ['RUN']
+VERIF_CASE = os.environ['VERIF_CASE']
+STEP = os.environ['STEP']
+COMPONENT = os.environ['COMPONENT']
+FIXevs = os.environ['FIXevs']
+MET_ROOT = os.environ['MET_ROOT']
+met_ver = os.environ['met_ver']
+evs_run_mode = os.environ['evs_run_mode']
+start_date = os.environ['start_date']
+end_date = os.environ['end_date']
+plot_verbosity = os.environ['plot_verbosity']
+event_equalization = os.environ['event_equalization']
+job_name = os.environ['job_name']
+line_type = os.environ['line_type']
+stat = os.environ['stat']
+grid = os.environ['grid']
+job_var = os.environ['job_var']
+vx_mask = os.environ['vx_mask']
+interp_method = os.environ['interp_method']
+interp_points_list = os.environ['interp_points_list'].split(', ')
+fcst_var_name = os.environ['fcst_var_name']
+fcst_var_level_list = os.environ['fcst_var_level_list'].split(', ')
+fcst_var_thresh_list = os.environ['fcst_var_thresh_list'].split(', ')
+obs_var_name = os.environ['obs_var_name']
+obs_var_level_list = os.environ['obs_var_level_list'].split(', ')
+obs_var_thresh_list = os.environ['obs_var_thresh_list'].split(', ')
+model_list = os.environ['model_list'].split(' ')
+model_plot_name_list = os.environ['model_plot_name_list'].split(' ')
+plots_list = os.environ['plots_list'].split(', ')
+VERIF_TYPE = os.environ['VERIF_TYPE']
+date_type = os.environ['date_type']
+valid_hr_start = os.environ['valid_hr_start']
+valid_hr_end = os.environ['valid_hr_end']
+valid_hr_inc = os.environ['valid_hr_inc']
+init_hr_start = os.environ['init_hr_start']
+init_hr_end = os.environ['init_hr_end']
+init_hr_inc = os.environ['init_hr_inc']
+fhr_start = os.environ['fhr_start']
+fhr_end = os.environ['fhr_end']
+fhr_inc = os.environ['fhr_inc']
+if VERIF_CASE == 'grid2grid' and VERIF_TYPE == 'pres_levs':
+   truth_name_list = os.environ['truth_name_list'].split(' ') 
+else:
+   obs_name = os.environ['obs_name']
+
+# Set variables
+VERIF_CASE_STEP = VERIF_CASE+'_'+STEP
+start_date_dt = datetime.datetime.strptime(start_date, '%Y%m%d')
+end_date_dt = datetime.datetime.strptime(end_date, '%Y%m%d')
+now = datetime.datetime.now()
+
+# Set up directory paths
+logo_dir = os.path.join(FIXevs, 'logos')
+VERIF_CASE_STEP_dir = os.path.join(DATA, VERIF_CASE_STEP)
+stat_base_dir = os.path.join(VERIF_CASE_STEP_dir, 'data')
+plot_output_dir = os.path.join(VERIF_CASE_STEP_dir, 'plot_output')
+logging_dir = os.path.join(plot_output_dir, RUN+'.'+end_date, 'logs')
+VERIF_TYPE_image_dir = os.path.join(plot_output_dir, RUN+'.'+end_date,
+                                    'images', VERIF_TYPE)
+job_output_dir = os.path.join(plot_output_dir, RUN+'.'+end_date,
+                              VERIF_TYPE,job_name.replace('/','_'))
+if not os.path.exists(job_output_dir):
+    os.makedirs(job_output_dir)
+
+# Set up logging
+job_logging_file = os.path.join(logging_dir, 'evs_'+COMPONENT+'_'+RUN+'_'
+                                +VERIF_CASE+'_'+STEP+'_'+VERIF_TYPE+'_'
+                                +job_name.replace('/','_')+'_runon'
+                                +now.strftime('%Y%m%d%H%M%S')+'.log')
+logger = logging.getLogger(job_logging_file)
+logger.setLevel(plot_verbosity)
+formatter = logging.Formatter(
+    '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+    + '%(message)s',
+    '%m/%d %H:%M:%S'
+)
+file_handler = logging.FileHandler(job_logging_file, mode='a')
+file_handler.setFormatter(formatter)
+logger.addHandler(file_handler)
+logger_info = f"Log file: {job_logging_file}"
+print(logger_info)
+logger.info(logger_info)
+
+if len(model_list) > 10:
+    logger.error("TOO MANY MODELS LISTED ("+str(len(model_list))
+                 +", ["+', '.join(model_list)+"]), maximum is 10")
+    sys.exit(1)
+
+# Set up model information dictionary
+original_model_info_dict = {}
+for model_idx in range(len(model_list)):
+    model_num = model_idx + 1
+    original_model_info_dict['model'+str(model_num)] = {
+        'name': model_list[model_idx],
+        'plot_name': model_plot_name_list[model_idx],
+    }
+    if VERIF_CASE == 'grid2grid' and VERIF_TYPE == 'pres_levs':
+         original_model_info_dict['model'+str(model_num)]['obs_name'] = (
+             truth_name_list[model_idx]
+         )
+    elif VERIF_CASE == 'grid2grid' and VERIF_TYPE == 'means':
+         original_model_info_dict['model'+str(model_num)]['obs_name'] = (
+             model_list[model_idx]
+         )
+    else:
+        original_model_info_dict['model'+str(model_num)]['obs_name'] = obs_name
+
+# Set up date information dictionary
+original_date_info_dict = {
+    'date_type': date_type,
+    'start_date': start_date,
+    'end_date': end_date,
+    'init_hr_start': init_hr_start,
+    'init_hr_end': init_hr_end,
+    'init_hr_inc': init_hr_inc,
+}
+valid_hrs = list(range(int(valid_hr_start),
+                       int(valid_hr_end)+int(valid_hr_inc),
+                       int(valid_hr_inc)))
+init_hrs = list(range(int(init_hr_start),
+                      int(init_hr_end)+int(init_hr_inc),
+                      int(init_hr_inc)))
+fhrs = list(range(int(fhr_start), int(fhr_end)+int(fhr_inc), int(fhr_inc)))
+
+# Set up plot information dictionary
+original_plot_info_dict = {
+    'line_type': line_type,
+    'grid': grid,
+    'stat': stat,
+    'vx_mask': vx_mask,
+    'interp_method': interp_method,
+    'event_equalization': event_equalization
+}
+fcst_var_prod = list(
+    itertools.product([fcst_var_name], fcst_var_level_list,
+                      fcst_var_thresh_list)
+)
+obs_var_prod = list(
+    itertools.product([obs_var_name], obs_var_level_list,
+                      obs_var_thresh_list)
+)
+if len(fcst_var_prod) == len(obs_var_prod):
+    var_info = []
+    for v in range(len(fcst_var_prod)):
+        var_info.append((fcst_var_prod[v], obs_var_prod[v]))
+else:
+    logger.error("FORECAST AND OBSERVATION VARIABLE INFORMATION NOT THE "
+                 +"SAME LENGTH")
+    sys.exit(1)
+
+# Set up MET information dictionary
+original_met_info_dict = {
+    'root': MET_ROOT,
+    'version': met_ver
+}
+
+# Make the plots
+for plot in plots_list:
+    plot_specs = PlotSpecs(logger, plot)
+    model_info_dict = original_model_info_dict.copy()
+    date_info_dict = original_date_info_dict.copy()
+    plot_info_dict = original_plot_info_dict.copy()
+    met_info_dict = original_met_info_dict.copy()
+    if plot == 'precip_spatial_map':
+        model_info_dict['obs'] = {'name': 'ccpa',
+                                  'plot_name': 'ccpa',
+                                  'obs_name': '24hrCCPA'}
+        pcp_combine_base_dir = os.path.join(VERIF_CASE_STEP_dir, 'data')
+        import refs_atmos_plots_precip_spatial_map as gdap_psm
+        for psm_info in \
+                list(itertools.product(valid_hrs, fhrs)):
+            date_info_dict['valid_hr_start'] = str(psm_info[0])
+            date_info_dict['valid_hr_end'] = str(psm_info[0])
+            date_info_dict['valid_hr_inc'] = '24'
+            date_info_dict['forecast_hour'] = str(psm_info[1])
+            plot_info_dict['fcst_var_name'] = fcst_var_name
+            plot_info_dict['fcst_var_level'] = fcst_var_level_list[0]
+            plot_info_dict['fcst_var_thresh'] = 'NA'
+            plot_info_dict['obs_var_name'] = obs_var_name
+            plot_info_dict['obs_var_level'] = obs_var_level_list[0]
+            plot_info_dict['obs_var_thresh'] = 'NA'
+            plot_info_dict['interp_points'] = 'NA'
+            plot_psm = gdap_psm.PrecipSpatialMap(logger, pcp_combine_base_dir,
+                                                 job_output_dir,
+                                                 model_info_dict,
+                                                 date_info_dict,
+                                                 plot_info_dict,
+                                                 met_info_dict, logo_dir)
+            plot_psm.make_precip_spatial_map()
+    else:
+        logger.warning(plot+" not recongized")
+
+print("END: "+os.path.basename(__file__))

--- a/ush/cam/ush_refs_plot_py/refs_atmos_plots_precip_spatial_map.py
+++ b/ush/cam/ush_refs_plot_py/refs_atmos_plots_precip_spatial_map.py
@@ -1,0 +1,440 @@
+#! /usr/bin/env python3
+
+'''
+Name: refs_atmos_plots_precip_spatial_map.py
+Contact(s): Mallory Row
+Abstract: This script generates a spatial map for precip
+'''
+
+import netCDF4 as netcdf
+import pyproj
+import numpy as np
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import os
+import logging
+import sys
+import datetime
+import subprocess
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
+from cartopy import config
+from refs_atmos_plots_specs import PlotSpecs
+
+class PrecipSpatialMap:
+    """
+    Create a precipitation spatial map graphic
+    """
+
+    def __init__(self, logger, input_dir, output_dir, model_info_dict,
+                 date_info_dict, plot_info_dict, met_info_dict, logo_dir):
+        """! Initalize PrecipSpatialMap class
+             Args:
+                 logger          - logger object
+                 input_dir       - path to input directory (string)
+                 output_dir      - path to output directory (string)
+                 model_info_dict - model infomation dictionary (strings)
+                 plot_info_dict  - plot information dictionary (strings)
+                 date_info_dict  - date information dictionary (strings)
+                 met_info_dict   - MET information dictionary (strings)
+                 logo_dir        - directory with logo images (string)
+ 
+             Returns:
+        """
+        self.logger = logger
+        self.input_dir = input_dir
+        self.output_dir = output_dir
+        self.model_info_dict = model_info_dict
+        self.date_info_dict = date_info_dict
+        self.plot_info_dict = plot_info_dict
+        self.met_info_dict = met_info_dict
+        self.logo_dir = logo_dir
+
+    def make_precip_spatial_map(self):
+        """! Create the precipitation spatial map graphic
+             Args:
+             Returns:
+        """
+        self.logger.info(f"Creating preciptation spatial map...")
+        self.logger.debug(f"Input directory: {self.input_dir}")
+        self.logger.debug(f"Output directory: {self.output_dir}")
+        self.logger.debug(f"Model information dictionary: "
+                          +f"{self.model_info_dict}")
+        self.logger.debug(f"Date information dictionary: "
+                          +f"{self.date_info_dict}")
+        self.logger.debug(f"Plot information dictionary: "
+                          +f"{self.plot_info_dict}")
+        # Make job image directory
+        output_image_dir = os.path.join(self.output_dir, 'images')
+        if not os.path.exists(output_image_dir):
+            os.makedirs(output_image_dir)
+        self.logger.info(f"Plots will be in: {output_image_dir}")
+        # Set valid and initialization dates
+        valid_date_dt = datetime.datetime.strptime(
+            self.date_info_dict['end_date']
+            +self.date_info_dict['valid_hr_end'], '%Y%m%d%H'
+        )
+        init_date_dt = (
+            valid_date_dt 
+            - datetime.timedelta(
+                hours=int(self.date_info_dict['forecast_hour']))
+        )
+        # Set contour levels and color map
+        clevs_in = [0.01, 0.10, 0.25, 0.50, 0.75, 1.00, 1.25, 1.50,
+                    1.75, 2.00, 2.50, 3.00, 4.00, 5.00, 7.00, 10.00,
+                    15.00, 20.00]
+        colorlist_in = ['#7fff00', '#00cd00', '#008b00', '#104e8b',
+                        '#1e90ff', '#00b2ee', '#00eeee', '#8968cd',
+                        '#912cee', '#8b008b', '#8b0000', '#cd0000',
+                        '#ee4000', '#ff7f00', '#cd8500', '#ffd700',
+                        '#ffff00', '#ffff02']
+        cmap_over_color_in = '#ffaeb9'
+        clevs_mm = [0.1, 2, 5, 10, 15, 20, 25, 35, 50, 75, 100, 125,
+                    150, 175, 200]
+        colorlist_mm = ['chartreuse', 'green', 'blue', 'dodgerblue',
+                        'deepskyblue', 'cyan', 'mediumpurple',
+                        'mediumorchid', 'darkmagenta', 'darkred',
+                        'crimson', 'orangered', 'darkorange',
+                        'goldenrod', 'yellow']
+        cmap_over_color_mm = '#ffaeb9'
+        # Set Cartopy shapefile location
+        config['data_dir'] = config['repo_data_dir']
+        # Read in data
+        self.logger.info(f"Reading in model files from {self.input_dir}")
+        for model_num in self.model_info_dict:
+            model_num_dict = self.model_info_dict[model_num]
+            model_num_name = model_num_dict['name']
+            model_num_plot_name = model_num_dict['plot_name']
+            model_num_obs_name = model_num_dict['obs_name']
+            model_num_data_dir = os.path.join(self.input_dir, model_num_name)
+            make_plot = False
+            if model_num == 'obs':
+                image_data_source = 'qpe'
+                image_forecast_hour = '024'
+            else:
+                image_data_source = model_num_name
+                image_forecast_hour = (
+                    self.date_info_dict['forecast_hour'].zfill(3)
+                )
+            image_region_dict = {
+                'CONUS': 'conus',
+                'AK': 'alaska',
+                'HI': 'hawaii',
+                'PR': 'prico'
+            }
+            image_name = os.path.join(
+                output_image_dir,
+                image_data_source
+                +'.v'+valid_date_dt.strftime('%Y%m%d%H')+'.'
+                +image_forecast_hour+'h.'
+                +image_region_dict[self.plot_info_dict['vx_mask']]+'.png'
+            )
+            if model_num == 'obs':
+                model_num_file = os.path.join(
+                    model_num_data_dir,
+                    'ccpa_precip_24hrAccum_valid'
+                    +valid_date_dt.strftime('%Y%m%d%H')+'.nc'
+                )
+                if not os.path.exists(image_name):
+                    make_plot = True
+            else:
+                model_num_file = os.path.join(
+                    model_num_data_dir,
+                    model_num_name+'_precip_24hrAccum_init'
+                    +init_date_dt.strftime('%Y%m%d%H')+'_'
+                    +'fhr'+self.date_info_dict['forecast_hour'].zfill(3)
+                    +'.nc'
+                )
+            if not os.path.exists(image_name):
+                if os.path.exists(model_num_file):
+                    make_plot = True
+                else:
+                    make_plot = False
+                    self.logger.warning(f"{model_num_file} does not exist, "
+                                        +"not making plot")
+            else:
+                make_plot = False
+            if make_plot:
+                self.logger.debug("Plotting data from "+model_num_file)
+                precip_data = netcdf.Dataset(model_num_file)
+                precip_lat = precip_data.variables['lat'][:]
+                precip_lon = precip_data.variables['lon'][:]
+                precip_APCP_A24 = precip_data.variables['APCP_24'][:]
+                var_name = precip_data.variables['APCP_24'].getncattr('name')
+                var_level = precip_data.variables['APCP_24'].getncattr('level')
+                var_units = precip_data.variables['APCP_24'].getncattr('units')
+                if precip_lat.ndim == 1 and precip_lon.ndim == 1:
+                    x, y = np.meshgrid(precip_lon, precip_lat)
+                elif precip_lat.ndim == 2 and precip_lon.ndim == 2:
+                    x = precip_lon
+                    y = precip_lat
+                file_init_time = (precip_data.variables['APCP_24']\
+                                  .getncattr('init_time'))
+                file_valid_time = (precip_data.variables['APCP_24']\
+                                  .getncattr('valid_time'))
+                file_init_time_dt = datetime.datetime.strptime(
+                    file_init_time, '%Y%m%d_%H%M%S'
+                )
+                file_valid_time_dt = datetime.datetime.strptime(
+                    file_valid_time, '%Y%m%d_%H%M%S'
+                )
+                if valid_date_dt != file_valid_time_dt:
+                    self.logger.error(f"FILE VALID TIME {file_valid_time_dt} "
+                                      +"DOES NOT MATCH EXPECTED VALID TIME "
+                                      +f"{valid_date_dt}")
+                    sys.exit(1)
+                if model_num != 'obs':
+                    if init_date_dt != file_init_time_dt:
+                        self.logger.error(f"FILE INIT TIME {file_init_time_dt} "
+                                          +"DOES NOT MATCH EXPECTED INIT TIME "
+                                          +f"{init_date_dt}")
+                        sys.exit(1)
+                if var_units in ['mm', 'kg/m^2', 'm']:
+                    self.logger.info(f"Converting from {var_units} to " 
+                                     +"inches")
+                    precip_APCP_A24 = precip_APCP_A24 * 0.0393701
+                    var_units = 'inches'
+                self.logger.info(f"Doing plot set up")
+                plot_specs_psm = PlotSpecs(self.logger, 'precip_spatial_map')
+                plot_specs_psm.set_up_plot()
+                forecast_day = int(self.date_info_dict['forecast_hour'])/24.
+                if int(self.date_info_dict['forecast_hour']) % 24 == 0:
+                    forecast_day_plot = str(int(forecast_day))
+                else:
+                    forecast_day_plot = str(forecast_day)
+                if model_num == 'obs':
+                    plot_title = (
+                        model_num_plot_name.upper()+' '
+                        +plot_specs_psm.get_var_plot_name(var_name, var_level)+' '
+                        +f'({var_units})\n'
+                        +'valid '
+                        +(valid_date_dt-datetime.timedelta(hours=24))\
+                        .strftime('%d%b%Y %H')+'Z to '
+                        +valid_date_dt.strftime('%d%b%Y %H')+'Z'
+                    )
+                else:
+                    plot_title = (
+                        model_num_plot_name.upper()+' '
+                        +plot_specs_psm.get_var_plot_name(var_name, var_level)+' '
+                        +f'({var_units})\n'
+                        +'Forecast Day '+forecast_day_plot+' '
+                        +'(Hour '+self.date_info_dict['forecast_hour']+')\n'
+                        +'valid '
+                        +(valid_date_dt-datetime.timedelta(hours=24))\
+                        .strftime('%d%b%Y %H')+'Z to '
+                        +valid_date_dt.strftime('%d%b%Y %H')+'Z'
+                    )
+                plot_left_logo = False
+                plot_left_logo_path = os.path.join(self.logo_dir, 'noaa.png')
+                if os.path.exists(plot_left_logo_path):
+                    plot_left_logo = True
+                    left_logo_img_array = matplotlib.image.imread(
+                        plot_left_logo_path
+                    )
+                    left_logo_xpixel_loc,left_logo_ypixel_loc,left_logo_alpha = (
+                        plot_specs_psm.get_logo_location(
+                            'left', plot_specs_psm.fig_size[0],
+                             plot_specs_psm.fig_size[1],
+                             plt.rcParams['figure.dpi']
+                        )
+                    )
+                plot_right_logo = False
+                plot_right_logo_path = os.path.join(self.logo_dir, 'nws.png')
+                if os.path.exists(plot_right_logo_path):
+                    plot_right_logo = True
+                    right_logo_img_array = matplotlib.image.imread(
+                        plot_right_logo_path
+                    )
+                    right_logo_xpixel_loc,right_logo_ypixel_loc,right_logo_alpha = (
+                        plot_specs_psm.get_logo_location(
+                            'right', plot_specs_psm.fig_size[0],
+                            plot_specs_psm.fig_size[1],
+                            plt.rcParams['figure.dpi']
+                        )
+                    )
+                if var_units == 'inches':
+                    clevs = clevs_in
+                    cmap = matplotlib.colors.ListedColormap(colorlist_in)
+                    cmap_over_color = cmap_over_color_in
+                elif var_units in ['mm', 'kg/m^2']:
+                    clevs = clevs_mm
+                    cmap = matplotlib.colors.ListedColormap(colorlist_mm)
+                    cmap_over_color = cmap_over_color_mm
+                norm = matplotlib.colors.BoundaryNorm(clevs, cmap.N)
+                # Create plot
+                self.logger.info(f"Creating plot for {model_num_file}")
+                fig = plt.figure(figsize=(plot_specs_psm.fig_size[0],
+                                          plot_specs_psm.fig_size[1]))
+                gs_hspace, gs_wspace = 0, 0
+                gs_bottom, gs_top = 0.125, 0.85
+                gs = gridspec.GridSpec(1,1, bottom=gs_bottom, top=gs_top,
+                                       hspace=gs_hspace, wspace=gs_wspace)
+                fig.suptitle(plot_title)
+                if plot_left_logo:
+                    left_logo_img = fig.figimage(
+                        left_logo_img_array, left_logo_xpixel_loc,
+                        left_logo_ypixel_loc, zorder=1, alpha=right_logo_alpha
+                    )
+                    left_logo_img.set_visible(True)
+                if plot_right_logo:
+                    right_logo_img = fig.figimage(
+                        right_logo_img_array, right_logo_xpixel_loc,
+                        right_logo_ypixel_loc, zorder=1, alpha=right_logo_alpha
+                    )
+                if self.plot_info_dict['vx_mask'] == 'CONUS':
+                    extent = [-124,-70,18.0,50.0]
+                    central_lon = -97.6
+                    central_lat = 35.4
+                elif self.plot_info_dict['vx_mask'] == 'AK':
+                    extent = [-180,-110,45.0,75.0]
+                    central_lon = -145
+                    central_lat = 60
+                elif self.plot_info_dict['vx_mask'] == 'PR':
+                    extent = [-75,-60,12.0,25.0]
+                    central_lon = -67.5
+                    central_lat = 18.5
+                elif self.plot_info_dict['vx_mask'] == 'HI':
+                    extent = [-165,-150,15.0,25.0]
+                    central_lon = -157.5
+                    central_lat = 20
+                myproj=ccrs.LambertConformal(central_longitude=central_lon,
+                                             central_latitude=central_lat,
+                                             false_easting=0.0,
+                                             false_northing=0.0,
+                                             globe=None)
+                ax1 = fig.add_subplot(gs[0], projection=myproj)
+                ax1.set_extent(extent)
+                ax1.add_feature(cfeature.COASTLINE.with_scale('50m'),
+                                zorder=2, linewidth=1)
+                ax1.add_feature(cfeature.BORDERS.with_scale('50m'),
+                                zorder=2, linewidth=1)
+                ax1.add_feature(cfeature.STATES.with_scale('50m'),
+                                zorder=2, linewidth=1)
+                CF1 = ax1.contourf(x, y, precip_APCP_A24,
+                                   transform=ccrs.PlateCarree(),
+                                   levels=clevs, norm=norm,
+                                   cmap=cmap, extend='max')
+                CF1.cmap.set_over(cmap_over_color)
+                cbar_left = gs.get_grid_positions(fig)[2][0]
+                cbar_width = (gs.get_grid_positions(fig)[3][-1]
+                              - gs.get_grid_positions(fig)[2][0])
+                cbar_bottom = 0.075
+                cbar_height = 0.03
+                cbar_ax = fig.add_axes(
+                    [cbar_left, cbar_bottom, cbar_width, cbar_height]
+                )
+                cbar = fig.colorbar(CF1, cax=cbar_ax,
+                                    orientation='horizontal',
+                                    ticks=CF1.levels)
+                cbar.ax.set_xlabel(f'Precipitation ({var_units})',
+                                   labelpad = 0)
+                cbar.ax.xaxis.set_tick_params(pad=0)
+                cbar_tick_labels_list = []
+                for tick in cbar.get_ticks():
+                    if str(tick).split('.')[1] == '0':
+                        cbar_tick_labels_list.append(
+                            str(int(tick))
+                        )
+                    else:
+                        cbar_tick_labels_list.append(
+                            str(round(tick,3)).rstrip('0')
+                        )
+                cbar.ax.set_xticklabels(cbar_tick_labels_list)
+                self.logger.info("Saving image as "+image_name)
+                plt.savefig(image_name)
+                plt.clf()
+                plt.close('all')
+                # Convert png to gif, if possible
+                check_convert = subprocess.run(
+                    ['which', 'convert'], stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
+                if check_convert.returncode == 0:
+                    self.logger.info(f"Converting {image_name} to "
+                                     +f"{image_name.replace('.png', '.gif')}")
+                    run_convert = subprocess.run(
+                        ['convert', image_name,
+                         image_name.replace('.png', '.gif')]
+                    )
+                else:
+                    self.logger.warning("convert executable not in PATH, "
+                                        "not creating gif of image")
+
+def main():
+    # Need settings
+    INPUT_DIR = os.environ['HOME']
+    OUTPUT_DIR = os.environ['HOME']
+    LOGO_DIR = os.environ['HOME'],
+    MODEL_INFO_DICT = {
+        'model1': {'name': 'MODEL_A',
+                   'plot_name': 'PLOT_MODEL_A',
+                   'obs_name': 'MODEL_A_OBS'},
+        'obs': {'name': 'OBS',
+                'plot_name': 'PLOT_OBS',
+                'obs_name': 'OBS'}
+    }
+    DATE_INFO_DICT = {
+        'date_type': 'DATE_TYPE',
+        'start_date': 'START_DATE',
+        'end_date': 'END_DATE',
+        'valid_hr_start': 'VALID_HR_START',
+        'valid_hr_end': 'VALID_HR_END',
+        'valid_hr_inc': 'VALID_HR_INC',
+        'init_hr_start': 'INIT_HR_START',
+        'init_hr_end': 'INIT_HR_END',
+        'init_hr_inc': 'INIT_HR_INC',
+        'forecast_hour': 'FORECAST_HOUR'
+    }
+    PLOT_INFO_DICT = {
+        'line_type': 'LINE_TYPE',
+        'grid': 'GRID',
+        'stat': 'STAT',
+        'vx_mask': 'VX_MASK',
+        'event_equalization': 'EVENT_EQUALIZATION',
+        'interp_method': 'INTERP_METHOD',
+        'interp_points': 'INTERP_POINTS',
+        'fcst_var_name': 'FCST_VAR_NAME',
+        'fcst_var_level': 'FCST_VAR_LEVEL',
+        'fcst_var_thresh': 'FCST_VAR_THRESH',
+        'obs_var_name': 'OBS_VAR_NAME',
+        'obs_var_level': 'OBS_VAR_LEVEL',
+        'obs_var_thresh': 'OBS_VAR_THRESH',
+    }
+    MET_INFO_DICT = {
+        'root': '/PATH/TO/MET',
+        'version': '10.1.1'
+    }
+    # Create OUTPUT_DIR
+    if not os.path.exists(OUTPUT_DIR):
+        os.makedirs(OUTPUT_DIR)
+    # Set up logging
+    logging_dir = os.path.join(OUTPUT_DIR, 'logs')
+    if not os.path.exists(logging_dir):
+         os.makedirs(logging_dir)
+    job_logging_file = os.path.join(logging_dir, 
+                                    os.path.basename(__file__)+'_runon'
+                                    +datetime.datetime.now()\
+                                    .strftime('%Y%m%d%H%M%S')+'.log')
+    logger = logging.getLogger(job_logging_file)
+    logger.setLevel('DEBUG')
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(job_logging_file, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {job_logging_file}"
+    print(logger_info)
+    logger.info(logger_info)
+    p = PrecipSpatialMap(logger, INPUT_DIR, OUTPUT_DIR, MODEL_INFO_DICT,
+                         DATE_INFO_DICT, PLOT_INFO_DICT, MET_INFO_DICT,
+                         LOGO_DIR)
+    p.make_precip_spatial_map()
+
+if __name__ == "__main__":
+    main()

--- a/ush/cam/ush_refs_plot_py/refs_atmos_plots_specs.py
+++ b/ush/cam/ush_refs_plot_py/refs_atmos_plots_specs.py
@@ -1,0 +1,1133 @@
+#! /usr/bin/env python3
+
+import matplotlib
+import matplotlib.pyplot as plt
+import datetime
+import sys
+import os
+import numpy as np
+
+class PlotSpecs:
+    def __init__(self, logger, plot_type):
+        """! Initalize PlotSpecs class
+
+             Args:
+                 logger    - logger object
+                 plot_type - type of graphic being produced (string)
+ 
+             Returns:
+        """
+        self.plot_type = plot_type
+        self.logger = logger
+        self.font_weight = 'bold'
+        self.axis_title_weight = 'bold'
+        self.axis_title_size = 16
+        self.axis_title_pad = 15
+        self.axis_title_loc = 'center'
+        self.axis_offset = False
+        self.axis_label_weight = 'bold'
+        self.axis_label_size = 16
+        self.axis_label_pad = 10
+        self.xtick_label_size = 16
+        self.xtick_major_pad = 10
+        self.ytick_label_size = 16
+        self.ytick_major_pad = 10
+        self.fig_title_weight = 'bold'
+        self.fig_title_size = 16
+        self.fig_subplot_right = 0.95
+        self.fig_subplot_left = 0.1
+        self.fig_subplot_top = 0.925
+        self.fig_subplot_bottom = 0.075
+        self.legend_handle_text_pad = 0.25
+        self.legend_handle_length = 1.25
+        self.legend_border_axis_pad = 0
+        self.legend_col_space = 1.0
+        self.legend_frame_on = True
+        self.legend_bbox = (0,1)
+        self.legend_font_size = 13
+        self.legend_loc = 'center'
+        self.legend_ncol = 1
+        self.title_loc = 'center'
+        self.fig_size=(16.,16.)
+        if self.plot_type == 'time_series':
+            self.fig_size = (16., 8.)
+            self.fig_subplot_top = 0.87
+            self.fig_subplot_bottom = 0.1
+            self.fig_subplot_right = 0.925
+            self.fig_subplot_left = 0.085
+            self.axis_label_size = 15
+            self.xtick_label_size = 15
+            self.ytick_label_size = 15
+            self.legend_frame_on = False
+            self.legend_bbox = (0.5, 0.05)
+            self.legend_ncol = 4
+        elif self.plot_type in ['lead_average', 'valid_hour_average',
+                                'threshold_average']:
+            self.fig_size = (16., 16.)
+            self.fig_subplot_top = 0.9
+            self.fig_subplot_bottom = 0.05
+            self.fig_subplot_right = 0.92
+            self.fig_subplot_left = 0.12
+            self.legend_frame_on = False
+            self.legend_bbox = (0.5, 0.05)
+            self.legend_ncol = 5
+            self.fig_title_size = 18
+        elif self.plot_type == 'lead_by_date':
+            self.fig_size = (16., 16.)
+            self.axis_title_pad = 5
+            self.axis_title_loc = 'left'
+            self.fig_subplot_top = 0.9
+            self.fig_subplot_bottom = 0.075
+            self.fig_subplot_right = 0.923
+            self.fig_subplot_left = 0.15
+            self.fig_title_size = 18
+        elif self.plot_type == 'stat_by_level':
+            self.fig_size = (16., 16.)
+            self.fig_subplot_top = 0.925
+            self.fig_subplot_bottom = 0.05
+            self.fig_subplot_right = 0.925
+            self.fig_subplot_left = 0.1
+            self.legend_frame_on = False
+            self.legend_bbox = (0.01, 0.995)
+            self.legend_ncol = 1
+            self.legend_font_size = 15
+            self.legend_loc = 'upper left'
+            self.fig_title_size = 18
+        elif self.plot_type == 'lead_by_level':
+            self.fig_size = (16., 16.)
+            self.axis_title_pad = 5
+            self.axis_title_loc = 'left'
+            self.fig_subplot_top = 0.95
+            self.fig_subplot_bottom = 0.025
+            self.fig_subplot_right = 0.95
+            self.fig_subplot_left = 0.1
+            self.fig_title_size = 18
+        elif self.plot_type in ['precip_spatial_map', 'nohrsc_spatial_map']:
+            self.fig_size = (8., 6.)
+            self.fig_title_size = 13
+            self.fig_subplot_right = 0.975
+            self.fig_subplot_left = 0.025
+            self.axis_label_size = 12
+            self.xtick_label_size = 12
+            self.axis_tick_size = 13
+        elif self.plot_type == 'performance_diagram':
+            self.fig_size = (16., 16.)
+            self.fig_subplot_top = 0.9
+            self.fig_subplot_bottom = 0.175
+            self.fig_subplot_right = 0.85
+            self.fig_subplot_left = 0.075
+            self.legend_frame_on = True
+            self.legend_loc = 'upper center'
+            self.legend_ncol = 5
+            self.legend_font_size = 16
+            self.fig_title_size = 18
+        else:
+            self.logger.error(f"{self.plot_type} NOT RECOGNIZED")
+            sys.exit(1)
+
+    def set_up_plot(self):
+        """! Set up the matplotlib rcParams
+
+             Args:
+ 
+             Returns:
+        """
+        plt.rcParams['font.weight'] = self.font_weight
+        plt.rcParams['axes.titleweight'] = self.axis_title_weight
+        plt.rcParams['axes.titlesize'] = self.axis_title_size
+        plt.rcParams['axes.titlepad'] = self.axis_title_pad
+        plt.rcParams['axes.titlelocation'] = self.axis_title_loc
+        plt.rcParams['axes.labelweight'] = self.axis_label_weight
+        plt.rcParams['axes.labelsize'] = self.axis_label_size
+        plt.rcParams['axes.labelpad'] = self.axis_label_pad
+        plt.rcParams['axes.formatter.useoffset'] = self.axis_offset
+        plt.rcParams['xtick.labelsize'] = self.xtick_label_size
+        plt.rcParams['xtick.major.pad'] = self.xtick_major_pad
+        plt.rcParams['ytick.labelsize'] = self.ytick_label_size
+        plt.rcParams['ytick.major.pad'] = self.ytick_major_pad
+        plt.rcParams['figure.subplot.left'] = self.fig_subplot_left
+        plt.rcParams['figure.subplot.right'] = self.fig_subplot_right
+        plt.rcParams['figure.subplot.top'] = self.fig_subplot_top
+        plt.rcParams['figure.subplot.bottom'] = self.fig_subplot_bottom
+        plt.rcParams['figure.titleweight'] = self.fig_title_weight
+        plt.rcParams['figure.titlesize'] = self.fig_title_size
+        plt.rcParams['legend.handletextpad'] = self.legend_handle_text_pad
+        plt.rcParams['legend.handlelength'] = self.legend_handle_length
+        plt.rcParams['legend.borderaxespad'] = self.legend_border_axis_pad
+        plt.rcParams['legend.columnspacing'] = self.legend_col_space
+        plt.rcParams['legend.frameon'] = self.legend_frame_on
+        if float(matplotlib.__version__[0:3]) >= 3.3:
+            plt.rcParams['date.epoch'] = '0000-12-31T00:00:00'
+
+    def get_stat_plot_name(self, stat):
+        """! Get the full statistic name that will be
+             displayed on the plot
+
+             Args:
+                 stat - abbreviated statistic name (string)
+ 
+             Returns:
+                 stat_plot_name - full statistic name that
+                                  will be displayed on the plot
+                                  (string)
+        """
+        stat_plot_name_dict = {
+            'ACC': 'Anomaly Correlation Coefficient',
+            'BIAS': 'Bias (Mean Error)',
+            'CSI': 'Critical Success Index',
+            'ETS': 'Equitable Threat Score',
+            'FBAR': 'Forecast Mean',
+            'FBAR_OBAR': 'Forecast and Observation Mean',
+            'FBIAS': 'Frequency Bias',
+            'FSS': 'Fraction Skill Score',
+            'FY_OY': 'Forecast:Yes,Obs:Yes',
+            'GSS': 'Gilbert Skill Score',
+            'HSS': 'Heidke Skill Score',
+            'ME': 'Mean Error (Bias)',
+            'OBAR': 'Observation Mean',
+            'POD': 'Probability of Detection',
+            'PERF_DIA': 'Performance Diagram',
+            'RMSE': 'Root Mean Square Error',
+            'S1': 'S1 Score',
+            'SRATIO': 'Success Ratio (1-FAR)'
+        }
+        if stat in list(stat_plot_name_dict.keys()):
+            stat_plot_name = stat_plot_name_dict[stat]
+        else:
+            self.logger.debug(f"{stat} not recognized, using {stat} on plot")
+            stat_plot_name = stat
+        return stat_plot_name
+
+    def get_var_plot_name(self, var_name, var_level):
+        """! Get the full variable information that will be displayed
+             on the plot
+
+             Args:
+                 var_name   - abbreviated variable name (string)
+                 var_level  - abbreviated variable level (string)
+             Returns:
+                 var_plot_name - full variable information that
+                                 will be displayed on the plot
+                                 (string)
+        """
+        var_name_level = var_name+'/'+var_level
+        var_plot_name_dict = {
+            'APCP/A24': '24 hour Accumulated Precipitation',
+            'APCP_A24/A24': '24 hour Accumulated Precipitation',
+            'APCP_24/A24': '24 hour Accumulated Precipitation',
+            'APCP_24_A24_ENS_MEAN/A24': '24 hour Accumulated Precipitation',
+            'APCP_24_A24_ENS_MEAN': '24 hour Accumulated Precipitation',
+            'CAPE/P90-0': 'Mixed-Layer CAPE',
+            'CAPE/Z0': 'Surface Based CAPE',
+            'CFRZR/L0': 'Precipitation Type - Freezing Rain',
+            'CICEP/L0': 'Precipitation Type - Ice Pellets',
+            'CRAIN/L0': 'Precipitation Type - Rain',
+            'CSNOW/L0': 'Precipitation Type - Snow',
+            'CWAT/L0': 'Cloud Water',
+            'DPT/Z2': '2 meter Dewpoint',
+            'GUST/Z0': 'Surface Wind Gust',
+            'HGT/CEILING': 'Ceiling',
+            'HGT/all': 'Geopotential Height - All Levels',
+            'HGT/trop': 'Geopotential Height - Troposphere',
+            'HGT/ltrop': 'Geopotential Height - Lower Troposphere',
+            'HGT/utrop': 'Geopotential Height - Upper Troposphere',
+            'HGT/strat': 'Geopotential Height - Stratosphere',
+            'HGT/P1': '1 hPa Geopotential Height',
+            'HGT/P5': '5 hPa Geopotential Height',
+            'HGT/P10': '10 hPa Geopotential Height',
+            'HGT/P20': '20 hPa Geopotential Height',
+            'HGT/P50': '50 hPa Geopotential Height',
+            'HGT/P100': '100 hPa Geopotential Height',
+            'HGT/P150': '150 hPa Geopotential Height',
+            'HGT/P200': '200 hPa Geopotential Height',
+            'HGT/P250': '250 hPa Geopotential Height',
+            'HGT/P300': '300 hPa Geopotential Height',
+            'HGT/P400': '400 hPa Geopotential Height',
+            'HGT/P500': '500 hPa Geopotential Height',
+            'HGT/P700': '700 hPa Geopotential Height',
+            'HGT/P850': '850 hPa Geopotential Height',
+            'HGT/P925': '925 hPa Geopotential Height',
+            'HGT/P1000': '1000 hPa Geopotential Height',
+            'HGT/TROPOPAUSE': 'Tropopause Geopotential Height',
+            'HGT_ANOM_DAILYAVG/P500': ('500 hPa Daily Avg '
+                                       +'Geopotential Height Anomaly'),
+            'HGT_DECOMP_WV1_0-3/P500': ('500 hPa Geopotential Height: '
+                                        +'Waves 0-3'),
+            'HGT_DECOMP_WV1_0-20/P500': ('500 hPa Geopotential Height: '
+                                         +'Waves 0-20'),
+            'HGT_DECOMP_WV1_4-9/P500': ('500 hPa Geopotential Height: '
+                                        +'Waves 4-9'),
+            'HGT_DECOMP_WV1_10-20/P500': ('500 hPa Geopotential Height: '
+                                          +'Waves 10-20'), 
+            'HPBL/L0': 'Planetary Boundary Layer Height',
+            'ICEC_DAILYAVG/Z0': 'Daily Avg Ice Concentration',
+            'ICEC_WEEKLYAVG/Z0': 'Weekly Avg Ice Concentration',
+            'O3MR/all': 'Ozone Mixing Ratio - All Levels',
+            'O3MR/trop': 'Ozone Mixing Ratio - Troposphere',
+            'O3MR/ltrop': 'Ozone Mixing Ratio - Lower Troposphere',
+            'O3MR/utrop': 'Ozone Mixing Ratio - Upper Troposphere',
+            'O3MR/strat': 'Ozone Mixing Ratio - Stratosphere',
+            'O3MR/P1': '1 hPa Ozone Mixing Ratio',
+            'O3MR/P5': '5 hPa Ozone Mixing Ratio',
+            'O3MR/P10': '10 hPa Ozone Mixing Ratio',
+            'O3MR/P20': '20 hPa Ozone Mixing Ratio',
+            'O3MR/P30': '30 hPa Ozone Mixing Ratio',
+            'O3MR/P50': '50 hPa Ozone Mixing Ratio',
+            'O3MR/P70': '70 hPa Ozone Mixing Ratio',
+            'O3MR/P100': '100 hPa Ozone Mixing Ratio',
+            'O3MR/P925': '925 hPa Ozone Mixing Ratio',
+            'PRES/TROPOPAUSE': 'Tropopause Pressure',
+            'PRES/Z0': 'Surface Pressure',
+            'PRMSL/Z0': 'Pressure Reduced to MSL',
+            'PWAT/L0': 'Precipitable Water',
+            'RH/all': 'Relative Humidity - All Levels',
+            'RH/trop': 'Relative Humidity - Troposphere',
+            'RH/ltrop': 'Relative Humidity - Lower Troposphere',
+            'RH/utrop': 'Relative Humidity - Upper Troposphere',
+            'RH/strat': 'Relative Humidity - Stratosphere',
+            'RH/P1': '1 hPa Relative Humidity',
+            'RH/P5': '5 hPa Relative Humidity',
+            'RH/P10': '10 hPa Relative Humidity',
+            'RH/P20': '20 hPa Relative Humidity',
+            'RH/P50': '50 hPa Relative Humidity',
+            'RH/P100': '100 hPa Relative Humidity',
+            'RH/P150': '150 hPa Relative Humidity',
+            'RH/P200': '200 hPa Relative Humidity',
+            'RH/P250': '250 hPa Relative Humidity',
+            'RH/P300': '300 hPa Relative Humidity',
+            'RH/P400': '400 hPa Relative Humidity',
+            'RH/P500': '500 hPa Relative Humidity',
+            'RH/P700': '700 hPa Relative Humidity',
+            'RH/P850': '850 hPa Relative Humidity',
+            'RH/P925': '925 hPa Relative Humidity',
+            'RH/P1000': '1000 hPa Relative Humidity',
+            'RH/Z2': '2 meter Relative Humidity',
+            'SNOD_A24/Z0': '24 hour Snow Accumulation (derived from SNOD)',
+            'SOILW/Z0.1-0': '0.1-0 meter Volumetric Soil Moisture Content',
+            'SPFH/all': 'Specific Humidity - All Levels',
+            'SPFH/trop': 'Specific Humidity - Troposphere',
+            'SPFH/ltrop': 'Specific Humidity - Lower Troposphere',
+            'SPFH/utrop': 'Specific Humidity - Upper Troposphere',
+            'SPFH/strat': 'Specific Humidity - Stratosphere',
+            'SPFH/P1': '1 hPa Specific Humidity',
+            'SPFH/P5': '5 hPa Specific Humidity',
+            'SPFH/P10': '10 hPa Specific Humidity',
+            'SPFH/P20': '20 hPa Specific Humidity',
+            'SPFH/P50': '50 hPa Specific Humidity',
+            'SPFH/P100': '100 hPa Specific Humidity',
+            'SPFH/P150': '150 hPa Specific Humidity',
+            'SPFH/P200': '200 hPa Specific Humidity',
+            'SPFH/P250': '250 hPa Specific Humidity',
+            'SPFH/P300': '300 hPa Specific Humidity',
+            'SPFH/P400': '400 hPa Specific Humidity',
+            'SPFH/P500': '500 hPa Specific Humidity',
+            'SPFH/P700': '700 hPa Specific Humidity',
+            'SPFH/P850': '850 hPa Specific Humidity',
+            'SPFH/P925': '925 hPa Specific Humidity',
+            'SPFH/P1000': '1000 hPa Specific Humidity',
+            'SPFH/Z2': '2 meter Specific Humidity',
+            'SST_DAILYAVG/Z0': 'Daily Avg Sea Surface Temperature',
+            'TCDC/TOTAL': 'Total Cloud Cover',
+            'TMP/all': 'Temperature - All Levels',
+            'TMP/trop': 'Temperature - Troposphere',
+            'TMP/ltrop': 'Temperature - Lower Troposphere',
+            'TMP/utrop': 'Temperature - Upper Troposphere',
+            'TMP/strat': 'Temperature - Stratosphere',
+            'TMP/P1': '1 hPa Temperature',
+            'TMP/P5': '5 hPa Temperature',
+            'TMP/P10': '10 hPa Temperature',
+            'TMP/P20': '20 hPa Temperature',
+            'TMP/P50': '50 hPa Temperature',
+            'TMP/P100': '100 hPa Temperature',
+            'TMP/P150': '150 hPa Temperature',
+            'TMP/P100': '100 hPa Temperature',
+            'TMP/P200': '200 hPa Temperature',
+            'TMP/P250': '250 hPa Temperature',
+            'TMP/P300': '300 hPa Temperature',
+            'TMP/P400': '400 hPa Temperature',
+            'TMP/P500': '500 hPa Temperature',
+            'TMP/P700': '700 hPa Temperature',
+            'TMP/P850': '850 hPa Temperature',
+            'TMP/P925': '925 hPa Temperature',
+            'TMP/P1000': '1000 hPa Temperature',
+            'TMP/TROPOPAUSE': 'Tropopause Temperature',
+            'TMP/Z2': '2 meter Temperature',
+            'TMP_ANOM_DAILYAVG/Z2': '2 meter Daily Avg Temperature Anomaly',
+            'TOZNE/L0': 'Total Ozone',
+            'TSOIL/Z0.1-0': '0.1-0 meter Soil Temperature',
+            'UGRD/all': 'U-Component of Wind - All Levels',
+            'UGRD/trop': 'U-Component of Wind - Troposphere',
+            'UGRD/ltrop': 'U-Component of Wind - Lower Troposphere',
+            'UGRD/utrop': 'U-Component of Wind - Upper Troposphere',
+            'UGRD/strat': 'U-Component of Wind - Stratosphere',
+            'UGRD/P1': '1 hPa U-Component of Wind',
+            'UGRD/P5': '5 hPa U-Component of Wind',
+            'UGRD/P10': '10 hPa U-Component of Wind',
+            'UGRD/P20': '20 hPa U-Component of Wind',
+            'UGRD/P50': '50 hPa U-Component of Wind',
+            'UGRD/P100': '100 hPa U-Component of Wind',
+            'UGRD/P150': '150 hPa U-Component of Wind',
+            'UGRD/P200': '200 hPa U-Component of Wind',
+            'UGRD/P250': '250 hPa U-Component of Wind',
+            'UGRD/P300': '300 hPa U-Component of Wind',
+            'UGRD/P400': '400 hPa U-Component of Wind',
+            'UGRD/P500': '500 hPa U-Component of Wind',
+            'UGRD/P700': '700 hPa U-Component of Wind',
+            'UGRD/P850': '850 hPa U-Component of Wind',
+            'UGRD/P925': '925 hPa U-Component of Wind',
+            'UGRD/P1000': '1000 hPa U-Component of Wind',
+            'UGRD/Z10': '10 meter U-Component of Wind',
+            'UGRD_VGRD/all': 'Vector Wind - All Levels',
+            'UGRD_VGRD/trop': 'Vector Wind - Troposphere',
+            'UGRD_VGRD/ltrop': 'Vector Wind - Lower Troposphere',
+            'UGRD_VGRD/utrop': 'Vector Wind - Upper Troposphere',
+            'UGRD_VGRD/strat': 'Vector Wind - Stratosphere',
+            'UGRD_VGRD/P1': '1 hPa Vector Wind',
+            'UGRD_VGRD/P5': '5 hPa Vector Wind',
+            'UGRD_VGRD/P10': '10 hPa Vector Wind',
+            'UGRD_VGRD/P20': '20 hPa Vector Wind',
+            'UGRD_VGRD/P50': '50 hPa Vector Wind',
+            'UGRD_VGRD/P100': '100 hPa Vector Wind',
+            'UGRD_VGRD/P150': '150 hPa Vector Wind',
+            'UGRD_VGRD/P200': '200 hPa Vector Wind',
+            'UGRD_VGRD/P250': '250 hPa Vector Wind',
+            'UGRD_VGRD/P300': '300 hPa Vector Wind',
+            'UGRD_VGRD/P400': '400 hPa Vector Wind',
+            'UGRD_VGRD/P500': '500 hPa Vector Wind',
+            'UGRD_VGRD/P700': '700 hPa Vector Wind',
+            'UGRD_VGRD/P850': '850 hPa Vector Wind',
+            'UGRD_VGRD/P925': '925 hPa Vector Wind',
+            'UGRD_VGRD/P1000': '1000 hPa Vector Wind',
+            'UGRD_VGRD/Z10': '10 meter Vector Wind',
+            'VIS/Z0': 'Visibility',
+            'VGRD/all': 'V-Component of Wind - All Levels',
+            'VGRD/trop': 'V-Component of Wind - Troposphere',
+            'VGRD/ltrop': 'V-Component of Wind - Lower Troposphere',
+            'VGRD/utrop': 'V-Component of Wind - Upper Troposphere',
+            'VGRD/strat': 'V-Component of Wind - Stratosphere',
+            'VGRD/P1': '1 hPa V-Component of Wind',
+            'VGRD/P5': '5 hPa V-Component of Wind',
+            'VGRD/P10': '10 hPa V-Component of Wind',
+            'VGRD/P20': '20 hPa V-Component of Wind',
+            'VGRD/P50': '50 hPa V-Component of Wind',
+            'VGRD/P100': '100 hPa V-Component of Wind',
+            'VGRD/P150': '150 hPa V-Component of Wind',
+            'VGRD/P200': '200 hPa V-Component of Wind',
+            'VGRD/P250': '250 hPa V-Component of Wind',
+            'VGRD/P300': '300 hPa V-Component of Wind',
+            'VGRD/P400': '400 hPa V-Component of Wind',
+            'VGRD/P500': '500 hPa V-Component of Wind',
+            'VGRD/P700': '700 hPa V-Component of Wind',
+            'VGRD/P850': '850 hPa V-Component of Wind',
+            'VGRD/P925': '925 hPa V-Component of Wind',
+            'VGRD/P1000': '1000 hPa V-Component of Wind',
+            'VGRD/Z10': '10 meter V-Component of Wind',
+            'WEASD/Z0': 'Water Equivalent of Accumulated Snow Depth',
+            'WEASD_A24/Z0': '24 hour Snow Accumulation (derived from WEASD)',
+            'WNDSHR/P850-P200': 'Wind Shear (850-200 hPa)'
+        }
+        if var_name_level in list(var_plot_name_dict.keys()):
+            var_plot_name = var_plot_name_dict[var_name_level]
+        else:
+            self.logger.debug(f"{var_name_level} not recognized, "
+                              +f"using {var_name_level} on plot")
+            var_plot_name = var_name_level
+        return var_plot_name
+
+    def get_vx_mask_plot_name(self, vx_mask):
+        """! Get the full verification masking information that will
+             be displayed on the plot
+
+             Args:
+                 vx_mask - abbreviated verification mask name (string)
+ 
+             Returns:
+                 vx_mask_plot_name - full verification mask name that
+                                     will be displayed on the plot
+                                     (string)
+        """
+        vx_mask_plot_name_dict = {
+             'Alaska': 'Alaska',
+             'ANTARCTIC': 'Antarctic 50S-90S',
+             'Appalachia': 'Appalachia',
+             'ARCTIC': 'Arctic 50N-90N',
+             'ATL_MDR': 'Atlantic Main Development Region',
+             'CONUS': 'CONUS',
+             'CONUS_Central': 'CONUS - Central',
+             'CONUS_East': 'CONUS - East',
+             'CONUS_South': 'CONUS - South',
+             'CONUS_West': 'CONUS - West',
+             'CPlains': 'Central Plains',
+             'DeepSouth': 'Deep South',
+             'EPAC_MDR': 'East Pacific Main Development Region',
+             'GLOBAL': 'Global',
+             'GreatBasin': 'Great Basin',
+             'GreatLakes': 'Great Lakes',
+             'Mezquital': 'Mezquital',
+             'MidAtlantic': 'Mid-Atlantic',
+             'N60N90': '60N-90N',
+             'NAO': 'Northern Atlantic Ocean',
+             'NPO': 'Northern Pacific Ocean',
+             'NHEM': 'Northern Hemisphere 20N-80N',
+             'NorthAtlantic': 'Northeast (North Atlantic)',
+             'NPlains': 'Northern Plains',
+             'NRockies': 'Northern Rockies',
+             'PacificNW': 'Pacific Northwest',
+             'PacificSW': 'Pacific Southwest',
+             'Prairie': 'Prairie',
+             'S60S90': '60S-90S',
+             'SAO': 'Southern Atlantic Ocean',
+             'SPO': 'Southern Pacific Ocean',
+             'SHEM': 'Southern Hemisphere 20S-80S',
+             'Southeast': 'Southeast',
+             'Southwest': 'Southwest',
+             'SPlains': 'Southern Plains',
+             'SRockies': 'Southern Rockies',
+             'TROPICS': 'Tropics 20S-20N',
+        }
+        if vx_mask in list(vx_mask_plot_name_dict.keys()):
+            vx_mask_plot_name = vx_mask_plot_name_dict[vx_mask]
+        else:
+            self.logger.debug(f"{vx_mask} not recognized, "
+                              +f"using {vx_mask} on plot")
+            vx_mask_plot_name = vx_mask
+        return vx_mask_plot_name
+
+    def get_dates_plot_name(self, date_type, start_date_hr, end_date_hr,
+                            other_hr_list, forecast_hour):
+        """! Get the full date information that will be displayed on the plot
+
+             Args:
+                 date_type     - type of dates (string, VALID or INIT)
+                 start_date_hr - starting date and hour (string, YYYYmmddHH)
+                 end_date_hr   - ending date and hour (string, YYYYmmddHH)
+                 other_hr_list - list of hours for opposite of date_type
+                                 (strings)
+                 forecast_hour - forecast hour, if not applicable is NA
+ 
+             Returns:
+                 date_plot_name - full date information that
+                                  will be displayed on the plot
+                                  (string)
+        """
+        date_plot_name = date_type.lower()+' '
+        start_date_hr_dt = datetime.datetime.strptime(start_date_hr, '%Y%m%d%H')
+        end_date_hr_dt = datetime.datetime.strptime(end_date_hr, '%Y%m%d%H')
+        date_plot_name = (date_plot_name
+                          +start_date_hr_dt.strftime('%d%b%Y %H')+'Z-'
+                          +end_date_hr_dt.strftime('%d%b%Y %H')+'Z, ')
+        if date_type == 'VALID':
+            date_plot_name = (date_plot_name
+                              +'cycles: '+', '.join(other_hr_list))
+        elif date_type == 'INIT':
+            date_plot_name = (date_plot_name
+                              +'valid: '+', '.join(other_hr_list))
+        if forecast_hour != 'NA':
+            forecast_day = int(forecast_hour)/24.
+            if int(forecast_hour) % 24 == 0:
+                forecast_day_plot = str(int(forecast_day))
+            else: 
+                forecast_day_plot = str(forecast_day)
+            date_plot_name = (date_plot_name
+                              +', Forecast Day '+forecast_day_plot+' '
+                              +'(Hour '+forecast_hour+')')
+        return date_plot_name
+
+    def get_plot_title(self, plot_info_dict, date_info_dict, units):
+        """! Construct the title for the plot
+
+             Args:
+                 plot_info_dict  - plot information dictionary (strings)
+                 date_info_dict  - date information dictionary (strings)
+                 units           - variable units (string)
+ 
+             Returns:
+                 plot_title - full plot title that will be 
+                              displayed on the plot
+                              (string)
+        """
+        plot_title = (
+            self.get_stat_plot_name(plot_info_dict['stat'])+' - '
+            +plot_info_dict['grid']+'/'
+            +self.get_vx_mask_plot_name(plot_info_dict['vx_mask'])+'\n'
+        )
+        if date_info_dict['date_type'] == 'VALID':
+            start_date_hr =  (date_info_dict['start_date']
+                              +date_info_dict['valid_hr_start'])
+            end_date_hr =  (date_info_dict['end_date']
+                            +date_info_dict['valid_hr_end'])
+            other_hr_list = [
+                str(hr).zfill(2)+'Z' \
+                for hr in range(int(date_info_dict['init_hr_start']),
+                                int(date_info_dict['init_hr_end'])
+                                +int(date_info_dict['init_hr_inc']),
+                                int(date_info_dict['init_hr_inc']))
+            ]
+        elif date_info_dict['date_type'] == 'INIT':
+            start_date_hr =  (date_info_dict['start_date']
+                              +date_info_dict['init_hr_start'])
+            end_date_hr =  (date_info_dict['end_date']
+                            +date_info_dict['init_hr_end'])
+            other_hr_list = [
+                str(hr).zfill(2)+'Z' \
+                for hr in range(int(date_info_dict['valid_hr_start']),
+                                int(date_info_dict['valid_hr_end'])
+                                +int(date_info_dict['valid_hr_inc']),
+                                int(date_info_dict['valid_hr_inc']))
+            ]
+        if self.plot_type in ['time_series', 'stat_by_level',
+                              'performance_diagram', 'threshold_average']:
+            fhr_for_title = date_info_dict['forecast_hour']
+        elif self.plot_type in ['lead_average', 'valid_hour_average',
+                                'lead_by_date', 'lead_by_level']:
+            fhr_for_title = 'NA'
+        if plot_info_dict['fcst_var_name'] == 'HGT_DECOMP':
+            var_name_for_title = (plot_info_dict['fcst_var_name']
+                                  +'_'+plot_info_dict['interp_method'])
+        else:
+            var_name_for_title = plot_info_dict['fcst_var_name']
+        if self.plot_type in ['stat_by_level', 'lead_by_level']:
+            var_level_for_title = plot_info_dict['vert_profile']
+        else:
+            var_level_for_title = plot_info_dict['fcst_var_level']
+        if self.plot_type in ['performance_diagram', 'threshold_average']:
+            var_thresh_for_title = 'NA'
+        else:
+            var_thresh_for_title = plot_info_dict['fcst_var_thresh']
+        if plot_info_dict['fcst_var_name'] == 'CAPE' \
+                and plot_info_dict['stat'] in ['RMSE', 'BIAS', 'ME',
+                                               'FBAR_OBAR']:
+            var_thresh_for_title = 'NA'
+        plot_title = (plot_title
+                      +self.get_var_plot_name(var_name_for_title,
+                                              var_level_for_title))
+        plot_title = plot_title+' '+'('+units+')'
+        if var_thresh_for_title != 'NA':
+            plot_title = plot_title+', '+var_thresh_for_title+' '+units
+            thresh_value = float(plot_info_dict['fcst_var_thresh'][2:])
+            if plot_info_dict['fcst_var_name'] == 'APCP':
+                thresh_in = round(thresh_value*0.0393701, 3)
+                plot_title = plot_title+' ('+str(thresh_in)+' in)'
+            elif plot_info_dict['fcst_var_name'] in ['SNOD_A24', 'WEASD_A24']:
+                thresh_in = round(thresh_value*39.3701,3)
+                plot_title = plot_title+' ('+str(thresh_in)+' in)'
+            elif plot_info_dict['fcst_var_name'] == 'DPT':
+                thresh_F = round((((thresh_value-273.15)*9)/5)+32)
+                plot_title = plot_title+' ('+str(thresh_F)+' F)'
+            elif plot_info_dict['fcst_var_name'] == 'HGT' \
+                    and plot_info_dict['fcst_var_level'] == 'CEILING':
+                thresh_kft = round(thresh_value/304.8,1)
+                if int(thresh_kft) == thresh_kft:
+                    thresh_kft = int(thresh_kft)
+                plot_title = plot_title+' ('+str(thresh_kft)+' kft)'
+            elif plot_info_dict['fcst_var_name'] == 'VIS':
+                thresh_mile = round(thresh_value * 0.000621371,1)
+                if int(thresh_mile) == thresh_mile:
+                    thresh_mile = int(thresh_mile)
+                plot_title = plot_title+' ('+str(thresh_mile)+' mile)'
+        if plot_info_dict['interp_method'] == 'NBRHD_SQUARE':
+            plot_title = (plot_title+' '
+                          +'Neighborhood Points: '
+                          +plot_info_dict['interp_points'])
+        plot_title = (plot_title+'\n'
+                      +self.get_dates_plot_name(date_info_dict['date_type'],
+                                                start_date_hr, end_date_hr,
+                                                other_hr_list, fhr_for_title))
+        return plot_title
+
+    def get_savefig_name(self, image_dir, plot_info_dict, date_info_dict):
+        """! Construct the full path to save the plot
+
+             Args:
+                 image_dir       - full path to directory of where
+                                   to save (string)
+                 plot_info_dict  - plot information dictionary (strings)
+                 date_info_dict  - date information dictionary (strings)
+ 
+             Returns:
+                 image_path - full path of the name the plot will
+                              be saved as (string)
+        """
+        component_savefig_name = 'refs'
+        if plot_info_dict['stat'] == 'PERF_DIA':
+            metric_savefig_name = 'ctc'
+        else:
+            metric_savefig_name = plot_info_dict['stat']
+        if plot_info_dict['interp_method'] == 'NBRHD_SQUARE':
+            nwidth = int(np.sqrt(float(plot_info_dict['interp_points'])))
+            metric_savefig_name = (
+                metric_savefig_name+'_'
+                +'width'+str(nwidth)
+            )
+        if 'fcst_var_thresh' in list(plot_info_dict.keys()):
+            if plot_info_dict['fcst_var_thresh'] != 'NA':
+                thresh_symbol, thresh_letter = gda_util.format_thresh(
+                    plot_info_dict['fcst_var_thresh']
+                )
+                metric_savefig_name = (
+                    metric_savefig_name+'_'
+                    +thresh_letter.replace('.','p')
+                )
+        parameter_savefig_name = plot_info_dict['fcst_var_name']
+        if plot_info_dict['fcst_var_name'] == 'HGT_DECOMP':
+            parameter_savefig_name = (
+                parameter_savefig_name+'_'
+                +plot_info_dict['interp_method'].replace('WV1_', '')\
+                .replace('-', '_')
+            )
+        level_savefig_name = (
+            plot_info_dict['fcst_var_level'].replace('-', '_')\
+            .replace('.', 'p')
+        )
+        start_date_dt = datetime.datetime.strptime(
+            date_info_dict['start_date'], '%Y%m%d'
+        )
+        end_date_dt = datetime.datetime.strptime(
+            date_info_dict['end_date'], '%Y%m%d'
+        )
+        ndays = int((end_date_dt - start_date_dt).total_seconds()/86400) + 1
+        ndays_savefig_name = 'last'+str(ndays)+'days'
+        if self.plot_type == 'time_series':
+            plot_type_savefig_name = 'timeseries'
+        elif self.plot_type == 'lead_average':
+            plot_type_savefig_name = 'fhrmean'
+        elif self.plot_type == 'lead_by_date':
+            plot_type_savefig_name = 'leaddate'
+        elif self.plot_type == 'lead_by_level':
+            plot_type_savefig_name = 'vertprof_fhrmean'
+        elif self.plot_type == 'performance_diagram':
+            plot_type_savefig_name = 'perfdia'
+        elif self.plot_type == 'stat_by_level':
+            plot_type_savefig_name = 'vertprof'
+        elif self.plot_type == 'threshold_average':
+            plot_type_savefig_name = 'threshmean'
+        elif self.plot_type == 'valid_hour_average':
+            plot_type_savefig_name = 'vhrmean'
+        else:
+            plot_type_savefig_name = self.plot_type.replace('_', '')
+        if self.plot_type in ['time_series', 'lead_average',
+                              'stat_by_level', 'lead_by_level',
+                              'lead_by_date', 'performance_diagram',
+                              'threshold_average']:
+            plot_type_savefig_name = plot_type_savefig_name+'_valid'
+            valid_hr = int(date_info_dict['valid_hr_start'])
+            while valid_hr <= int(date_info_dict['valid_hr_end']):
+                plot_type_savefig_name = (plot_type_savefig_name
+                                          +str(valid_hr).zfill(2))
+                valid_hr+=int(date_info_dict['valid_hr_inc'])
+            plot_type_savefig_name = plot_type_savefig_name+'Z'
+        if self.plot_type in ['time_series', 'stat_by_level',
+                              'performance_diagram',
+                              'threshold_average']:
+            plot_type_savefig_name = (
+                 plot_type_savefig_name+'_'
+                 +'f'+date_info_dict['forecast_hour'].zfill(3)
+            )
+        else:
+            plot_type_savefig_name = (
+                 plot_type_savefig_name+'_'
+                 +'f'+str(date_info_dict['forecast_hours'][-1]).zfill(3)
+            )
+        grid_savefig_name = plot_info_dict['grid']
+        region_savefig_dict = {
+            'Alaska': 'alaska',
+            'Appalachia': 'buk_apl',
+            'ANTARCTIC': 'antarctic',
+            'ARCTIC': 'arctic',
+            'ATL_MDR': 'al_mdr',
+            'CONUS': 'buk_conus',
+            'CONUS_East': 'buk_conus_e',
+            'CONUS_Central': 'buk_conus_c',
+            'CONUS_South': 'buk_conus_s',
+            'CONUS_West': 'buk_conus_w',
+            'CPlains': 'buk_cpl',
+            'DeepSouth': 'buk_ds',
+            'EPAC_MDR': 'ep_mdr',
+            'GLOBAL': 'glb',
+            'GreatBasin': 'buk_grb',
+            'GreatLakes': 'buk_grlk',
+            'Mezqutial': 'buk_mez',
+            'MidAtlantic': 'buk_matl',
+            'N60N90': 'n60',
+            'NAO': 'nao',
+            'NHEM': 'nhem',
+            'NorthAtlantic': 'buk_ne',
+            'NPlains': 'buk_npl',
+            'NPO': 'npo',
+            'NRockies': 'buk_nrk',
+            'PacificNW': 'buk_npw',
+            'PacificSW': 'buk_psw',
+            'Prairie': 'buk_pra',
+            'S60S90': 's60',
+            'SAO': 'sao',
+            'SHEM': 'shem',
+            'Southeast': 'buk_se',
+            'Southwest': 'buk_sw',
+            'SPlains': 'buk_spl',
+            'SPO': 'spo',
+            'SRockies': 'buk_srk',
+            'TROPICS': 'tropics'
+        }
+        if plot_info_dict['vx_mask'] in list(region_savefig_dict.keys()):
+            region_savefig_name = (
+                region_savefig_dict[plot_info_dict['vx_mask']]
+            )
+        else:    
+            region_savefig_name = plot_info_dict['vx_mask']
+        savefig_name = (
+            'evs.'
+            +component_savefig_name+'.'
+            +metric_savefig_name+'.'
+            +parameter_savefig_name+'_'+level_savefig_name+'.'
+            +ndays_savefig_name+'.'
+            +plot_type_savefig_name+'.'
+            +grid_savefig_name+'_'+region_savefig_name
+            +'.png'
+        )
+        image_path = os.path.join(image_dir, savefig_name.lower())
+        if plot_info_dict['fcst_var_name'] == 'CAPE':
+            image_path = image_path.replace('_z0', '_l0').replace('_p90_0', '_l90')
+            if plot_info_dict['stat'] in ['RMSE', 'BIAS', 'ME', 'FBAR_OBAR']:
+                image_path = image_path.replace('_gt0||', '')
+        return image_path
+
+    def get_logo_location(self, position, x_figsize, y_figsize, dpi):
+        """! Get locations for the logos
+
+             Args:
+                 position  - side of image (string, "left" or "right")
+                 x_figsize - image size in x direction (float)
+                 y_figsize - image size in y direction(float)
+                 dpi       - image dots per inch (float)
+ 
+             Returns:
+                 x_loc - logo position in x direction (float)
+                 y_loc - logo position in y direction (float)
+                 alpha - alpha value (float)
+        """
+        alpha = 0.5
+        if x_figsize == 8 and y_figsize == 6:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0.0
+                y_loc = y_figsize * dpi * 0.858
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.9
+                y_loc = y_figsize * dpi * 0.858
+        elif x_figsize == 16 and y_figsize == 8:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0.0
+                y_loc = y_figsize * dpi * 0.89
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.948
+                y_loc = y_figsize * dpi * 0.89
+        elif x_figsize == 16 and y_figsize == 16:
+            if position == 'left':
+                x_loc = x_figsize * dpi * 0
+                y_loc = y_figsize * dpi * 0.945
+            elif position == 'right':
+                x_loc = x_figsize * dpi * 0.948
+                y_loc = y_figsize * dpi * 0.945
+        return x_loc, y_loc, alpha
+
+    def get_plot_colormaps(self, stat):
+        """! Get colormaps for contour plots
+
+             Args:
+                 stat    - statistic name (string)
+
+             Returns:
+                 subplot0_cmap  - colormap for subplot 0
+                 subplotsN_cmap - colormap for other subplots
+        """
+        if stat in ['BIAS', 'ME', 'FBIAS']:
+            cmap_bias_original = plt.cm.PiYG_r
+            colors_bias = cmap_bias_original(
+                np.append(np.linspace(0,0.3,10), np.linspace(0.7,1,10))
+            )
+            subplot0_cmap = matplotlib.colors.LinearSegmentedColormap.from_list(
+                'cmap_bias', colors_bias
+            )
+        else:
+            subplot0_cmap = plt.cm.BuPu_r
+        if stat in ['BIAS', 'ME', 'FBIAS']:
+            subplotsN_cmap = subplot0_cmap
+        else:
+            if stat == 'RMSE':
+                cmap_diff_original = plt.cm.bwr
+            else:
+                cmap_diff_original = plt.cm.bwr_r
+            colors_diff = cmap_diff_original(
+                np.append(np.linspace(0,0.425,10), np.linspace(0.575,1,10))
+            )
+            subplotsN_cmap = (
+                matplotlib.colors.LinearSegmentedColormap.from_list('cmap_diff',
+                                                                    colors_diff)
+            )
+        return subplot0_cmap, subplotsN_cmap
+
+    def get_centered_contour_levels(self, data, center_value, spacing):
+        """! Get contour levels for plotting levels center on a certain
+             value
+                  Args:
+                      data         - array of data to be contoured
+                      center_value - center value of the levels (integer)
+                      spacing      - float for spacing for power function,
+                                     value of 1.0 gives evenly spaced
+                                     contour intervals
+                  Returns:
+                      center_clevels - array of contour levels
+        """
+        if np.abs(np.nanmin(data)) > np.nanmax(data):
+            cmax = np.abs(np.nanmin(data))
+            cmin = np.nanmin(data)
+        else:
+            cmax = np.nanmax(data)
+            cmin = -1 * np.nanmax(data)
+        if cmax > 100:
+            clevels_cmax = cmax - (cmax * 0.2)
+            clevels_cmin = cmin + (cmin * 0.2)
+        elif cmax > 10:
+            clevels_cmax = cmax - (cmax * 0.1)
+            clevels_cmin = cmin + (cmin * 0.1)
+        else:
+            clevels_cmax = cmax
+            clevels_cmin = cmin
+        if cmax > 1:
+            clevels_round_cmin = round(clevels_cmin-1,0)
+            clevels_round_cmax = round(clevels_cmax+1,0)
+        else:
+            clevels_round_cmin = round(clevels_cmin-0.1,1)
+            clevels_round_cmax = round(clevels_cmax+0.1,1)
+        steps = 6
+        span = cmax
+        dx = 1.0 / (steps-1)
+        pos = np.array([0 + (i*dx)**spacing*span for i in range(steps)],
+                       dtype=float)
+        neg = np.array(pos[1:], dtype=float) * -1
+        centered_clevels = np.append(neg[::-1], pos)
+        if center_value != 0:
+            centered_clevels = centered_clevels + center_value
+        return centered_clevels
+
+    def get_plot_contour_levels(self, stat, subplot0_data, subplotsN_data):
+        """! Get contour levels
+
+             Args:
+                 stat           - statistic name (string)
+                 subplot0_data  - array of data for subplot 0
+                 subplotsN_data - array of data for other subplots
+
+             Returns:
+                 have_subplot0_levs  - boolean if have valid values
+                                       subplot 0
+                 subplot0_levs       - array of contour levels for
+                                       subplot 0
+                 have_subplotsN_levs - boolean if have valid values
+                                       other subplots
+                 subplotsN_levs      - array of contour levels for
+                                       other subplots
+        """
+        have_subplot0_levs = False
+        subplot0_levs = np.array([np.nan])
+        if stat == 'ACC':
+            have_subplot0_levs = True
+            subplot0_levs = np.array([0.0, 0.25, 0.5, 0.6, 0.7, 0.8,
+                                      0.9, 0.95, 0.99, 1])
+        elif not np.ma.masked_invalid(subplot0_data).mask.all():
+            cmax = np.nanmax(subplot0_data)
+            if cmax > 100:
+                spacing = 2.25
+            elif cmax > 10:
+                spacing = 2
+            else:
+                spacing = 1.75
+            if stat == 'RMSE':
+                steps = 12
+                dx = 1.0 / (steps-1)
+                have_subplot0_levs = True
+                subplot0_levs = np.array(
+                    [0+(i*dx)**spacing*cmax for i in range(steps)],
+                    dtype=float
+                )
+            elif stat in ['BIAS', 'ME', 'FBIAS']:
+                if stat in ['BIAS', 'ME']:
+                    center_value = 0
+                elif stat == 'FBIAS':
+                    center_value = 1
+                have_subplot0_levs = True
+                subplot0_levs = self.get_centered_contour_levels(
+                    subplot0_data, center_value, spacing
+                )
+        have_subplotsN_levs = False
+        subplotsN_levs = np.array([np.nan])
+        if stat == 'ACC':
+            have_subplotsN_levs = True
+            subplotsN_levs = np.array([-0.5, -0.4, -0.3, -0.2, -0.1, -0.05,
+                                       0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5])
+        else:
+            if np.shape(subplotsN_data) != np.shape([np.nan]):
+                if stat in ['BIAS', 'ME', 'FBIAS']:
+                    have_subplotsN_levs = have_subplot0_levs
+                    subplotsN_levs = subplot0_levs
+                if not have_subplotsN_levs:
+                    for N in range(len(subplotsN_data[:,0,0])):
+                        if stat in ['BIAS', 'ME', 'FBIAS']:
+                            subplotN_data = subplotsN_data[N,:,:]
+                            if np.nanmax(subplotN_data) > 100:
+                                spacing = 2.25
+                            elif np.nanmax(subplotN_data) > 100:
+                                spacing = 2
+                            else:
+                                spacing = 1.75
+                            if stat in ['BIAS', 'ME']:
+                                center_value = 0
+                            elif stat == 'FBIAS':
+                                center_value = 1
+                        else:
+                            subplotN_data = (subplotsN_data[N,:,:]
+                                             - subplot0_data)
+                            center_value = 0
+                            spacing = 1.25
+                        if not np.ma.masked_invalid(subplotN_data).mask.all():
+                            have_subplotsN_levs = True
+                            subplotsN_levs = self.get_centered_contour_levels(
+                                subplotN_data, center_value, spacing
+                            )
+                            break
+        return have_subplot0_levs, subplot0_levs, have_subplotsN_levs, subplotsN_levs
+
+    def get_vert_profile_levels(self, vert_profile):
+        """! Get list of levels that make up the vertical profile
+
+             Args:
+                vert_profile - name of vertical profile (string)
+
+             Returns:
+                 vert_profile_levs - list of pressure levels that
+                                     make up the vertical profile
+                                     (strings)
+        """
+        vert_profile_levels_dict = {
+            'all': ['P1000', 'P925', 'P850', 'P700', 'P500', 'P400', 'P300',
+                    'P250', 'P200', 'P150', 'P100', 'P50', 'P20', 'P10',
+                    'P5'],
+            'ltrop': ['P1000', 'P925', 'P850', 'P700', 'P500'],
+            'utrop': ['P500', 'P400', 'P300', 'P250', 'P200', 'P150', 'P100'],
+            'trop': ['P1000', 'P925', 'P850', 'P700', 'P500', 'P400',
+                     'P300', 'P250', 'P200', 'P150', 'P100'],
+            'strat': ['P100', 'P50', 'P20', 'P10', 'P5']
+        }
+        if vert_profile in list(vert_profile_levels_dict.keys()):
+            vert_profile_levels = vert_profile_levels_dict[vert_profile]
+        else:
+            self.logger.debug(f"{vert_profile} not recognized, "
+                              +f"using all levels")
+            vert_profile_levels = vert_profile_levels_dict['all']
+        return vert_profile_levels
+
+    def get_marker_plot_settings(self):
+        """! Get dictionary plot settings for models
+
+             Args:
+
+             Returns: 
+                 marker_plot_settings_dict - dictionary of
+                                             marker plotting specifications
+                                             (strings)
+        """
+        marker_plot_settings_dict = {
+            'marker1': {'marker': 'o', 'markersize': 12},
+            'marker2': {'marker': 'P', 'markersize': 14},
+            'marker3': {'marker': '^', 'markersize': 14},
+            'marker4': {'marker': 'X', 'markersize': 14},
+            'marker5': {'marker': 's', 'markersize': 12},
+            'marker6': {'marker': 'D', 'markersize': 12},
+            'marker7': {'marker': 'v', 'markersize': 14},
+            'marker8': {'marker': 'p', 'markersize': 14},
+            'marker9': {'marker': '<', 'markersize': 14},
+            'marker10': {'marker': 'd', 'markersize': 14},
+            'marker11': {'marker': r'$\spadesuit$', 'markersize': 14},
+            'marker12': {'marker': '>', 'markersize': 14},
+            'marker13': {'marker': r'$\clubsuit$', 'markersize': 14},
+        }
+        return marker_plot_settings_dict
+
+    def get_model_plot_settings(self):
+        """! Get dictionary plot settings for models
+
+             Args:
+
+             Returns: 
+                 model_plot_settings_dict - dictionary of
+                                            model plotting specifications
+                                            (strings)
+        """
+        model_plot_settings_dict = {
+            'model1': {'color': '#000000',
+                       'marker': 'o', 'markersize': 6,
+                       'linestyle': 'solid', 'linewidth': 3},
+            'model2': {'color': '#fb2020',
+                       'marker': '^', 'markersize': 7,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model3': {'color': '#1e3cff',
+                       'marker': 'X', 'markersize': 7,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model4': {'color': '#00dc00',
+                       'marker': 'P', 'markersize': 7,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model5': {'color': '#e69f00',
+                       'marker': 'o', 'markersize': 6,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model6': {'color': '#56b4e9',
+                       'marker': 'o', 'markersize': 6,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model7': {'color': '#696969',
+                       'marker': 's', 'markersize': 6,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model8': {'color': '#8400c8',
+                       'marker': 'D', 'markersize': 6,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model9': {'color': '#d269c1',
+                       'marker': 's', 'markersize': 6,
+                       'linestyle': 'solid', 'linewidth': 1.5},
+            'model10': {'color': '#f0e492',
+                        'marker': 'o', 'markersize': 6,
+                        'linestyle': 'solid', 'linewidth': 1.5},
+            'obs': {'color': '#aaaaaa',
+                    'marker': 'None', 'markersize': 0,
+                    'linestyle': 'solid', 'linewidth': 2},
+            'gfs': {'color': '#000000',
+                    'marker': 'o', 'markersize': 6,
+                    'linestyle': 'solid', 'linewidth': 3},
+            'cfs': {'color': '#56b4e9',
+                    'marker': 'o', 'markersize': 6,
+                    'linestyle': 'solid', 'linewidth': 1.5},
+            'cmc': {'color': '#1e3cff',
+                     'marker': 'X', 'markersize': 7,
+                     'linestyle': 'solid', 'linewidth': 1.5},
+            'cmc_regional': {'color': '#8400c8',
+                             'marker': 'D', 'markersize': 6,
+                             'linestyle': 'solid', 'linewidth': 1.5},
+            'dwd': {'color': '#56b4e9',
+                    'marker': 'o', 'markersize': 6,
+                    'linestyle': 'solid', 'linewidth': 1.5},
+            'ecmwf': {'color': '#fb2020',
+                      'marker': '^', 'markersize': 7,
+                      'linestyle': 'solid', 'linewidth': 1.5},
+            'fnmoc': {'color': '#00dc00',
+                      'marker': 'P', 'markersize': 7,
+                      'linestyle': 'solid', 'linewidth': 1.5},
+            'imd': {'color': '#8400c8',
+                    'marker': 'D', 'markersize': 6,
+                    'linestyle': 'solid', 'linewidth': 1.5},
+            'jma': {'color': '#696969',
+                    'marker': 's', 'markersize': 6,
+                    'linestyle': 'solid', 'linewidth': 1.5},
+            'metfra': {'color': '#00dc00',
+                      'marker': 'P', 'markersize': 7,
+                      'linestyle': 'solid', 'linewidth': 1.5},
+            'ukmet': {'color': '#e69f00',
+                      'marker': 'o', 'markersize': 7,
+                      'linestyle': 'solid', 'linewidth': 1.5},
+        }
+        return model_plot_settings_dict

--- a/ush/cam/ush_refs_plot_py/roc_curve.py
+++ b/ush/cam/ush_refs_plot_py/roc_curve.py
@@ -1,0 +1,1395 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          roc_curve.py
+# Contact(s):    Marcel Caron
+# Developed:     Sep. 26, 2022 by Marcel Caron 
+# Last Modified: Sep. 26, 2022 by Marcel Caron             
+# Title:         Receiver Operator Characteristic (ROC) curve
+# Abstract:      Plots METplus CTC output as a line plot, probability of
+#                detection, which represents the y-axis, varying by false alarm 
+#                rate, which represents the x-axis. Line colors and styles are 
+#                unique for each model, and several models can be plotted at 
+#                once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+
+
+SETTINGS_DIR = os.environ['USH_DIR']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(20., 14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def get_bias_label_position(bias_value, radius):
+    x = np.sqrt(np.power(radius, 2)/(np.power(bias_value, 2)+1))
+    y = np.sqrt(np.power(radius, 2) - np.power(x, 2))
+    return (x, y)
+
+def plot_performance_diagram(df: pd.DataFrame, logger: logging.Logger, 
+                      date_range: tuple, model_list: list, num: int = 0, 
+                      level: str = '500', flead='all', thresh: list = ['<20'], 
+                      metric1_name: str = 'SRATIO', metric2_name: str = 'POD', 
+                      metric3_name: str = 'CSI', date_type: str = 'VALID', 
+                      date_hours: list = [0,6,12,18], verif_type: str = 'pres', 
+                      line_type: str = 'CTC', save_dir: str = '.', dpi: int = 100, 
+                      confidence_intervals: bool = False, interp_pts: list = [], 
+                      bs_nrep: int = 5000, bs_method: str = 'MATCHED_PAIRS', 
+                      ci_lev: float = .95, bs_min_samp: int = 30, 
+                      eval_period: str = 'TEST', display_averages: bool = True, 
+                      save_header: str = '', plot_group: str = 'sfc_upper',
+                      sample_equalization: bool = True,
+                      plot_logo_left: bool = False,
+                      plot_logo_right: bool = False, path_logo_left: str = '.',
+                      path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                      zoom_logo_right: float = 1.):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+
+    if (str(metric1_name).upper() != 'FARATE' 
+            or str(metric2_name).upper() != 'POD'):
+        w1 = (f"The ROC curve may not plot correctly unless the"
+              + f" order of metrics provided is \'FARATE\' and \'POD\'.")
+        w2 = (f"The order provided is \'{metric1_name}\', and"
+              + f" \'{metric2_name}\'.")
+        w3 = "Continuing ..."
+        logger.warning(w1)
+        logger.warning(w2)
+        logger.warning(w3)
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    if str(line_type).upper() == 'CTC' and np.array(thresh).size == 0:
+        logger.warning(f"Empty list of thresholds. Continuing onto next"
+                       + f" plot...")
+        logger.info("========================================")
+        return None
+
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
+            frange_save_phrase = f'{flead[0]}_TO_F{flead[-1]}'
+        frange_string = f'Forecast Hour{frange_phrase}'
+        frange_save_string = f'F{frange_save_phrase}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        frange_string = (f'Forecast Hours {flead[0]:02d}'+u'\u2013'
+                         + f'{flead[1]:02d}')
+        frange_save_string = f'F{flead[0]:02d}-F{flead[1]:02d}'
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        frange_string = f'Forecast Hour {flead:02d}'
+        frange_save_string = f'F{flead:02d}'
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads."
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(intep_pts, np.int):
+            interp_pts_string = f'(Wifth {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    requested_thresh_symbol, requested_thresh_letter = list(
+        zip(*[plot_util.format_thresh(t) for t in thresh])
+    )
+    symbol_found = False
+    for opt in ['>=', '>', '==','!=','<=', '<']: 
+        if any(opt in t for t in requested_thresh_symbol):
+            if all(opt in t for t in requested_thresh_symbol):
+                symbol_found = True
+                opt_letter = requested_thresh_letter[0][:2]
+                break
+            else:
+                e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                    + f" thresholds.")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+    if not symbol_found:
+        e = "FATAL ERROR: None of the requested thresholds contain a valid symbol."
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+
+    df_thresh_symbol, df_thresh_letter = list(
+        zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+    )
+    df['FCST_THRESH_SYMBOL'] = df_thresh_symbol
+    df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_thresh_letter]
+    requested_thresh_value = [
+        str(item)[2:] for item in requested_thresh_letter
+    ]
+    df = df[df['FCST_THRESH_SYMBOL'].isin(requested_thresh_symbol)]
+    thresholds_removed = (
+        np.array(requested_thresh_symbol)[
+            ~np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+        ]
+    )
+    requested_thresh_symbol = (
+        np.array(requested_thresh_symbol)[
+            np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+        ]
+    )
+    if thresholds_removed.size > 0:
+        thresholds_removed_string = ', '.join(thresholds_removed)
+        if len(thresholds_removed) > 1:
+            warning_string = (f"{thresholds_removed_string} thresholds were"
+                              + f" not found and will not be plotted.")
+        else:
+            warning_string = (f"{thresholds_removed_string} threshold was"
+                              + f" not found and will not be plotted.")
+        logger.warning(warning_string)
+        logger.warning("Continuing ...")
+
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model)
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL','FCST_THRESH_VALUE']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    df_aggregated = df_groups.sum()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    # Remove data if they exist for some but not all models at some value of 
+    # the indep. variable. Otherwise plot_util.calculate_stat will throw an 
+    # error
+    df_split = [df_aggregated.xs(str(model)) for model in model_list]
+    df_reduced = reduce(
+        lambda x,y: pd.merge(
+            x, y, on='FCST_THRESH_VALUE', how='inner'
+        ), 
+        df_split
+    )
+    df_aggregated = df_aggregated[
+        df_aggregated.index.get_level_values('FCST_THRESH_VALUE')
+        .isin(df_reduced.index)
+    ]
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    # Calculate desired metric
+    metric_long_names = []
+    for metric_name in [metric1_name, metric2_name]:
+        stat_output = plot_util.calculate_stat(
+            logger, df_aggregated, str(metric_name).lower()
+        )
+        df_aggregated[str(metric_name).upper()] = stat_output[0]
+        metric_long_names.append(stat_output[2])
+        if confidence_intervals:
+            ci_output = df_groups.apply(
+                lambda x: plot_util.calculate_bootstrap_ci(
+                    logger, bs_method, x, str(metric_name).lower(), bs_nrep,
+                    ci_lev, bs_min_samp
+                )
+            )
+            if any(ci_output['STATUS'] == 1):
+                logger.warning(f"Failed attempt to compute bootstrap"
+                               + f" confidence intervals.  Sample size"
+                               + f" for one or more groups is too small."
+                               + f" Minimum sample size can be changed"
+                               + f" in settings.py.")
+                logger.warning(f"Confidence intervals will not be"
+                               + f" plotted.")
+                confidence_intervals = False
+                continue
+            ci_output = ci_output.reset_index(level=2, drop=True)
+            ci_output = (
+                ci_output
+                .reindex(df_aggregated.index)
+                .reindex(ci_output.index)
+            )
+            df_aggregated[str(metric_name).upper()+'_BLERR'] = ci_output[
+                'CI_LOWER'
+            ].values
+            df_aggregated[str(metric_name).upper()+'_BUERR'] = ci_output[
+                'CI_UPPER'
+            ].values
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    df_aggregated[str(metric2_name).upper()] = (
+        df_aggregated[str(metric2_name).upper()]
+    ).astype(float).tolist()
+
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index='FCST_THRESH_VALUE'
+    )
+    pivot_metric2 = pd.pivot_table(
+        df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+        index='FCST_THRESH_VALUE'
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index='FCST_THRESH_VALUE'
+        )
+    pivot_metric1 = pivot_metric1.dropna() 
+    pivot_metric2 = pivot_metric2.dropna() 
+    all_thresh_idx = np.unique(
+        np.concatenate([
+            pivot_metric1.index, 
+            pivot_metric2.index, 
+        ])
+    )
+    all_model_col = np.unique(
+        np.concatenate([
+            pivot_metric1.columns,
+            pivot_metric2.columns,
+        ])
+    )
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_lower2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_upper2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        all_ci_thresh_idx = np.unique(
+            np.concatenate([
+                pivot_ci_lower1.index,
+                pivot_ci_upper1.index,
+                pivot_ci_lower2.index,
+                pivot_ci_upper2.index
+            ])
+        )
+        
+    for thresh_idx in all_thresh_idx:
+        if np.any([
+                thresh_idx not in pivot_metric.index for pivot_metric 
+                in [pivot_metric1, pivot_metric2]]):
+            pivot_metric1.drop(
+                labels=thresh_idx, inplace=True, errors='ignore'
+            )
+            pivot_metric2.drop(
+                labels=thresh_idx, inplace=True, errors='ignore'
+            )
+            if sample_equalization:
+                pivot_counts.drop(
+                    labels=thresh_idx, inplace=True, errors='ignore'
+                )
+    if confidence_intervals:
+        for ci_thresh_idx in all_ci_thresh_idx:
+            if np.any([
+                    ci_thresh_idx not in pivot_metric.index for pivot_metric
+                    in [pivot_metric1, pivot_metric2]]):
+                pivot_ci_lower1.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper1.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+                pivot_ci_lower2.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper2.drop(
+                    labels=ci_thresh_idx, inplace=True, errors='ignore'
+                )
+    models_in_pivot_metric = []
+    for model_col in all_model_col:
+        if np.any([
+                model_col not in pivot_metric.columns for pivot_metric
+                in [pivot_metric1, pivot_metric2]]):
+            pivot_metric1.drop(
+                columns=model_col, inplace=True, errors='ignore'
+            )
+            pivot_metric2.drop(
+                columns=model_col, inplace=True, errors='ignore'
+            )
+            if sample_equalization:
+                pivot_counts.drop(
+                    column=model_col, inplace=True, errors='ignore'
+                )
+            if confidence_intervals:
+                pivot_ci_lower1.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper1.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+                pivot_ci_lower2.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+                pivot_ci_upper2.drop(
+                    columns=model_col, inplace=True, errors='ignore'
+                )
+        else:
+            models_in_pivot_metric.append(model_col)
+    cols_to_keep = [
+        str(model)
+        in models_in_pivot_metric 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m)
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were all NaNs and will not be"
+            + f" plotted."
+        )
+    if pivot_metric1.empty or pivot_metric2.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any threshold. "
+        )
+        logger.warning(
+            f"This may occur if no forecast or observed events were counted "
+            + f"at any threshold for any model, so that all performance "
+            + f"statistics are undefined. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        print(
+            "Continuing due to missing data.  Check the log file for details."
+        )
+        return None
+
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected = False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model'
+                    )!=-1):
+                    need_to_rename = models_sharing_colors[np.flatnonzero(
+                        np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1
+                    )[0]]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model' + str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+
+    # Plot data
+    logger.info("Begin plotting ...")
+    '''
+    gray_colors = [
+        '#ffffff',
+        '#f5f5f5',
+        '#ececec',
+        '#dfdfdf',
+        '#cbcbcb',
+        '#b2b2b2',
+        '#8e8e8e',
+        '#6f6f6f',
+        '#545454',
+        '#3f3f3f',
+    ]
+
+    cmap = colors.ListedColormap(gray_colors)
+    '''
+    grid_ticks = np.arange(0.001, 1.001, 0.001)
+    fr_g, pod_g = np.meshgrid(grid_ticks, grid_ticks)
+    '''
+    bias = pod_g / sr_g
+    csi = 1.0 / (1.0 / sr_g + 1.0 / pod_g - 1.0)
+    bias_contour_vals = [
+        0.1, 0.2, 0.4, 0.6, 0.8, 1., 1.2, 1.5, 2., 3., 5., 10.
+    ]
+    b_contour = plt.contour(
+        sr_g, pod_g, bias, bias_contour_vals, 
+        colors='gray', linestyles='dashed'
+    )
+    csi_contour = plt.contourf(
+        sr_g, pod_g, csi, np.arange(0., 1.1, 0.1), cmap=cmap, extend='neither'
+    )
+    plt.clabel(
+        b_contour, fmt='%1.1f', 
+        manual=[
+            get_bias_label_position(bias_value, .75) 
+            for bias_value in bias_contour_vals
+        ]
+    )
+    '''
+    random_contour = plt.contour(
+        fr_g, pod_g, pod_g / fr_g, [1.],
+        colors='gray', linestyles='dashed'
+    )
+    y_min = 0.
+    y_max = 1.
+    thresh_labels = pivot_metric1.index
+    thresh_argsort = np.argsort(thresh_labels.astype(float))
+    requested_thresh_argsort = np.argsort([
+        float(item) for item in requested_thresh_value
+    ])
+    thresh_labels = [thresh_labels[i] for i in thresh_argsort]
+    requested_thresh_labels = [
+        requested_thresh_value[i] for i in requested_thresh_argsort
+    ]
+    thresh_markers = [
+        ('o',12),('P',14),('^',14),('X',14),('s',12),('D',12),('v',14),
+        ('p',14),('<',14),('d',14),(r'$\spadesuit$',14),('>',14),
+        (r'$\clubsuit$',14)
+    ]
+    if len(thresh_labels)+len(model_list) > 12:
+        e = (f"The plot legend may be cut off.  Consider reducing the number"
+             + f" of models or thresholds and rerunning the plotting job.")
+        logger.warning(e)
+        logger.warning("Continuing ...")
+    if len(thresh_labels) > len(thresh_markers):
+        e = (f"FATAL ERROR: Too many thresholds were requested.  Only {len(thresh_markers)}"
+             + f" or fewer thresholds may be plotted.")
+        logger.error(e)
+        logger.error("Quitting ...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    units = df['FCST_UNITS'].tolist()[0]
+    if units in reference.unit_conversions:
+        thresh_labels = [float(tlab) for tlab in thresh_labels]
+        thresh_labels = reference.unit_conversions[units]['formula'](thresh_labels)
+        thresh_diff_categories = np.array([
+            [np.power(10., y)]
+            for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+        ]).flatten()
+        precision_scale_indiv_mult = [
+            thresh_diff_categories[item] 
+            for item in np.digitize(thresh_labels, thresh_diff_categories)
+        ]
+        precision_scale_collective_mult = 100/min(precision_scale_indiv_mult)
+        precision_scale = np.multiply(
+            precision_scale_indiv_mult, precision_scale_collective_mult
+        )
+        thresh_labels = [
+            f'{np.round(tlab)/precision_scale[t]}' 
+            for t, tlab in enumerate(
+                np.multiply(thresh_labels, precision_scale)
+            )
+        ]
+        units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms)[0]
+    handles = [
+        f(
+            thresh_markers[i][0], 'white','solid',0.,thresh_markers[i][1], 
+            'black'
+        ) for i, item in enumerate(thresh_labels)
+    ]
+    labels = [
+        f'{opt}{thresh_label} {units}'
+        for thresh_label in thresh_labels
+    ]
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        counts = [
+            str(int(count)) if not isinstance(count,str) else count
+            for count in counts
+        ]
+        labels = [
+            label+f' ({counts[l]})'
+            for l, label in enumerate(labels)
+        ]
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        x_vals = [
+            pivot_metric1[str(model_list[m])].values[i] 
+            for i in thresh_argsort
+        ]
+        y_vals = [
+            pivot_metric2[str(model_list[m])].values[i] 
+            for i in thresh_argsort
+        ]
+        #mosaic_vals = pivot_metric3[str(model_list[m])].values
+        x_mean = np.nanmean(x_vals)
+        y_mean = np.nanmean(y_vals)
+        #mosaic_mean = np.nanmean(mosaic_vals)
+        if confidence_intervals:
+            x_vals_ci_lower = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            x_vals_ci_upper = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            y_vals_ci_lower = pivot_ci_lower2[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper = pivot_ci_upper2[
+                str(model_list[m])
+            ].values
+        if display_averages:
+            metric_mean_fmt_string = (f'{model_plot_name} ({x_mean:.2f},'
+                                      + f' {y_mean:.2f})')
+        else:
+            metric_mean_fmt_string = f'{model_plot_name}'
+        line_start = float(
+            np.multiply(x_vals,y_vals)[0] > np.multiply(x_vals,y_vals)[-1]
+        )
+        line_end = float(
+            np.multiply(x_vals,y_vals)[0] < np.multiply(x_vals,y_vals)[-1]
+        )
+        plt.plot(
+            np.concatenate(([line_start],x_vals,[line_end])), 
+            np.concatenate(([line_start],y_vals,[line_end])), 
+            marker='None', c=mod_setting_dicts[m]['color'], 
+            mew=2., mec='white', figure=fig, ms=0, 
+            ls=mod_setting_dicts[m]['linestyle'], 
+            lw=mod_setting_dicts[m]['linewidth']
+        )
+        for i, item in enumerate(x_vals):
+            plt.scatter(
+                x_vals[i], y_vals[i], marker=thresh_markers[i][0], 
+                c=mod_setting_dicts[m]['color'], linewidths=2., 
+                edgecolors='white', figure=fig, s=thresh_markers[i][1]**2,
+                zorder=10
+            )
+        if confidence_intervals:
+            pc = plotter.get_error_boxes(
+                x_vals, y_vals, [x_vals_ci_lower, x_vals_ci_upper],
+                [y_vals_ci_lower, y_vals_ci_upper], 
+                ec=mod_setting_dicts[m]['color'],
+                ls=mod_setting_dicts[m]['linestyle'], lw=2.
+            )
+            ax.add_collection(pc)
+        handles+=[
+            f(
+                '', mod_setting_dicts[m]['color'], 
+                mod_setting_dicts[m]['linestyle'], 
+                2*mod_setting_dicts[m]['linewidth'], 0, 'white'
+            )
+        ]
+        labels+=[f'{metric_mean_fmt_string}']
+
+    # Configure axis ticks
+    xticks_min = 0.
+    xticks_max = 1.
+    incr = .1
+    xticks = [
+        x_val for x_val in np.arange(xticks_min, xticks_max+incr, incr)
+    ] 
+    xtick_labels = [f'{xtick:.1f}' for xtick in xticks]
+    x_buffer_size = .015
+    ax.set_xlim(
+        xticks_min-incr*x_buffer_size, xticks_max+incr*x_buffer_size
+    )
+    yticks_min = 0.
+    yticks_max = 1.
+    yticks = [
+        y_val for y_val in np.arange(yticks_min, yticks_max+incr, incr)
+    ] 
+    ytick_labels = [f'{ytick:.1f}' for ytick in yticks]
+    y_buffer_size = .015
+    ax.set_ylim(
+        yticks_min-incr*y_buffer_size, yticks_max+incr*y_buffer_size
+    )
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    ax.set_ylabel(f'{metric_long_names[1]}')
+    ax.set_xlabel(f'{metric_long_names[0]}') 
+    ax.set_xticklabels(xtick_labels)
+    ax.set_yticklabels(ytick_labels)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', pad=15
+    )
+
+    ax.legend(
+        handles, labels, loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=4, frameon=True, numpoints=1, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.35, linestyle='--', 
+        linewidth=.5, c='black', zorder=0
+    )
+    
+    fig.subplots_adjust(bottom=.15, right=.77, left=.23, wspace=0, hspace=0)
+    '''
+    cax = fig.add_axes([.775, .2, .01, .725])
+    cbar_ticks = [0.,.1,.2,.3,.4,.5,.6,.7,.8,.9,1.]
+    cb = plt.colorbar(
+        csi_contour, orientation='vertical', cax=cax, ticks=cbar_ticks,
+        spacing='uniform', drawedges=True
+    )
+    cb.dividers.set_color('black')
+    cb.dividers.set_linewidth(2)
+    cb.ax.tick_params(
+        labelsize=8, labelright=True, labelleft=False, right=False
+    )
+    cb.ax.set_yticklabels(
+        [f'{cbar_tick:.1f}' for cbar_tick in cbar_ticks], 
+        fontdict={'fontsize': 12}
+    )
+    cax.hlines([0, 1], 0, 1, colors='black', linewidth=4)
+    cb.set_label(f'{metric_long_names[2]}')
+    '''
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = ''
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = ''
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'ML'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level_num}MB_'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'SB'
+        else:
+            level_string = ''
+            level_savename = ''
+    elif (str(verif_type).lower() 
+            in ['sfc', 'conus_sfc', 'polar_sfc', 'mrms', 'metar']):
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = ''
+                else:
+                    level_string = 'Surface '
+                    level_savename = 'SFC_'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM_'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level_num}M_'
+        elif 'L' in str(level) or 'A' in str(level):
+            level_string = ''
+            level_savename = ''
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}_'
+    elif str(verif_type).lower() in ['ccpa']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'{level_num}H_'
+        else:
+            level_string = f''
+            level_savename = f''
+    else:
+        level_string = f'{level} '
+        level_savename = f'{level}_'
+    thresholds_phrase = ', '.join([
+        f'{opt}{thresh_label}' for thresh_label in thresh_labels
+    ])
+    thresholds_save_phrase = ''.join([
+        f'{opt_letter}{thresh_label}' 
+        for thresh_label in requested_thresh_labels
+    ])
+    thresholds_string = f'Forecast Thresholds {thresholds_phrase}'
+    title1 = f'ROC Curve'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    if not units:
+        title2 = (f'{level_string}{var_long_name} (unitless), {domain_string}')
+    else:
+        title2 = (f'{level_string}{var_long_name} ({units}), {domain_string}')
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}, {frange_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    ax.set_title(title_center, loc=plotter.title_loc) 
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left*0.8)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction',
+                xybox=(0, 3), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right*0.8)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.), xycoords='axes fraction',
+                xybox=(0, 3), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'roc_curve_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(level_savename).lower()}'
+                 + f'{str(var_savename).lower()}')
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    save_name+=f'_{str(frange_save_string).lower()}'
+    save_name+=f'_{str(thresholds_save_phrase).lower()}')
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        try:
+            os.makedirs(save_subdir)
+        except FileExistsError as e:
+            logger.warning(f"Several processes are making {save_subdir} at "
+                           + f"the same time. Passing")
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: Ignored for performance diagrams")
+    logger.debug(f"X_MAX_LIMIT: Ignored for performance diagrams")
+    logger.debug(f"X_LIM_LOCK: Ignored for performance_diagrams")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    metrics = METRICS
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    if (str(INTERP).upper()
+           not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    for metric in metrics:
+        if (str(metric).lower()
+                not in case_specs['plot_stats_list']
+                .replace(' ','').split(',')):
+            e = (f"FATAL ERROR: The requested metric is not valid for the"
+                 + f" requested case type ({VERIF_CASETYPE}) and"
+                 + f" line_type ({LINE_TYPE}): {metric}")
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e+"\nQuitting ...")
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds'] 
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds'] 
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for l, fcst_level in enumerate(FCST_LEVELS):
+            if len(FCST_LEVELS) != len(OBS_LEVELS):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+            if (FCST_LEVELS[l] not in var_specs['fcst_var_levels'] 
+                    or OBS_LEVELS[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid:"
+                     + f" {requested_var}/{level}")
+                logger.warning(e)
+                logger.warning("Continuing ...")
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the"
+                         + f" requested case type ({VERIF_CASETYPE}) and"
+                         + f" line_type ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    date_hours, FLEADS, requested_var, fcst_var_names, 
+                    obs_var_names, MODELS, domain, INTERP, MET_VERSION, 
+                    clear_prune_dir
+                )
+                if df is None:
+                    continue
+                for metric in metrics:
+                    if (str(metric).lower()
+                            not in case_specs['plot_stats_list']
+                            .replace(' ','').split(',')):
+                        e = (f"The requested metric is not valid for the"
+                             + f" requested case type ({VERIF_CASETYPE}) and"
+                             + f" line_type ({LINE_TYPE}): {metric}")
+                        logger.warning(e)
+                        logger.warning("Continuing ...")
+                        continue
+                df_metric = df
+                plot_performance_diagram(
+                    df_metric, logger, date_range, MODELS, num=num, 
+                    flead=FLEADS, level=fcst_level, thresh=fcst_thresh, 
+                    metric1_name=metrics[0], metric2_name=metrics[1],
+                    date_type=DATE_TYPE,  verif_type=VERIF_TYPE, 
+                    line_type=LINE_TYPE, date_hours=date_hours, 
+                    save_dir=SAVE_DIR, eval_period=EVAL_PERIOD, 
+                    display_averages=display_averages, save_header=URL_HEADER,
+                    plot_group=plot_group, 
+                    confidence_intervals=CONFIDENCE_INTERVALS, interp_pts=INTERP_PNTS,
+                    bs_nrep=bs_nrep, bs_method=bs_method, ci_lev=ci_lev, 
+                    bs_min_samp=bs_min_samp,
+                    sample_equalization=sample_equalization,
+                    plot_logo_left=plot_logo_left,
+                    plot_logo_right=plot_logo_right,
+                    path_logo_left=path_logo_left,
+                    path_logo_right=path_logo_right,
+                    zoom_logo_left=zoom_logo_left,
+                    zoom_logo_right=zoom_logo_right
+                )
+                num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = check_STATS(os.environ['STATS']).replace(' ','').split(',')[:3]
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+
+
+    # Still need to configure CIs (doesn't work yet)
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    bs_method = toggle.plot_settings['bs_method']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove
+    # samples used to aggregate each statistic if the samples are not shared
+    # by all models.  Required to display sample sizes
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    FCST_LEVELS = [str(level) for level in FCST_LEVELS]
+    OBS_LEVELS = [str(level) for level in OBS_LEVELS]
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/settings.py
+++ b/ush/cam/ush_refs_plot_py/settings.py
@@ -1,0 +1,3717 @@
+#! /usr/bin/env python3
+
+from datetime import datetime, timedelta as td
+
+import os
+import numpy as np
+
+class Toggle():
+    def __init__(self):
+        
+        '''
+        Dictionary with values that can be adjusted by the user to change a
+        particular plot setting.  
+        '''
+        self.plot_settings = {
+            'x_min_limit': -9999., # x-axis values will not subceed this value
+            'x_max_limit': 9999., # x-axis values will not exceed this value
+            'x_lim_lock': False, # lock the x-axis lower an upper limits to x_min_limit and x_max_limit, respectively
+            'y_min_limit': -9999.,
+            'y_max_limit': 9999.,
+            'y_lim_lock': False,
+            'ci_lev': .95, # confidence level, as a float > 0. and < 1.
+            'bs_nrep': 5000, # number of bootstrap repetitions when confidence intervals are computed
+            'bs_method': 'FORECASTS', # bootstrap method. 'FORECASTS' bootstraps the lines in the stat files, 'MATCHED_PAIRS' bootstraps the f-o matched pairs
+            'bs_min_samp': 30, # Minimum number of samples allowed for boostrapping to performed (if there are fewer samples, no confidence intervals)
+            'display_averages': False, # display mean statistic for each model, averaged across the dimension of the independent variable
+            'sample_equalization': True, # equalize samples along each value of the independent variable where data exist
+            #'sample_equalization': False, # just for SREF-GEFS comparison! 
+            'keep_shared_events_only': False, # functional for time_series only.
+            'clear_prune_directory': False, # remove the intermediate directory created to store pruned data files temporarily
+            'plot_logo_left': True,
+            'plot_logo_right': True,
+            'zoom_logo_left': 1.0, 
+            'zoom_logo_right': 1.0,
+            'delete_intermed_data': True 
+            #'delete_intermed_data': False # Just for SREF/GEFS comparison since they have different lead times. whether or not to delete DataFrame rows if, for any model, rows include NaN (currently only used in lead_average.py)
+        }
+
+class Templates():
+    def __init__(self):
+        
+        '''
+        Custom template used to find .stat files in OUTPUT_BASE_DIR.
+        
+        output_base_template must be a string. Use curly braces {} to enclose variable
+        names that will be substituted with the appropriate value according to
+        the plotting request.   
+
+        Current possible variable names:    Example substituted values:
+        ================================    ===========================
+        RUN_CASE                            grid2obs
+        RUN_TYPE                            conus_sfc
+        LINE_TYPE                           sl1l2
+        VX_MASK                             conus
+        FCST_VAR_NAME                       VIS
+        VAR_NAME                            VISsfc
+        MODEL                               HRRR
+        EVAL_PERIOD                         PAST30DAYS
+        valid?fmt=%Y%m or VALID?fmt=%Y%m    202206
+
+        Additionally, variable names may have the _LOWER or _UPPER suffix to 
+        substitute a lower- or upper-case conversion of the desired string.
+
+        Finally, use asterisk * as a wildcard to match with and use data from
+        several .stat files, or for portions of the .stat file name that vary but 
+        are inconsequential.
+
+        Example: 
+        "{RUN_CASE_LOWER}/{MODEL}/{valid?fmt=%Y%m}/{MODEL}_{valid?fmt=%Y%m%d}*"
+        '''
+        self.output_base_template = "{MODEL_LOWER}/{MODEL}_{valid?fmt=%Y%m%d}*"
+
+class Paths():
+    def __init__(self):
+        '''
+        Custom paths to left and right logos. 
+        
+        Referenced if plot_logo_left and plot_logo_right, in the Toggle class,
+        are set to True
+        '''
+        self.logo_left_path = f"{os.environ['FIXevs']}/logos/noaa.png"
+        self.logo_right_path =  f"{os.environ['FIXevs']}/logos/nws.png"
+
+class Presets():
+    def __init__(self):
+        
+        '''
+        Evaluation periods that are requested regularly can be defined here 
+        and then requested as the 'EVAL_PERIOD' variable in the plotting 
+        configuration file.
+        
+        Additional presets can be added, but must look like this:
+        'NAME_OF_PRESET': {
+            'valid_beg': 'YYYYmmdd',
+            'valid_end': 'YYYYmmdd',
+            'init_beg': 'YYYYmmdd',
+            'init_end': 'YYYYmmdd',
+        },
+
+        Dates must be in YYYYmmdd format.  A date can be written directly as
+        a string, or may be defined using python's built-in datetime and/or 
+        timedelta (use td) libraries, which are already imported.  Check 
+        the online documentation to learn how to use these libraries.
+        '''
+        self.date_presets = {
+            'last31days': {
+                'valid_beg': (datetime.now()-td(days=31)).strftime('%Y%m%d'),
+                'valid_end': (datetime.now()-td(days=1)).strftime('%Y%m%d'),
+                'init_beg': (datetime.now()-td(days=31)).strftime('%Y%m%d'),
+                'init_end': (datetime.now()-td(days=1)).strftime('%Y%m%d')
+            },
+            'last90days': {
+                'valid_beg': (datetime.now()-td(days=90)).strftime('%Y%m%d'),
+                'valid_end': (datetime.now()-td(days=1)).strftime('%Y%m%d'),
+                'init_beg': (datetime.now()-td(days=90)).strftime('%Y%m%d'),
+                'init_end': (datetime.now()-td(days=1)).strftime('%Y%m%d')
+            },
+            'PAST30DAYS': {
+                'valid_beg': (datetime.now()-td(days=30)).strftime('%Y%m%d'),
+                'valid_end': (datetime.now()-td(days=1)).strftime('%Y%m%d'),
+                'init_beg': (datetime.now()-td(days=30)).strftime('%Y%m%d'),
+                'init_end': (datetime.now()-td(days=1)).strftime('%Y%m%d')
+            },
+            'PAST7DAYS': {
+                'valid_beg': (datetime.now()-td(days=7)).strftime('%Y%m%d'),
+                'valid_end': (datetime.now()-td(days=1)).strftime('%Y%m%d'),
+                'init_beg': (datetime.now()-td(days=7)).strftime('%Y%m%d'),
+                'init_end': (datetime.now()-td(days=1)).strftime('%Y%m%d')
+            },
+            'PAST3DAYS': {
+                'valid_beg': (datetime.now()-td(days=3)).strftime('%Y%m%d'),
+                'valid_end': (datetime.now()-td(days=1)).strftime('%Y%m%d'),
+                'init_beg': (datetime.now()-td(days=3)).strftime('%Y%m%d'),
+                'init_end': (datetime.now()-td(days=1)).strftime('%Y%m%d')
+            },
+            '2020': {
+                'valid_beg': '20200101',
+                'valid_end': '20201231',
+                'init_beg': '20200101',
+                'init_end': '20201231'
+            },
+            '2021': {
+                'valid_beg': '20210101',
+                'valid_end': '20211231',
+                'init_beg': '20210101',
+                'init_end': '20211231'
+            },
+            'DJF': {
+                'valid_beg': (datetime.now()-td(days=365)).strftime('%Y1201'),
+                'valid_end': datetime.now().strftime('%Y0228'),
+                'init_beg': (datetime.now()-td(days=365)).strftime('%Y1201'),
+                'init_end': datetime.now().strftime('%Y0228')
+            },
+            'MAM': {
+                'valid_beg': datetime.now().strftime('%Y0301'),
+                'valid_end': datetime.now().strftime('%Y0531'),
+                'init_beg': datetime.now().strftime('%Y0301'),
+                'init_end': datetime.now().strftime('%Y0531')
+            },
+            'JJA': {
+                'valid_beg': datetime.now().strftime('%Y0601'),
+                'valid_end': datetime.now().strftime('%Y0831'),
+                'init_beg': datetime.now().strftime('%Y0601'),
+                'init_end': datetime.now().strftime('%Y0831')
+            },
+            'SON': {
+                'valid_beg': datetime.now().strftime('%Y0901'),
+                'valid_end': datetime.now().strftime('%Y1130'),
+                'init_beg': datetime.now().strftime('%Y0901'),
+                'init_end': datetime.now().strftime('%Y1130')
+            }
+        }
+            
+class ModelSpecs():
+    def __init__(self):
+        
+        '''
+        The model_alias dictionary defines the appropriate key to be used
+        when finding settings and the long name for certain requested models 
+        that may have several possible names in MET .stat files and file names.  
+        
+        e.g., AKARW and CONUSARW, although they are different, may use the same 
+        line/marker settings and the same long name on plots, and so both can 
+        be defined here as aliases of the same model settings, if desired.
+        '''
+        self.model_alias = {
+            'ARW': {
+                'settings_key':'HRW_ARW', 
+                'plot_name':'HiResW ARW'
+            },
+            'ARW2': {
+                'settings_key':'HRW_ARW2', 
+                'plot_name':'HiResW ARW2'
+            },
+            'FV3': {
+                'settings_key':'HRW_FV3', 
+                'plot_name':'HiResW FV3'
+            },
+            'NMMB': {
+                'settings_key':'HRW_NMMB', 
+                'plot_name':'HiResW NMMB'
+            },
+            'AKARW': {
+                'settings_key':'HRW_ARW', 
+                'plot_name':'HiResW ARW'
+            },
+            'AKARW2': {
+                'settings_key':'HRW_ARW2', 
+                'plot_name':'HiResW ARW2'
+            },
+            'AKFV3': {
+                'settings_key':'HRW_FV3', 
+                'plot_name':'HiResW FV3'
+            },
+            'AKNEST': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Nest'
+            },
+            'AKNMMB': {
+                'settings_key':'HRW_NMMB', 
+                'plot_name':'HiResW NMMB'
+            },
+            'CONUSARW': {
+                'settings_key':'HRW_ARW', 
+                'plot_name':'HiResW ARW'
+            },
+            'CONUSARW2': {
+                'settings_key':'HRW_ARW2', 
+                'plot_name':'HiResW ARW2'
+            },
+            'CONUSFV3': {
+                'settings_key':'HRW_FV3', 
+                'plot_name':'HiResW FV3'
+            },
+            'CONUSNEST': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Nest'
+            },
+            'CONUSNMMB': {
+                'settings_key':'HRW_NMMB', 
+                'plot_name':'HiResW NMMB'
+            },
+            'hireswarw': {
+                'settings_key':'HRW_ARW', 
+                'plot_name':'HiResW ARW'
+            },
+            'hireswarwmem2': {
+                'settings_key':'HRW_ARW2', 
+                'plot_name':'HiResW ARW2'
+            },
+            'hireswfv3': {
+                'settings_key':'HRW_FV3', 
+                'plot_name':'HiResW FV3'
+            },
+            'REFS_MEAN':{
+                'settings_key':'REFS_MEAN', 
+                'plot_name':'REFS Mean'
+            },
+            'REFS_AVRG':{
+                'settings_key':'REFS_AVRG', 
+                'plot_name':'REFS Average of MEAN and PMMN'
+            },
+            'REFS_LPMM':{
+                'settings_key':'REFS_LPMM', 
+                'plot_name':'REFS Local Probability-Matched Mean'
+            },
+            'REFS_PMMN':{
+                'settings_key':'REFS_PMMN', 
+                'plot_name':'REFS Probability-Matched Mean'
+            },
+            'REFS_PROB':{
+                'settings_key':'REFS_PROB', 
+                'plot_name':'REFS Probability'
+            },
+            'REFSX_MEAN':{
+                'settings_key':'REFSX_MEAN', 
+                'plot_name':'REFS-X Mean'
+            },
+            'CONUSREFS_MEAN':{
+                'settings_key':'REFS_MEAN', 
+                'plot_name':'REFS Mean'
+            },
+            'CONUSREFS_AVRG':{
+                'settings_key':'REFS_AVRG', 
+                'plot_name':'REFS Average of MEAN and PMMN'
+            },
+            'CONUSREFS_LPMM':{
+                'settings_key':'REFS_LPMM', 
+                'plot_name':'REFS Local Probability-Matched Mean'
+            },
+            'CONUSREFS_PMMN':{
+                'settings_key':'REFS_PMMN', 
+                'plot_name':'REFS Probability-Matched Mean'
+            },
+            'CONUSREFS_PROB':{
+                'settings_key':'REFS_PROB', 
+                'plot_name':'REFS Probability'
+            },
+            'CONUSREFSX_MEAN':{
+                'settings_key':'REFSX_MEAN', 
+                'plot_name':'REFS-X Mean'
+            },
+            'AKREFS_MEAN':{
+                'settings_key':'REFS_MEAN', 
+                'plot_name':'REFS Mean'
+            },
+            'AKREFS_AVRG':{
+                'settings_key':'REFS_AVRG', 
+                'plot_name':'REFS Average of MEAN and PMMN'
+            },
+            'AKREFS_LPMM':{
+                'settings_key':'REFS_LPMM', 
+                'plot_name':'REFS Local Probability-Matched Mean'
+            },
+            'AKREFS_PMMN':{
+                'settings_key':'REFS_PMMN', 
+                'plot_name':'REFS Probability-Matched Mean'
+            },
+            'AKREFS_PROB':{
+                'settings_key':'REFS_PROB', 
+                'plot_name':'REFS Probability'
+            },
+            'AKREFSX_MEAN':{
+                'settings_key':'REFSX_MEAN', 
+                'plot_name':'REFS-X Mean'
+            },
+            'PRREFS_MEAN':{
+                'settings_key':'REFS_MEAN', 
+                'plot_name':'REFS Mean'
+            },
+            'PRREFS_AVRG':{
+                'settings_key':'REFS_AVRG', 
+                'plot_name':'REFS Average of MEAN and PMMN'
+            },
+            'PRREFS_LPMM':{
+                'settings_key':'REFS_LPMM', 
+                'plot_name':'REFS Local Probability-Matched Mean'
+            },
+            'PRREFS_PMMN':{
+                'settings_key':'REFS_PMMN', 
+                'plot_name':'REFS Probability-Matched Mean'
+            },
+            'PRREFS_PROB':{
+                'settings_key':'REFS_PROB', 
+                'plot_name':'REFS Probability'
+            },
+            'PRREFSX_MEAN':{
+                'settings_key':'REFSX_MEAN', 
+                'plot_name':'REFS-X Mean'
+            },
+            'HIREFS_MEAN':{
+                'settings_key':'REFS_MEAN', 
+                'plot_name':'REFS Mean'
+            },
+            'HIREFS_AVRG':{
+                'settings_key':'REFS_AVRG', 
+                'plot_name':'REFS Average of MEAN and PMMN'
+            },
+            'HIREFS_LPMM':{
+                'settings_key':'REFS_LPMM', 
+                'plot_name':'REFS Local Probability-Matched Mean'
+            },
+            'HIREFS_PMMN':{
+                'settings_key':'REFS_PMMN', 
+                'plot_name':'REFS Probability-Matched Mean'
+            },
+            'HIREFS_PROB':{
+                'settings_key':'REFS_PROB', 
+                'plot_name':'REFS Probability'
+            },
+            'HIREFSX_MEAN':{
+                'settings_key':'REFSX_MEAN', 
+                'plot_name':'REFS-X Mean'
+            },
+            'NARRE_MEAN':{
+                'settings_key':'NARRE_MEAN', 
+                'plot_name':'NARRE Mean'
+            },
+            'HIARW': {
+                'settings_key':'HRW_ARW', 
+                'plot_name':'HiResW ARW'
+            },
+            'HIARW2': {
+                'settings_key':'HRW_ARW2', 
+                'plot_name':'HiResW ARW2'
+            },
+            'HIFV3': {
+                'settings_key':'HRW_FV3', 
+                'plot_name':'HiResW FV3'
+            },
+            'HINMMB': {
+                'settings_key':'HRW_NMMB', 
+                'plot_name':'HiResW NMMB'
+            },
+            'HAWAIINEST': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Nest'
+            },
+            'PRARW': {
+                'settings_key':'HRW_ARW', 
+                'plot_name':'HiResW ARW'
+            },
+            'PRARW2': {
+                'settings_key':'HRW_ARW2', 
+                'plot_name':'HiResW ARW2'
+            },
+            'PRFV3': {
+                'settings_key':'HRW_FV3', 
+                'plot_name':'HiResW FV3'
+            },
+            'PRNMMB': {
+                'settings_key':'HRW_NMMB', 
+                'plot_name':'HiResW NMMB'
+            },
+            'PRICONEST': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Nest'
+            },
+            'FV3LAMDA': {
+                'settings_key':'LAMDA', 
+                'plot_name':'FV3LAM-DA'
+            },
+            'FV3LAMDAX': {
+                'settings_key':'LAMDAX', 
+                'plot_name':'FV3LAM-DAX'
+            },
+            'FV3LAMDAXAK': {
+                'settings_key':'LAMDAX', 
+                'plot_name':'FV3LAM-DAX'
+            },
+            'FV3LAMDAXHI': {
+                'settings_key':'LAMDAX', 
+                'plot_name':'FV3LAM-DAX'
+            },
+            'FV3LAMDAXNA': {
+                'settings_key':'LAMDAX', 
+                'plot_name':'FV3LAM-DAX'
+            },
+            'FV3LAMDAXPR': {
+                'settings_key':'LAMDAX', 
+                'plot_name':'FV3LAM-DAX'
+            },
+            'FV3LAM': {
+                'settings_key':'LAM', 
+                'plot_name':'FV3LAM'
+            },
+            'FV3LAMAK': {
+                'settings_key':'LAM', 
+                'plot_name':'FV3LAM'
+            },
+            'FV3LAMHI': {
+                'settings_key':'LAM', 
+                'plot_name':'FV3LAM'
+            },
+            'FV3LAMNA': {
+                'settings_key':'LAM', 
+                'plot_name':'FV3LAM'
+            },
+            'FV3LAMPR': {
+                'settings_key':'LAM', 
+                'plot_name':'FV3LAM'
+            },
+            'FV3LAMX': {
+                'settings_key':'LAMX', 
+                'plot_name':'FV3LAM-X'
+            },
+            'FV3LAMXAK': {
+                'settings_key':'LAMX', 
+                'plot_name':'FV3LAM-X'
+            },
+            'FV3LAMXHI': {
+                'settings_key':'LAMX', 
+                'plot_name':'FV3LAM-X'
+            },
+            'FV3LAMXNA': {
+                'settings_key':'LAMX', 
+                'plot_name':'FV3LAM-X'
+            },
+            'FV3LAMXPR': {
+                'settings_key':'LAMX', 
+                'plot_name':'FV3LAM-X'
+            },
+            'NAM_NEST': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Nest'
+            },
+            'NAM_FIREWXNEST': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Fire Wx Nest'
+            },
+            'namnest': {
+                'settings_key':'NAM_NEST', 
+                'plot_name':'NAM Nest'
+            },
+            'HRRRAK': {
+                'settings_key':'HRRR', 
+                'plot_name':'HRRR'
+            },
+            'hrrr': {
+                'settings_key':'HRRR', 
+                'plot_name':'HRRR'
+            },
+            'NAMNA': {
+                'settings_key':'NAM', 
+                'plot_name':'NAM'
+            },
+            'RAPAK': {
+                'settings_key':'RAP', 
+                'plot_name':'RAP'
+            },
+            'RAPNA': {
+                'settings_key':'RAP', 
+                'plot_name':'RAP'
+            },
+            'RRFS_A': {
+                'settings_key':'RRFS_A', 
+                'plot_name':'RRFS-A'
+            },
+            'RRFS_A_AK': {
+                'settings_key':'RRFS_A', 
+                'plot_name':'RRFS-A Alaska'
+            },
+            'RRFS_A_PR': {
+                'settings_key':'RRFS_A', 
+                'plot_name':'RRFS-A Puerto Rico'
+            },
+            'RRFS_A_HI': {
+                'settings_key':'RRFS_A', 
+                'plot_name':'RRFS-A Hawaii'
+            },
+            'RRFS_A_CONUS': {
+                'settings_key':'RRFS_A', 
+                'plot_name':'RRFS-A CONUS'
+            },
+            'RRFS_A_NACONUS': {
+                'settings_key':'RRFS_A_NA', 
+                'plot_name':'RRFS-A N. America'
+            },
+            'wafs': {
+                'settings_key':'WAFS', 
+                'plot_name':'WAFS'
+            }
+        }
+
+        '''
+        model_settings defines the line/marker specifications according
+        to the model being plotted.  See the online documentation for python's
+        matplotlib library to learn the possible specifications.
+        
+        Some keys, however, represent generic model settings (model1, model2, etc..).  
+        These generic settings are used if a model is requested in the configuration 
+        file but not already included in this list, in which case generic settings 
+        are chosen that don't match the settings for any other model already included 
+        in the plot.
+        '''
+        self.model_settings = {
+            'model1': {'color': '#000000',
+                       'marker': 'o', 'markersize': 12,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model2': {'color': '#fb2020',
+                       'marker': '^', 'markersize': 14,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model3': {'color': '#1e3cff',
+                       'marker': 'X', 'markersize': 14,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model4': {'color': '#00dc00',
+                       'marker': 'P', 'markersize': 14,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model5': {'color': '#e69f00',
+                       'marker': 'o', 'markersize': 12,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model6': {'color': '#56b4e9',
+                       'marker': 'o', 'markersize': 12,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model7': {'color': '#696969',
+                       'marker': 's', 'markersize': 12,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model8': {'color': '#8400c8',
+                       'marker': 'D', 'markersize': 12,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model9': {'color': '#d269c1',
+                       'marker': 's', 'markersize': 12,
+                       'linestyle': 'solid', 'linewidth': 3.},
+            'model10': {'color': '#f0e492',
+                        'marker': 'o', 'markersize': 12,
+                        'linestyle': 'solid', 'linewidth': 3.},
+            'obs': {'color': '#aaaaaa',
+                    'marker': 'None', 'markersize': 0,
+                    'linestyle': 'solid', 'linewidth': 4.},
+            'LAM': {'color': '#00dc00',
+                      'marker': 'o', 'markersize': 12,
+                      'linestyle': 'solid', 'linewidth': 3.},
+            'LAMDA': {'color': '#8400c8',
+                      'marker': 'o', 'markersize': 12,
+                      'linestyle': 'solid', 'linewidth': 3.},
+            'LAMX': {'color': '#00dc00',
+                       'marker': 'P', 'markersize': 14,
+                       'linestyle': 'dashed', 'linewidth': 3.},
+            'LAMDAX': {'color': '#8400c8',
+                       'marker': 'P', 'markersize': 14,
+                       'linestyle': 'dashed', 'linewidth': 3.},
+            'HWRF': {'color': '#00dc00',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'HMON': {'color': '#8400c8',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'HRW_ARW': {'color': '#00dc00',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'HRW_ARW2': {'color': '#e69f00',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'HRW_FV3': {'color': '#56b4e9',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'REFS_MEAN': {'color': '#000000',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'REFS_AVRG': {'color': '#183cf5',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'REFS_PMMN': {'color': '#8400c8',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'REFS_LPMM': {'color': '#d269c1',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'REFSX_MEAN': {'color': '#000000',
+                     'marker': 'P', 'markersize': 14,
+                     'linestyle': 'dashed', 'linewidth': 3.},
+            'HRRR': {'color': '#fb2020',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'NAM': {'color': '#1e3cff',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'NAM_NEST': {'color': '#1e3cff',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'RRFS_A': {'color': '#00dc00',
+                      'marker': 'o', 'markersize': 12,
+                      'linestyle': 'solid', 'linewidth': 3.},
+            'RRFS_A_NA': {'color': '#00dc00',
+                      'marker': 'P', 'markersize': 14,
+                      'linestyle': 'dashed', 'linewidth': 3.},
+            'GFS': {'color': '#000000',
+                    'marker': 'o', 'markersize': 12,
+                    'linestyle': 'solid', 'linewidth': 5.},
+            'GFS_DASHED': {'color': '#000000',
+                           'marker': 'o', 'markersize': 12,
+                           'linestyle': 'dashed', 'linewidth': 5.},
+            'GEFS': {'color': '#000000',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 5.},
+            'CMCE': {'color': '#1e3cff',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 5.},
+            'ECME': {'color': '#fb2020',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 5.},
+            'SREF': {'color': '#fb2020',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 5.},
+            'NAEFS': {'color': '#7f00ff',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 5.},
+            'NARRE_MEAN': {'color': '#000000',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 5.},
+            'EC': {'color': '#fb2020',
+                   'marker': 'o', 'markersize': 12,
+                   'linestyle': 'solid', 'linewidth': 3.},
+            'CMC': {'color': '#1e3cff',
+                    'marker': 'o', 'markersize': 12,
+                    'linestyle': 'solid', 'linewidth': 3.},
+            'CTCX': {'color': '#56b4e9',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.},
+            'OFCL': {'color': '#696969',
+                     'marker': 'o', 'markersize': 12,
+                     'linestyle': 'solid', 'linewidth': 3.}
+        }    
+      
+    def get_color_dict(self, name):
+        color_dict = self.model_settings[name]
+        return color_dict
+
+class Reference():
+    def __init__(self):
+        '''
+        The plotting scripts will convert MET units if they are listed below.
+        The name of the unit must match one of the keys in the 
+        unit_conversions dictionary.  The name of the new unit will become the
+        value of the 'convert_to' key, and if necessary, the data and axis 
+        labels will be converted according to the value of the 'formula' key.
+        Formulas are defined as regular functions in the formulas() subclass 
+        of the Reference() class (i.e., below...)
+        '''
+        self.unit_conversions = {
+            'kg/m^2': {
+                 'convert_to': 'mm',
+                 'formula': self.formulas.mm_to_mm
+            },
+            'K': {
+                'convert_to': 'F',
+                'formula': self.formulas.K_to_F
+            },
+            'C': {
+                'convert_to': 'F',
+                'formula': self.formulas.C_to_F
+            },
+            'm/s': {
+                'convert_to': 'kt',
+                'formula': self.formulas.mps_to_kt
+            },
+            'Pa': {
+                'convert_to': 'hPa',
+                'formula': self.formulas.PA_to_hPa
+            },
+        }
+
+        '''
+        Given a var_name, which is used to find the desired forecast field 
+        in the MET .stat files, the plotting scripts will print the long name 
+        of the associated forecast field according to this dictionary.  Add 
+        keys and values, not forgetting to include a comma at the end of any 
+        new lines.
+        '''
+        self.variable_translator = {'TMP': 'Temperature',
+                                    'TMP_Z0_mean': 'Temperature',
+                                    'HGT': 'Geopotential Height',
+                                    'HGTcldceil':'Ceiling Height',
+                                    'HGT_WV1_0-3': ('Geopotential Height:' 
+                                                    + ' Waves 0-3'),
+                                    'HGT_WV1_4-9': ('Geopotential Height:'
+                                                    + ' Waves 4-9'),
+                                    'HGT_WV1_10-20': ('Geopotential Height:'
+                                                      + ' Waves 10-20'),
+                                    'HGT_WV1_0-20': ('Geopotential Height:'
+                                                     + ' Waves 0-20'),
+                                    'RH': 'Relative Humidity',
+                                    'SPFH': 'Specific Humidity',
+                                    'DPT': 'Dewpoint Temperature',
+                                    'UGRD': 'Zonal Wind Speed',
+                                    'VGRD': 'Meridional Wind Speed',
+                                    'UGRD_VGRD': 'Vector Wind',
+                                    'WIND': 'Wind Speed',
+                                    'GUST': 'Wind Gust',
+                                    'GUSTsfc': 'Wind Gust',
+                                    'CAPE': 'Surface-Based CAPE',
+                                    'SBCAPE': 'Surface-Based CAPE',
+                                    'CAPEsfc': 'Surface-Based CAPE',
+                                    'MLCAPE': 'Mixed-Layer CAPE',
+                                    'PRES': 'Pressure',
+                                    'MSLET': 'Pressure Reduced to MSL',
+                                    'PRMSL': 'Pressure Reduced to MSL',
+                                    'MSLMA': 'Mean Sea Level Pressure',
+                                    'MSLET': 'Mean Sea Level Pressure',
+                                    'MSLP': 'Mean Sea Level Pressure',
+                                    'O3MR': 'Ozone Mixing Ratio',
+                                    'TOZNE': 'Total Ozone',
+                                    'OZCON1': 'OZCON1',
+                                    'HPBL': 'Planetary Boundary Layer Height',
+                                    'TSOIL': 'Soil Temperature',
+                                    'SOILW': ('Volumetric Soil Moisture'
+                                              + ' Content'),
+                                    'weasd': 'Accum. Snow Depth Water equiv.',
+                                    'WEASD_L0': 'Accum. Snow Depth Water equiv.',
+                                    'WEASD': 'Accum. Snow Depth Water equiv.',
+                                    'SNOD_L0':'Accum. Snow Depth',
+                                    'ASNOW': 'Accum. Snow Depth Water equiv.',
+                                    'APCP': ('Accumulated'
+                                                + ' Precipitation'),
+                                    'APCP_01': ('Accumulated'
+                                                + ' Precipitation'),
+                                    'APCP_03': ('Accumulated'
+                                                + ' Precipitation'),
+                                    'APCP_06': ('Accumulated'
+                                                + ' Precipitation'),
+                                    'APCP_24': ('Accumulated'
+                                                + ' Precipitation'),
+                                    'PWAT': 'Precipitable Water',
+                                    'CWAT': 'Cloud Water',
+                                    'TCDC': 'Cloud Area Fraction',
+                                    'HGTCLDCEIL': 'Cloud Ceiling Height',
+                                    'VIS': 'Visibility',
+                                    'sst': 'Sea Surface Temperature',
+                                    'ssh': 'Sea Surface Height',
+                                    'ice_coverage': 'Sea Ice Concentration',
+                                    'sss': 'Sea Surface Salinity',
+                                    'ICEC_Z0_mean': 'Sea Ice Concentration',
+                                    'ICESEV': 'Icing Severity',
+                                    'REFC': 'Composite Reflectivity',
+                                    'REFD': 'Above Ground Level Reflectivity',
+                                    'RETOP': 'Echo Top Height',
+                                    #added for PSTD:  Binbin Zhou
+                                    'TMP_ENS_FREQ_lt273.15': 'TMP < 0 C',
+                                    'WIND_ENS_FREQ_ge15.4':  'Wind speed >= 30kt',
+                                    'WIND_ENS_FREQ_ge20.58': 'Wind speed >= 40kt',
+                                    'APCP_24_ENS_FREQ_gt1': 'APCP_24hr > 1 mm',
+                                    'APCP_24_ENS_FREQ_gt2': 'APCP_24hr > 2 mm',
+                                    'APCP_24_ENS_FREQ_gt5': 'APCP_24hr > 5 mm',
+                                    'APCP_24_ENS_FREQ_gt10': 'APCP_24hr > 10 mm',
+                                    'APCP_24_ENS_FREQ_gt20': 'APCP_24hr > 20 mm',
+                                    'APCP_24_ENS_FREQ_gt25': 'APCP_24hr > 25 mm',
+                                    'APCP_24_ENS_FREQ_gt50': 'APCP_24hr > 50 mm'}
+        '''
+        Given a domain requested in the plotting configuration file, the
+        plotting scripts will print the long name of that domain according
+        to this dictionary.  Add keys and values, not forgetting to include
+        a comma at the end of any new lines.
+        '''
+        self.domain_translator = {'NHX': 'Northern Hemisphere 20N-80N',
+                                  'SHX': 'Southern Hemisphere 20S-80S',
+                                  'NHEM': 'Northern Hemisphere 20N-80N',
+                                  'SHEM': 'Southern Hemisphere 20S-80S',
+                                  'TRO': 'Tropics 20S-20N',
+                                  'TROPICS': 'Tropics 20S-20N',
+                                  'PNA': 'Pacific North America',
+                                  'N60': '60N-90N',
+                                  'S60': '60S-90S',
+                                  'North_Pacific': 'Northern Pacific Ocean',
+                                  'NPO': 'Northern Pacific Ocean',
+                                  'South_Pacific': 'Southern Pacific Ocean',
+                                  'SPO': 'Southern Pacific Ocean',
+                                  'Equatorial_Pacific': 'Equatorial Pacific Ocean',
+                                  'North_Atlantic': 'Northern Atlantic Ocean',
+                                  'NAO': 'Northern Atlantic Ocean',
+                                  'South_Atlantic': 'Southern Atlantic Ocean',
+                                  'SAO': 'Southern Atlantic Ocean',
+                                  'Equatorial_Atlantic': 'Equatorial Atlantic Ocean',
+                                  'Indian': 'Indian Ocean',
+                                  'Southern': 'Southern Ocean',
+                                  'Mediterranean': 'Mediterranean Sea',
+                                  'NH': 'Northern Hemisphere 20N-90N',
+                                  'SH': 'Southern Hemisphere 20S-90S',
+                                  'AR2': 'AR2',
+                                  'ASIA': 'Asia',
+                                  'AUNZ': 'Australia and New Zealand',
+                                  'NAMR': 'North America',
+                                  'NHM': 'Northern Hemisphere',
+                                  'NPCF': 'North Pacific Ocean',
+                                  'SHM': 'Southern Hemisphere',
+                                  'TRP': 'TRP',
+                                  'G002': 'Global',
+                                  'G003': 'Global',
+                                  'Global': 'Global',
+                                  'G130': 'CONUS - NCEP Grid 130',
+                                  'G211': 'CONUS - NCEP Grid 211',
+                                  'G221': 'CONUS - NCEP Grid 221',
+                                  'G236': 'CONUS - NCEP Grid 236',
+                                  'G223': 'CONUS - NCEP Grid 223',
+                                  'CONUS': 'CONUS',
+                                  'POLAR': 'Polar 60-90 N/S',
+                                  'ARCTIC': 'Arctic',
+                                  'ANTARCTIC': 'Antarctic',
+                                  'Arctic': 'Arctic Ocean',
+                                  'Antarctic': 'Antarctic Ocean',
+                                  'EAST': 'Eastern US',
+                                  'CONUS_East': 'Eastern US',
+                                  'WEST': 'Western US',
+                                  'CONUS_West': 'Western US',
+                                  'CONUS_Central': 'Central US',
+                                  'CONUS_South': 'Southern US',
+                                  'NWC': 'Northwest Coast',
+                                  'PacificNW': 'Pacific Northwest',
+                                  'SWC': 'Southwest Coast',
+                                  'PacificSW': 'Pacific Southwest',
+                                  'NMT': 'Northern Mountain Region',
+                                  'NRockies': 'Northern Rocky Mountains',
+                                  'GRB': 'Great Basin',
+                                  'GreatBasin': 'Great Basin',
+                                  'SMT': 'Southern Mountain Region',
+                                  'SRockies': 'Southern Rocky Mountains',
+                                  'SWD': 'Southwest Desert',
+                                  'Mezquital': 'Mezquital',
+                                  'NPL': 'Northern Plains',
+                                  'NPlains': 'Northern Plains',
+                                  'CPlains': 'Central Plains',
+                                  'SPL': 'Southern Plains',
+                                  'SPlains': 'Southern Plains',
+                                  'Prairie': 'Prairie',
+                                  'GreatLakes': 'Great Lakes',
+                                  'MDW': 'Midwest',
+                                  'LMV': 'Lower Mississippi Valley',
+                                  'APL': 'Appalachians',
+                                  'Appalachia': 'Appalachia',
+                                  'NorthAtlantic': 'North Atlantic',
+                                  'MidAtlantic': 'Mid-Atlantic',
+                                  'NEC': 'Northeast Coast',
+                                  'SEC': 'Southeast Coast',
+                                  'Southeast': 'Southeast CONUS',
+                                  'GMC': 'Gulf of Mexico Coast',
+                                  'DeepSouth': 'Deep South',
+                                  'Alaska': 'Alaska',
+                                  'NAK': 'Northern Alaska',
+                                  'SAK': 'Southern Alaska',
+                                  'Hawaii': 'Hawaii',
+                                  'PuertoRico': 'Puerto Rico',
+                                  'Guam': 'Guam',
+                                  'FireWx': 'Fire Weather Nest',
+                                  'SEA_ICE': 'Global - Sea Ice',
+                                  'SEA_ICE_FREE': 'Global - Sea Ice Free',
+                                  'SEA_ICE_POLAR': 'Polar - Sea Ice',
+                                  'SEA_ICE_FREE_POLAR': ('Polar - Sea Ice'
+                                                         + ' Free')}
+        self.linetype_cols = {'FHO':['TOTAL','F_RATE','H_RATE','O_RATE'],
+                              'CTC':['TOTAL','FY_OY','FY_ON','FN_OY','FN_ON'],
+                              'CTS':['TOTAL','BASER','BASER_NCL','BASER_NCU',
+                                     'BASER_BCL','BASER_BCU','FMEAN',
+                                     'FMEAN_NCL','FMEAN_NCU','FMEAN_BCL',
+                                     'FMEAN_BCU','ACC','ACC_NCL','ACC_NCU',
+                                     'ACC_BCL','ACC_BCU','FBIAS','FBIAS_BCL',
+                                     'FBIAS_BCU','PODY','PODY_NCL','PODY_NCU',
+                                     'PODY_BCL','PODY_BCU','PODN','PODN_NCL',
+                                     'PODN_NCU','PODN_BCL','PODN_BCU','POFD',
+                                     'POFD_NCL','POFD_NCU','POFD_BCL',
+                                     'POFD_BCU','FAR','FAR_NCL','FAR_NCU',
+                                     'FAR_BCL','FAR_BCU','CSI','CSI_NCL',
+                                     'CSI_NCU','CSI_BCL','CSI_BCU','GSS',
+                                     'GSS_BCL','GSS_BCU','HK','HK_NCL',
+                                     'HK_NCU','HK_BCL','HK_BCU','HSS',
+                                     'HSS_BCL','HSS_BCU','ODDS','ODDS_NCL',
+                                     'ODDS_NCU','ODDS_BCL','ODDS_BCU','LODDS',
+                                     'LODDS_NCL','LODDS_NCU','LODDS_BCL',
+                                     'LODDS_BCU','ORSS','ORSS_NCL','ORSS_NCU',
+                                     'ORSS_BCL','ORSS_BCU','EDS','EDS_NCL',
+                                     'EDS_NCU','EDS_BCL','EDS_BCU','SEDS',
+                                     'SEDS_NCL','SEDS_NCU','SEDS_BCL',
+                                     'SEDS_BCU','EDI','EDI_NCL','EDI_NCU',
+                                     'EDI_BCL','EDI_BCU','SEDI','SEDI_NCL',
+                                     'SEDI_NCU','SEDI_BCL','SEDI_BCU','BAGSS',
+                                     'BAGSS_BCL','BAGSS_BCU'],
+                              'CNT':['TOTAL','FBAR','FBAR_NCL','FBAR_NCU',
+                                     'FBAR_BCL','FBAR_BCU','FSTDEV',
+                                     'FSTDEV_NCL','FSTDEV_NCU','FSTDEV_BCL',
+                                     'FSTDEV_BCU','OBAR','OBAR_NCL',
+                                     'OBAR_NCU','OBAR_BCL','OBAR_BCU',
+                                     'OSTDEV','OSTDEV_NCL','OSTDEV_NCU',
+                                     'OSTDEV_BCL','OSTDEV_BCU','PR_CORR',
+                                     'PR_CORR_NCL','PR_CORR_NCU',
+                                     'PR_CORR_BCL','PR_CORR_BCU','SP_CORR', 
+                                     'KT_CORR','RANKS','FRANK_TIES',
+                                     'ORANK_TIES','ME','ME_NCL','ME_NCU',
+                                     'ME_BCL','ME_BCU','ESTDEV','ESTDEV_NCL',
+                                     'ESTDEV_NCU','ESTDEV_BCL','ESTDEV_BCU',
+                                     'MBIAS','MBIAS_BCL','MBIAS_BCU',
+                                     'MAE','MAE_BCL','MAE_BCU',
+                                     'MSE','MSE_BCL','MSE_BCU',
+                                     'BCMSE','BCMSE_BCL','BCMSE_BCU',
+                                     'RMSE','RMSE_BCL','RMSE_BCU',
+                                     'E10','E10_BCL','E10_BCU',
+                                     'E25','E25_BCL','E25_BCU',
+                                     'E50','E50_BCL','E50_BCU',
+                                     'E75','E75_BCL','E75_BCU',
+                                     'E90','E90_BCL','E90_BCU',
+                                     'IQR','IQR_BCL','IQR_BCU',
+                                     'MAD','MAD_BCL','MAD_BCU',
+                                     'ANOM_CORR','ANOM_CORR_NCL',
+                                     'ANOM_CORR_NCU','ANOM_CORR_BCL',
+                                     'ANOM_CORR_BCU',
+                                     'ME2','ME2_BCL','ME2_BCU',
+                                     'MSESS','MSESS_BCL','MSESS_BCU',
+                                     'RMSFA','RMSFA_BCL','RMSFA_BCU',
+                                     'RMSOA','RMSOA_BCL','RMSOA_BCU',
+                                     'ANOM_CORR_UNCNTR',
+                                     'ANOM_CORR_UNCNTR_BCL',
+                                     'ANOM_CORR_UNCNTR_BCU'],
+                              'MCTC':['TOTAL','N_CAT','Fi_Oj'],
+                              'MCTS':['TOTAL','N_CAT','ACC','ACC_NCL',
+                                      'ACC_NCU','ACC_BCL','ACC_BCU',
+                                      'HK','HK_BCL','HK_BCU',
+                                      'GER','GER_BCL','GER_BCU'],
+                              'PCT':['TOTAL','N_THRESH','THRESH_i','OY_i',
+                                      'ON_i','THRESH_n'],
+                              'PSTD':['TOTAL','N_THRESH','BASER','BASER_NCL',
+                                      'BASER_NCU','RELIABILITY','RESOLUTION',
+                                      'UNCERTAINTY','ROC_AUC','BRIER',
+                                      'BRIER_NCL','BRIER_NCU','BRIERCL',
+                                      'BRIERCL_NCL','BRIERCL_NCU',
+                                      'BSS','BSS_SMPL','THRESH_i'],
+                              'PJC':['TOTAL','N_THRESH','THRESH_i','OY_TP_i',
+                                     'ON_TP_i','CALIBRATION_i','REFINEMENT_i',
+                                     'LIKELIHOOD_i','BASER_i','THRESH_n'],
+                              'PRC':['TOTAL','N_THRESH','THRESH_i','PODY_i',
+                                      'POFD_i','THRESH_n'],
+                              'ECLV':['TOTAL','BASER','VALUE_BASER','N_PNT',
+                                      'CL_i','VALUE_i'],
+                              'SL1L2':['TOTAL','FBAR','OBAR','FOBAR','FFBAR',
+                                       'OOBAR','MAE'],
+                              'SAL1L2':['TOTAL','FABAR','OABAR','FOABAR',
+                                        'FFABAR','OOABAR','MAE'],
+                              'VL1L2':['TOTAL','UFBAR','VFBAR','UOBAR',
+                                       'VOBAR','UVFOBAR','UVFFBAR','UVOOBAR',
+                                       'F_SPEED_BAR','O_SPEED_BAR',
+                                       'TOTAL_DIR','DIR_ME','DIR_MAE','DIR_MSE'],
+                              'VAL1L2':['TOTAL','UFABAR','VFABAR','UOABAR',
+                                        'VOABAR','UVFOABAR','UVFFABAR',
+                                        'UVOOABAR'],
+                              'VCNT':['TOTAL','FBAR','OBAR','FS_RMS','OS_RMS',
+                                      'MSVE','RMSVE','FSTDEV','OSTDEV',
+                                      'FDIR','ODIR','FBAR_SPEED','OBAR_SPEED',
+                                      'VDIFF_SPEED','VDIFF_DIR','SPEED_ERR',
+                                      'SPEED_ABSERR','DIR_ERR','DIR_ABSERR'],
+                              'MPR':['TOTAL','INDEX','OBS_SID','OBS_LAT',
+                                     'OBS_LON','OBS_LVL','OBS_ELV','FCST',
+                                     'OBS','OBS_QC','CLIMO_MEAN',
+                                     'CLIMO_STDEV','CLIMO_CDF'],
+                              'NBRCTC':['TOTAL','FY_OY','FY_ON','FN_OY',
+                                        'FN_ON'],
+                              'NBRCTS':['TOTAL','BASER','BASER_NCL',
+                                        'BASER_NCU','BASER_BCL','BASER_BCU',
+                                        'FMEAN','FMEAN_NCL','FMEAN_NCU',
+                                        'FMEAN_BCL','FMEAN_BCU','ACC',
+                                        'ACC_NCL','ACC_NCU','ACC_BCL',
+                                        'ACC_BCU','FBIAS','FBIAS_BCL',
+                                        'FBIAS_BCU','PODY','PODY_NCL',
+                                        'PODY_NCU','PODY_BCL','PODY_BCU',
+                                        'PODN','PODN_NCL','PODN_NCU',
+                                        'PODN_BCL','PODN_BCU','POFD',
+                                        'POFD_NCL','POFD_NCU','POFD_BCL',
+                                        'POFD_BCU','FAR','FAR_NCL','FAR_NCU',
+                                        'FAR_BCL','FAR_BCU','CSI','CSI_NCL',
+                                        'CSI_NCU','CSI_BCL','CSI_BCU','GSS',
+                                        'GSS_BCL','GSS_BCU','HK','HK_NCL',
+                                        'HK_NCU','HK_BCL','HK_BCU','HSS',
+                                        'HSS_BCL','HSS_BCU','ODDS','ODDS_NCL',
+                                        'ODDS_NCU','ODDS_BCL','ODDS_BCU',
+                                        'LODDS','LODDS_NCL','LODDS_NCU',
+                                        'LODDS_BCL','LODDS_BCU','ORSS',
+                                        'ORSS_NCL','ORSS_NCU','ORSS_BCL',
+                                        'ORSS_BCU','EDS','EDS_NCL','EDS_NCU',
+                                        'EDS_BCL','EDS_BCU','SEDS','SEDS_NCL',
+                                        'SEDS_NCU','SEDS_BCL','SEDS_BCU',
+                                        'EDI','EDI_NCL','EDI_NCU','EDI_BCL',
+                                        'EDI_BCU','SEDI','SEDI_NCL',
+                                        'SEDI_NCU','SEDI_BCL','SEDI_BCU',
+                                        'BAGSS','BAGSS_BCL','BAGSS_BCU'],
+                              'NBRCNT':['TOTAL','FBS','FBS_BCL','FBS_BCU',
+                                        'FSS','FSS_BCL','FSS_BCU',
+                                        'AFSS','AFSS_BCL','AFSS_BCU',
+                                        'UFSS','UFSS_BCL','UFSS_BCU',
+                                        'F_RATE','F_RATE_BCL','F_RATE_BCU',
+                                        'O_RATE','O_RATE_BCL','O_RATE_BCU'],
+                              'ECNT':['TOTAL', 'N_ENS', 'CRPS', 'CRPSS', 'IGN', 
+                                        'ME', 'RMSE', 'SPREAD',
+                                        'ME_OERR', 'RMSE_OERR', 'SPREAD_OERR', 
+                                        'SPREAD_PLUS_OERR', 'CRPSCL', 'CRPS_EMP', 
+                                        'CRPSCL_EMP', 'CRPSS_EMP',  'CRPS_EMP_FAIR',
+                                        'SPREAD_MD', 'MAE', 'MAE_OERR', 'BIAS_RATIO',
+                                        'N_GE_OBS', 'ME_GE_OBS', 'N_LT_OBS', 'ME_LT_OBS'], 
+                              'GRAD':['TOTAL','FGBAR','OGBAR','MGBAR','EGBAR',
+                                      'S1','S1_OG','FGOG_RATIO','DX','DY'],
+                              'DMAP':['TOTAL','FY','OY','FBIAS','BADDELEY',
+                                      'HAUSDORFF','MED_FO','MED_OF','MED_MIN',
+                                      'MED_MAX','MED_MEAN','FOM_FO','FOM_OF',
+                                      'FOM_MIN','FROM_MAX','FOM_MEAN','ZHU_FO',
+                                      'ZHU_OF','ZHU_MIN','ZHU_MAX','ZHU_MEAN'],
+        }
+
+        '''
+        Define plotting jobs that are allowed in order to draw attention to 
+        configuration typos, to delineate the bounds of expected user
+        configurations, and to prevent unexpected behavior.  
+        
+        The case_type dictionary contains nested dictionaries, each named for
+        a specific configuration, and nested based on the type of configuration.  
+        The hierarchy is this: 
+        self.case_type[VERIF_CASE_VERIF_TYPE][LINE_TYPE]['var_dict'][var_name]
+        
+        The var_name dictionary contains possible settings for the fcst/obs
+        names, levels, thresholds, and options stored in the MET .stat files.
+        It also includes the appropriate plotting group for that var_name
+        (e.g., 'sfc_upper', 'radar',  or 'precip').
+
+        The LINE_TYPE dictionary includes the 'var_dict' dictionary and a few 
+        additional variables. 'plot_stats_list' is a string containing a 
+        comma-separated list of possible metrics that may be computed using 
+        LINE_TYPE lines. 'interp' is a string containing a comma-separated list
+        of possible interpolation methods that may be searched for if the 
+        line type is LINE_TYPE. 'vx_mask_list' is a python list of strings,
+        each string representing a possible domain name in the VX_MASK column
+        in the MET .stat file.
+        '''
+        self.case_type = {
+            'grid2grid_anom': {
+                'SAL1L2': {
+                    'plot_stats_list': 'acc',
+                    'interp': 'NEAREST, BILIN',
+                    #Added 'G003','NHEM','SHEM','TROPICS','CONUS' for global_ens: 
+                    'vx_mask_list' : ['NHX', 'SHX', 'PNA', 'TRO', 'G003','NHEM','SHEM','TROPICS','CONUS'],
+                    'var_dict': {
+                        'HGT': {'fcst_var_names': ['HGT'],
+                                'fcst_var_levels': [
+                                    'P1000', 'P700', 'P500', 'P250'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['HGT','GH'],
+                                'obs_var_levels': [
+                                    'P1000', 'P700', 'P500', 'P250'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'HGT_WV1_0-20': {'fcst_var_names': ['HGT'],
+                                         'fcst_var_levels': [
+                                             'P1000', 'P700', 'P500', 'P250'
+                                         ],
+                                         'fcst_var_thresholds': '',
+                                         'fcst_var_options': '',
+                                         'obs_var_names': ['HGT'],
+                                         'obs_var_levels': [
+                                             'P1000', 'P700', 'P500', 'P250'
+                                         ],
+                                         'obs_var_thresholds': '',
+                                         'obs_var_options': '',
+                                         'plot_group':'sfc_upper'},
+                        'HGT_WV1_0-3': {'fcst_var_names': ['HGT'],
+                                        'fcst_var_levels': [
+                                            'P1000', 'P700', 'P500', 'P250'
+                                        ],
+                                        'fcst_var_thresholds': '',
+                                        'fcst_var_options': '',
+                                        'obs_var_names': ['HGT'],
+                                        'obs_var_levels': [
+                                            'P1000', 'P700', 'P500', 'P250'
+                                        ],
+                                        'obs_var_thresholds': '',
+                                        'obs_var_options': '',
+                                        'plot_group':'sfc_upper'},
+                        'HGT_WV1_4-9': {'fcst_var_names': ['HGT'],
+                                        'fcst_var_levels': [
+                                            'P1000', 'P700', 'P500', 'P250'
+                                        ],
+                                        'fcst_var_thresholds': '',
+                                        'fcst_var_options': '',
+                                        'obs_var_names': ['HGT'],
+                                        'obs_var_levels': [
+                                            'P1000', 'P700', 'P500', 'P250'
+                                        ],
+                                        'obs_var_thresholds': '',
+                                        'obs_var_options': '',
+                                        'plot_group':'sfc_upper'},
+                        'HGT_WV1_10-20': {'fcst_var_names': ['HGT'],
+                                          'fcst_var_levels': [
+                                              'P1000', 'P700', 'P500', 'P250'
+                                          ],
+                                          'fcst_var_thresholds': '',
+                                          'fcst_var_options': '',
+                                          'obs_var_names': ['HGT'],
+                                          'obs_var_levels': [
+                                              'P1000', 'P700', 'P500', 'P250'
+                                          ],
+                                          'obs_var_thresholds': '',
+                                          'obs_var_options': '',
+                                          'plot_group':'sfc_upper'},
+                        'TMP': {'fcst_var_names': ['TMP'],
+                                'fcst_var_levels': ['P850', 'P500', 'P250'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['TMP','T'],
+                                'obs_var_levels': ['P850', 'P500', 'P250'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                 'fcst_var_levels': ['P850', 'P500', 'P250', 'Z10'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['UGRD','U','10U'],
+                                 'obs_var_levels': ['P850', 'P500', 'P250','Z10','L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                 'fcst_var_levels': ['P850', 'P500', 'P250','Z10'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['VGRD','V','10V'],
+                                 'obs_var_levels': ['P850', 'P500', 'P250','Z10','L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'PRMSL': {'fcst_var_names': ['PRMSL','MSLET'],
+                                  'fcst_var_levels': ['Z0','L0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL','MSL'],
+                                  'obs_var_levels': ['Z0','L0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'}
+                    }
+                },
+                'VAL1L2': {
+                    'plot_stats_list': 'acc',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : ['NHX', 'SHX', 'PNA', 'TRO'],
+                    'var_dict': {
+                        'UGRD_VGRD': {'fcst_var_names': ['UGRD_VGRD'],
+                                      'fcst_var_levels': [
+                                          'P850', 'P500', 'P250'
+                                      ],
+                                      'fcst_var_thresholds': '',
+                                      'fcst_var_options': '',
+                                      'obs_var_names': ['UGRD_VGRD'],
+                                      'obs_var_levels': [
+                                          'P850', 'P500', 'P250'
+                                      ],
+                                      'obs_var_thresholds': '',
+                                      'obs_var_options': '',
+                                      'plot_group':'sfc_upper'}
+                    }
+                }
+            },
+            'grid2grid_pres': {
+                'SL1L2': {
+                    'plot_stats_list': ('bias, rmse, msess, rsd, rmse_md,'
+                                        + ' rmse_pv, mae, me' ),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : ['NHX', 'SHX', 'PNA', 'TRO',
+                                      'G003','NHEM','SHEM','TROPICS','CONUS', 'CONUS_East',
+                                      'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'HGT': {'fcst_var_names': ['HGT'],
+                                'fcst_var_levels': [
+                                    'P1000', 'P850', 'P700', 'P500', 'P200', 
+                                    'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['HGT','GH'],
+                                'obs_var_levels': [
+                                    'P1000', 'P850', 'P700', 'P500', 'P200', 
+                                    'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'TMP': {'fcst_var_names': ['TMP'],
+                                'fcst_var_levels': [
+                                    'P1000', 'P850', 'P700', 'P500', 'P200', 
+                                    'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['TMP','T'],
+                                'obs_var_levels': [
+                                    'P1000', 'P850', 'P700', 'P500', 'P200', 
+                                    'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                 'fcst_var_levels': [
+                                     'P1000', 'P850', 'P700', 'P500', 'P250','P200', 
+                                     'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                 ],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['UGRD','U'],
+                                 'obs_var_levels': [
+                                     'P1000', 'P850', 'P700', 'P500','P250', 'P200', 
+                                     'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                 ],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                 'fcst_var_levels': [
+                                     'P1000', 'P850', 'P700', 'P500', 'P250', 'P200', 
+                                     'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                 ],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['VGRD','V'],
+                                 'obs_var_levels': [
+                                     'P1000', 'P850', 'P700', 'P500', 'P250', 'P200', 
+                                     'P100', 'P50', 'P20', 'P10', 'P5', 'P1'
+                                 ],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'O3MR': {'fcst_var_names': ['O3MR'],
+                                 'fcst_var_levels': [
+                                     'P100', 'P70', 'P50', 'P30', 'P20', 
+                                     'P10', 'P5', 'P1'
+                                 ],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['O3MR'],
+                                 'obs_var_levels': [
+                                     'P100', 'P70', 'P50', 'P30', 'P20', 
+                                     'P10', 'P5', 'P1'
+                                 ],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'}
+                    }
+                },
+                'VL1L2': {
+                    'plot_stats_list': ('bias, rmse, msess, rsd, rmse_md,'
+                                        + ' rmse_pv'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : ['NHX', 'SHX', 'PNA', 'TRO'],
+                    'var_dict': {
+                        'UGRD_VGRD': {'fcst_var_names': ['UGRD_VGRD'],
+                                      'fcst_var_levels': [
+                                          'P1000', 'P850', 'P700', 'P500', 
+                                          'P200', 'P100', 'P50', 'P20', 'P10', 
+                                          'P5', 'P1'
+                                      ],
+                                      'fcst_var_thresholds': '',
+                                      'fcst_var_options': '',
+                                      'obs_var_names': ['UGRD_VGRD'],
+                                      'obs_var_levels': [
+                                          'P1000', 'P850', 'P700', 'P500', 
+                                          'P200', 'P100', 'P50', 'P20', 'P10', 
+                                          'P5', 'P1'
+                                      ],
+                                      'obs_var_thresholds': '',
+                                      'obs_var_options': '',
+                                      'plot_group':'sfc_upper'}
+                    }
+                },
+                'ECNT': {
+                    'plot_stats_list': ('crps, crpss, rmse, spread, me, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'G003','NHEM','SHEM','TROPICS','CONUS', 'CONUS_East',
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'HGT': {'fcst_var_names': ['HGT'],
+                                'fcst_var_levels': [
+                                    'P1000', 'P700', 'P500'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['HGT','GH'],
+                                'obs_var_levels': [
+                                    'P1000', 'P700', 'P500'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'TMP': {'fcst_var_names': ['TMP'],
+                                'fcst_var_levels': [
+                                    'P850', 'P500'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['TMP','T'],
+                                'obs_var_levels': [
+                                    'P850', 'P500'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                'fcst_var_levels': [
+                                    'P850', 'P250'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['UGRD','U','10U'],
+                                'obs_var_levels': [
+                                    'P850', 'P250'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                'fcst_var_levels': [
+                                    'P850', 'P250'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['VGRD','V','10V'],
+                                'obs_var_levels': [
+                                    'P850', 'P250'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'}
+                    }
+                }
+            },
+            'grid2grid_sfc': {
+                'SL1L2': {
+                    'plot_stats_list': ('fbar, bias, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'NHX', 'SHX', 'N60', 'S60', 'TRO', 'NPO', 'SPO', 
+                        'NAO', 'SAO', 'G130', 'CONUS',
+                        'G003','NHEM','SHEM','TROPICS', 'CONUS_East',
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'TMPsfc': {'fcst_var_names': ['TMP'],
+                                   'fcst_var_levels': ['Z0'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['TMP'],
+                                   'obs_var_levels': ['Z0'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'sfc_upper'},
+                        'TMPtrops': {'fcst_var_names': ['TMP'],
+                                     'fcst_var_levels': ['L0'],
+                                     'fcst_var_thresholds': '',
+                                     'fcst_var_options': 'GRIB_lvl_typ = 7;',
+                                     'obs_var_names': ['TMP'],
+                                     'obs_var_levels': ['L0'],
+                                     'obs_var_thresholds': '',
+                                     'obs_var_options': 'GRIB_lvl_typ = 7;',
+                                     'plot_group':'sfc_upper'},
+                        'RH2m': {'fcst_var_names': ['RH'],
+                                 'fcst_var_levels': ['Z2'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['RH'],
+                                 'obs_var_levels': ['Z2'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'SPFH2m': {'fcst_var_names': ['SPFH'],
+                                   'fcst_var_levels': ['Z2'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['SPFH'],
+                                   'obs_var_levels': ['Z2'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'sfc_upper'},
+                        'HPBL': {'fcst_var_names': ['HPBL'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['HPBL'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'PRESsfc': {'fcst_var_names': ['PRES'],
+                                    'fcst_var_levels': ['Z0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['PRES'],
+                                    'obs_var_levels': ['Z0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'PREStrops': {'fcst_var_names': ['PRES'],
+                                      'fcst_var_levels': ['L0'],
+                                      'fcst_var_thresholds': '',
+                                      'fcst_var_options': 'GRIB_lvl_typ = 7;',
+                                      'obs_var_names': ['PRES'],
+                                      'obs_var_levels': ['L0'],
+                                      'obs_var_thresholds': '',
+                                      'obs_var_options': 'GRIB_lvl_typ = 7;',
+                                      'plot_group':'sfc_upper'},
+                        'PRMSL': {'fcst_var_names': ['PRMSL','MSLET'],
+                                  'fcst_var_levels': ['Z0','L0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL','MSL'],
+                                  'obs_var_levels': ['Z0','L0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'UGRD10m': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD','10U'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD10m': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD','10V'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD','10U'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD','10V'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'TSOILtop': {'fcst_var_names': ['TSOIL'],
+                                     'fcst_var_levels': ['Z10-0'],
+                                     'fcst_var_thresholds': '',
+                                     'fcst_var_options': '',
+                                     'obs_var_names': ['TSOIL'],
+                                     'obs_var_levels': ['Z10-0'],
+                                     'obs_var_thresholds': '',
+                                     'obs_var_options': '',
+                                     'plot_group':'sfc_upper'},
+                        'SOILWtop': {'fcst_var_names': ['SOILW'],
+                                     'fcst_var_levels': ['Z10-0'],
+                                     'fcst_var_thresholds': '',
+                                     'fcst_var_options': '',
+                                     'obs_var_names': ['SOILW'],
+                                     'obs_var_levels': ['Z10-0'],
+                                     'obs_var_thresholds': '',
+                                     'obs_var_options': '',
+                                     'plot_group':'sfc_upper'},
+                        'WEASD': {'fcst_var_names': ['WEASD'],
+                                  'fcst_var_levels': ['Z0','A06','A24'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['WEASD'],
+                                  'obs_var_levels': ['Z0','A06','A24'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'precip'},
+                        'CAPE': {'fcst_var_names': ['CAPE'],
+                                 'fcst_var_levels': ['Z0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['CAPE'],
+                                 'obs_var_levels': ['Z0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'cape'},
+                        'PWAT': {'fcst_var_names': ['PWAT'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['PWAT'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'CWAT': {'fcst_var_names': ['CWAT'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['CWAT'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'HGTtrops': {'fcst_var_names': ['HGT'],
+                                     'fcst_var_levels': ['L0'],
+                                     'fcst_var_thresholds': '',
+                                     'fcst_var_options': 'GRIB_lvl_typ = 7;',
+                                     'obs_var_names': ['HGT'],
+                                     'obs_var_levels': ['L0'],
+                                     'obs_var_thresholds': '',
+                                     'obs_var_options': 'GRIB_lvl_typ = 7;',
+                                     'plot_group':'sfc_upper'},
+                        'TOZNEclm': {'fcst_var_names': ['TOZNE'],
+                                     'fcst_var_levels': ['L0'],
+                                     'fcst_var_thresholds': '',
+                                     'fcst_var_options': '',
+                                     'obs_var_names': ['TOZNE'],
+                                     'obs_var_levels': ['L0'],
+                                     'obs_var_thresholds': '',
+                                     'obs_var_options': '',
+                                     'plot_group':'sfc_upper'}
+                    }
+                },
+                'ECNT': {
+                    'plot_stats_list': ('crps, crpss, rmse, spread, me, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'G003','NHEM','SHEM','TROPICS','CONUS', 'CONUS_East',
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'PRMSL': {'fcst_var_names': ['PRMSL','MSLET'],
+                                  'fcst_var_levels': ['Z0','L0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL','MSL'],
+                                  'obs_var_levels': ['Z0','L0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD','10U'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD','10V'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'SST':  {'fcst_var_names': ['TMP_Z0_mean'],
+                                    'fcst_var_levels': ['Z0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['analysed_sst'],
+                                    'obs_var_levels': ['0,*,*'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'}
+                    }
+                }
+            },
+            'grid2grid_mrms':{
+                'CTC': {
+                    'plot_stats_list': ('fss, csi, fbias, pod, faratio,'
+                                        + ' sratio'),
+                    'interp': 'NEAREST, NBRHD_CIRCLE, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'APL', 'GMC', 'GRB', 'LMV', 'MDW', 'NEC', 
+                        'NMT', 'NPL', 'NWC', 'SEC', 'SMT', 'SPL', 'SWC', 
+                        'SWD', 'DAY1_1200_TSTM', 'DAY2_1730_TSTM'
+                    ],
+                    'var_dict': {
+                        'REFC': {'fcst_var_names': ['REFC'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': ('>=20, >=30, >=40,'
+                                                         + ' >=50'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': [
+                                     'MergedReflectivityQCComposite'
+                                 ],
+                                 'obs_var_levels': ['Z500'],
+                                 'obs_var_thresholds': ('>=20, >=30, >=40,'
+                                                        + ' >=50'),
+                                 'obs_var_options': '',
+                                 'plot_group':'radar'},
+                        'RETOP': {'fcst_var_names': ['RETOP'],
+                                 'fcst_var_levels': ['L0','Z1000'],
+                                 'fcst_var_thresholds': ('>=20, >=30, >=40,'
+                                                         + ' >=50'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['EchoTop18'],
+                                 'obs_var_levels': ['L0','Z500'],
+                                 'obs_var_thresholds': ('>=20, >=30, >=40,'
+                                                        + ' >=50'),
+                                 'obs_var_options': '',
+                                 'plot_group':'radar'},
+                        'REFD': {'fcst_var_names': ['REFD'],
+                                 'fcst_var_levels': ['L0','Z1000'],
+                                 'fcst_var_thresholds': ('>=20, >=30, >=40,'
+                                                         + ' >=50'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['SeamlessHSR'],
+                                 'obs_var_levels': ['L0','Z500'],
+                                 'obs_var_thresholds': ('>=20, >=30, >=40,'
+                                                        + ' >=50'),
+                                 'obs_var_options': '',
+                                 'plot_group':'radar'}
+                    }
+                }
+            },
+            'radar_mrms':{
+                'CTC': {
+                    'plot_stats_list': ('fss, csi, fbias, pod, faratio,'
+                                        + ' sratio'),
+                    'interp': 'NEAREST, NBRHD_CIRCLE, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'APL', 'GMC', 'GRB', 'LMV', 'MDW', 'NEC', 
+                        'NMT', 'NPL', 'NWC', 'SEC', 'SMT', 'SPL', 'SWC', 
+                        'SWD', 'DAY1_1200_TSTM', 'DAY2_1730_TSTM'
+                    ],
+                    'var_dict': {
+                        'REFC': {'fcst_var_names': ['REFC'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': ('>=20, >=30, >=40,'
+                                                         + ' >=50'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': [
+                                     'MergedReflectivityQCComposite'
+                                 ],
+                                 'obs_var_levels': ['Z500'],
+                                 'obs_var_thresholds': ('>=20, >=30, >=40,'
+                                                        + ' >=50'),
+                                 'obs_var_options': '',
+                                 'plot_group':'radar'},
+                        'RETOP': {'fcst_var_names': ['RETOP'],
+                                 'fcst_var_levels': ['L0','Z1000'],
+                                 'fcst_var_thresholds': ('>=20, >=30, >=40,'
+                                                         + ' >=50'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['EchoTop18'],
+                                 'obs_var_levels': ['L0','Z500'],
+                                 'obs_var_thresholds': ('>=20, >=30, >=40,'
+                                                        + ' >=50'),
+                                 'obs_var_options': '',
+                                 'plot_group':'radar'},
+                        'REFD': {'fcst_var_names': ['REFD'],
+                                 'fcst_var_levels': ['L0','Z1000'],
+                                 'fcst_var_thresholds': ('>=20, >=30, >=40,'
+                                                         + ' >=50'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['SeamlessHSR'],
+                                 'obs_var_levels': ['L0','Z500'],
+                                 'obs_var_thresholds': ('>=20, >=30, >=40,'
+                                                        + ' >=50'),
+                                 'obs_var_options': '',
+                                 'plot_group':'radar'}
+                    }
+                }
+            },
+            'grid2obs_upper_air': {
+                'SL1L2': {
+                    'plot_stats_list': ('bias, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'NH', 'SH', 'TRO', 'G236', 'POLAR', 'ARCTIC', 
+                        'NAK', 'SAK',
+                        'G003','NHEM','SHEM','TROPICS','CONUS_East',
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'TMP': {'fcst_var_names': ['TMP'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50',
+                                                    'P10', 'P5', 'P1'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['TMP'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50',
+                                                   'P10', 'P5', 'P1'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'RH': {'fcst_var_names': ['RH'],
+                               'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50',
+                                                   'P10', 'P5', 'P1'],
+                               'fcst_var_thresholds': '',
+                               'fcst_var_options': '',
+                               'obs_var_names': ['RH'],
+                               'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                  'P700', 'P500', 'P400',
+                                                  'P300', 'P250', 'P200',
+                                                  'P150', 'P100', 'P50',
+                                                  'P10', 'P5', 'P1'],
+                               'obs_var_thresholds': '',
+                               'obs_var_options': '',
+                               'plot_group':'sfc_upper'},
+                        'SPFH': {'fcst_var_names': ['SPFH'],
+                                 'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                     'P700', 'P500', 'P400',
+                                                     'P300', 'P250', 'P200',
+                                                     'P150', 'P100', 'P50',
+                                                     'P10', 'P5', 'P1'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['SPFH'],
+                                 'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50',
+                                                    'P10', 'P5', 'P1'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'HGT': {'fcst_var_names': ['HGT'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50',
+                                                    'P10', 'P5', 'P1'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['HGT','ZOB'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50',
+                                                   'P10', 'P5', 'P1'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                    }
+                },
+                'VL1L2': {
+                    'plot_stats_list': ('bias, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'NH', 'SH', 'TRO', 'G236', 'POLAR', 'ARCTIC', 
+                        'NAK', 'SAK', 'Alaska', 'Hawaii', 'PRico'
+                    ],
+                    'var_dict': {
+                        'UGRD_VGRD': {'fcst_var_names': ['UGRD_VGRD'],
+                                      'fcst_var_levels': [
+                                          'P1000', 'P925', 'P850', 'P700', 
+                                          'P500', 'P400','P300', 'P250', 
+                                          'P200', 'P150', 'P100', 'P50', 
+                                          'P10', 'P5', 'P1'
+                                      ],
+                                      'fcst_var_thresholds': '',
+                                      'fcst_var_options': '',
+                                      'obs_var_names': ['UGRD_VGRD'],
+                                      'obs_var_levels': [
+                                          'P1000', 'P925', 'P850', 'P700', 
+                                          'P500', 'P400', 'P300', 'P250', 
+                                          'P200', 'P150', 'P100', 'P50', 
+                                          'P10', 'P5', 'P1'
+                                      ],
+                                      'obs_var_thresholds': '',
+                                      'obs_var_options': '',
+                                      'plot_group':'sfc_upper'},
+                    }
+                },
+                'ECNT':{
+                    'plot_stats_list': ('crps, crpss, rmse, spread, me, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'G003','NHEM','SHEM','TROPICS','CONUS', 'CONUS_East',
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska',
+                        'Hawaii', 'PRico'
+                    ],
+                    'var_dict': {
+                        'HGT': {'fcst_var_names': ['HGT'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['HGT'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'TMP': {'fcst_var_names': ['TMP'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['TMP'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['UGRD'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['VGRD'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'RH': {'fcst_var_names': ['RH'],
+                                'fcst_var_levels': ['P1000', 'P925', 'P850',
+                                                    'P700', 'P500', 'P400',
+                                                    'P300', 'P250', 'P200',
+                                                    'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['RH'],
+                                'obs_var_levels': ['P1000', 'P925', 'P850',
+                                                   'P700', 'P500', 'P400',
+                                                   'P300', 'P250', 'P200',
+                                                   'P150', 'P100', 'P50', 'P10'
+                                ],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'}
+                    }
+                },
+                'PSTD': {
+                    'plot_stats_list': ('bs,bss,bss_smpl'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West',
+                        'CONUS_Central', 'CONUS_South', 'Alaska',
+                        'Hawaii', 'PRico'
+                    ],
+                    'var_dict': {
+                        'TMP_lt0C': {'fcst_var_names': ['TMP_ENS_FREQ_lt273.15'],
+                                    'fcst_var_levels': ['P850', 'P700', 'P500'],
+                                    'fcst_var_thresholds': ['==0.10000', '==273.15'],
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['TMP'],
+                                    'obs_var_levels': ['P850','P700','P500'],
+                                    'obs_var_thresholds': '<273.15',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'WIND_ge30kt': {'fcst_var_names': ['WIND_ENS_FREQ_ge15.4'],
+                                    'fcst_var_levels': ['P850', 'P700', 'P500'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['WIND'],
+                                    'obs_var_levels': ['P850','P700','P500'],
+                                    'obs_var_thresholds': '>=15.4',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'WIND_ge40kt': {'fcst_var_names': ['WIND_ENS_FREQ_ge20.58'],
+                                    'fcst_var_levels': ['P850', 'P700', 'P500'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['WIND'],
+                                    'obs_var_levels': ['P850', 'P700', 'P500'],
+                                    'obs_var_thresholds': '>=20.58',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'}
+                    }
+                }        
+            },
+            'grid2obs_raob': {
+                'SL1L2': {
+                    'plot_stats_list': ('bcrmse, bias, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'HGT': {'fcst_var_names': ['HGT'],
+                                'fcst_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['HGT'],
+                                'obs_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'TMP': {'fcst_var_names': ['TMP'],
+                                'fcst_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['TMP'],
+                                'obs_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'UGRD': {'fcst_var_names': ['UGRD'],
+                                'fcst_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['UGRD'],
+                                'obs_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'VGRD': {'fcst_var_names': ['VGRD'],
+                                'fcst_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['VGRD'],
+                                'obs_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                    'P900', 'P875', 'P850', 'P825',
+                                                    'P800', 'P775', 'P750', 'P725',
+                                                    'P700', 'P675', 'P650', 'P625',
+                                                    'P600', 'P575', 'P550', 'P525',
+                                                    'P500', 'P475', 'P450', 'P425',
+                                                    'P400', 'P375', 'P350', 'P325',
+                                                    'P300', 'P275', 'P250', 'P225',
+                                                    'P200', 'P175', 'P150', 'P125',
+                                                    'P100', 'P75', 'P50', 'P30',
+                                                    'P20', 'P10'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'SPFH': {'fcst_var_names': ['SPFH'],
+                                 'fcst_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                     'P900', 'P875', 'P850', 'P825',
+                                                     'P800', 'P775', 'P750', 'P725',
+                                                     'P700', 'P675', 'P650', 'P625',
+                                                     'P600', 'P575', 'P550', 'P525',
+                                                     'P500', 'P475', 'P450', 'P425',
+                                                     'P400', 'P375', 'P350', 'P325',
+                                                     'P300', 'P275', 'P250', 'P225',
+                                                     'P200', 'P175', 'P150', 'P125',
+                                                     'P100', 'P75', 'P50', 'P30',
+                                                     'P20', 'P10'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['SPFH'],
+                                 'obs_var_levels': ['P1000', 'P975', 'P950', 'P925',
+                                                     'P900', 'P875', 'P850', 'P825',
+                                                     'P800', 'P775', 'P750', 'P725',
+                                                     'P700', 'P675', 'P650', 'P625',
+                                                     'P600', 'P575', 'P550', 'P525',
+                                                     'P500', 'P475', 'P450', 'P425',
+                                                     'P400', 'P375', 'P350', 'P325',
+                                                     'P300', 'P275', 'P250', 'P225',
+                                                     'P200', 'P175', 'P150', 'P125',
+                                                     'P100', 'P75', 'P50', 'P30',
+                                                     'P20', 'P10'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'SBCAPE': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['CAPE'],
+                                    'obs_var_levels': ['L100000-0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                        'MLCAPE': {'fcst_var_names': ['CAPE', 'MLCAPE'],
+                                    'fcst_var_levels': ['P90-0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['MLCAPE'],
+                                    'obs_var_levels': ['L90000-0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                        'HPBL': {'fcst_var_names': ['HGT','HPBL'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['HPBL'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                    }
+                },
+                'VL1L2': {
+                    'plot_stats_list': ('bias, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'UGRD_VGRD': {'fcst_var_names': ['UGRD_VGRD'],
+                                      'fcst_var_levels': [
+                                          'P1000', 'P975', 'P950', 'P925',
+                                          'P900', 'P875', 'P850', 'P825',
+                                          'P800', 'P775', 'P750', 'P725',
+                                          'P700', 'P675', 'P650', 'P625',
+                                          'P600', 'P575', 'P550', 'P525',
+                                          'P500', 'P475', 'P450', 'P425',
+                                          'P400', 'P375', 'P350', 'P325',
+                                          'P300', 'P275', 'P250', 'P225',
+                                          'P200', 'P175', 'P150', 'P125',
+                                          'P100', 'P75', 'P50', 'P30',
+                                          'P20', 'P10'
+                                      ],
+                                      'fcst_var_thresholds': '',
+                                      'fcst_var_options': '',
+                                      'obs_var_names': ['UGRD_VGRD'],
+                                      'obs_var_levels': [
+                                          'P1000', 'P975', 'P950', 'P925',
+                                          'P900', 'P875', 'P850', 'P825',
+                                          'P800', 'P775', 'P750', 'P725',
+                                          'P700', 'P675', 'P650', 'P625',
+                                          'P600', 'P575', 'P550', 'P525',
+                                          'P500', 'P475', 'P450', 'P425',
+                                          'P400', 'P375', 'P350', 'P325',
+                                          'P300', 'P275', 'P250', 'P225',
+                                          'P200', 'P175', 'P150', 'P125',
+                                          'P100', 'P75', 'P50', 'P30',
+                                          'P20', 'P10'
+                                      ],
+                                      'obs_var_thresholds': '',
+                                      'obs_var_options': '',
+                                      'plot_group':'sfc_upper'}
+                    }
+                },
+                'CTC': {
+                    'plot_stats_list': ('csi, fbias, pod,'
+                                        + ' faratio, sratio'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'SBCAPE': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': ('>=250, >=500, >=1000,'
+                                                            + ' >=1500, >=2000,'
+                                                            + ' >=3000,'
+                                                            + ' >=4000'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['CAPE'],
+                                    'obs_var_levels': ['L100000-0'],
+                                    'obs_var_thresholds': ('>=250, >=500, >=1000,'
+                                                          + ' >=1500, >=2000,'
+                                                          + ' >=3000,'
+                                                          + ' >=4000'),
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                        'MLCAPE': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['P90-0'],
+                                    'fcst_var_thresholds': ('>=250, >=500, >=1000,'
+                                                            + ' >=1500, >=2000,'
+                                                            + ' >=3000,'
+                                                            + ' >=4000'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['MLCAPE'],
+                                    'obs_var_levels': ['L90000-0'],
+                                    'obs_var_thresholds': ('>=250, >=500, >=1000,'
+                                                          + ' >=1500, >=2000,'
+                                                          + ' >=3000,'
+                                                          + ' >=4000'),
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                        'HPBL': {'fcst_var_names': ['HGT','HPBL'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '<=500, >=2000',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['HPBL'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '<=500, >=2000',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                    }
+                }
+            },
+            'grid2obs_metar': {
+                'SL1L2': {
+                    'plot_stats_list': ('bcrmse, bias'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '>=277.594,>=283.15,>=288.706,>=294.261',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'RH2m': {'fcst_var_names': ['RH'],
+                                 'fcst_var_levels': ['Z2'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['RH'],
+                                 'obs_var_levels': ['Z2'],
+                                 'obs_var_thresholds': '<=15,<=20,<=25,<=30',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'MSLP': {'fcst_var_names': ['MSLET','MSLMA'],
+                                  'fcst_var_levels': ['Z0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL'],
+                                  'obs_var_levels': ['Z0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'UGRD10m': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD10m': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'WIND10m': {'fcst_var_names': ['WIND'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['WIND'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'GUSTsfc': {'fcst_var_names': ['GUST'],
+                                    'fcst_var_levels': ['Z0','L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['GUST','L0'],
+                                    'obs_var_levels': ['Z0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                    }
+                },
+                'VL1L2': {
+                    'plot_stats_list': ('bcrmse, bias'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'UGRD_VGRD10m': {'fcst_var_names': ['UGRD_VGRD'],
+                                         'fcst_var_levels': ['Z10'],
+                                         'fcst_var_thresholds': '',
+                                         'fcst_var_options': '',
+                                         'obs_var_names': ['UGRD_VGRD'],
+                                         'obs_var_levels': ['Z10'],
+                                         'obs_var_thresholds': '',
+                                         'obs_var_options': '',
+                                         'plot_group':'sfc_upper'},
+                    }
+                },
+                'CTC': {
+                    'plot_stats_list': ('csi, ets, fbias, pod,'
+                                        + ' faratio, sratio'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': (' >=277.594, >=283.15,'
+                                                          + ' >=288.706, >=294.261'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': (' >=277.594, >=283.15,'
+                                                         + ' >=288.706, >=294.261'),
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'RH2m': {'fcst_var_names': ['RH'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': (' <=15, >=15, <=20, >=20, '
+                                                          + ' <=25, >=25, <=30, >=30'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['RH'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': (' <=15, >=15, <=20, >=20, '
+                                                         + ' <=25, >=25, <=30, >=30'),
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'VIS': {'fcst_var_names': ['VIS'],
+                                   'fcst_var_levels': ['Z0'],
+                                   'fcst_var_thresholds': ('<=805, <=1609,'
+                                                           + ' <=4828, <=8045,'
+                                                           + ' >=8045,'
+                                                           + ' <=16090'),
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['VIS'],
+                                   'obs_var_levels': ['Z0'],
+                                   'obs_var_thresholds': ('<=805, <=1609,'
+                                                          + ' <=4828, <=8045,'
+                                                          + ' >=8045,'
+                                                          + ' <=16090'),
+                                   'obs_var_options': '',
+                                   'plot_group':'ceil_vis'},
+                        'CEILING': {'fcst_var_names': ['HGT'],
+                                       'fcst_var_levels': ['L0','CEILING'],
+                                       'fcst_var_thresholds': ('<=152,'
+                                                               + ' <=305,'
+                                                               + ' >=914, <=914,'
+                                                               + ' <=1524, '
+                                                               + ' <=3048'),
+                                       'fcst_var_options': ('GRIB_lvl_typ ='
+                                                            + ' 215;'),
+                                       'obs_var_names': ['CEILING','HGT'],
+                                       'obs_var_levels': ['L0'],
+                                       'obs_var_thresholds': ('<=152,'
+                                                              + ' <=305,'
+                                                              + ' >=914, <=914,'
+                                                              + ' <=1524, '
+                                                              + ' <=3048'),
+                                       'obs_var_options': '',
+                                       'plot_group':'ceil_vis'},
+                        'TCDC': {'fcst_var_names': ['TCDC'],
+                                 'fcst_var_levels': ['L0','TOTAL'],
+                                 'fcst_var_thresholds': '<10, >10, >50, >90',
+                                 'fcst_var_options': 'GRIB_lvl_typ = 200;',
+                                 'obs_var_names': ['TCDC'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '<10, >10, >50, >90',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                    }
+                },
+                'CNT': {
+                    'plot_stats_list': ('fss'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes',
+                        'Mezquital', 'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies',
+                        'PacificNW', 'Prairie', 'Southeast', 'SPlains', 'SRockies',
+                        'Alaska', 'Hawaii', 'PuertoRico', 'Guam', 'FireWx', 'DAY1_1200_TSTM',
+                        'DAY1_0100_TSTM'
+                    ],
+                    'var_dict': {
+                        'TCDC': {'fcst_var_names': ['TCDC'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['TCDC'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                    }
+                },
+            },
+            'grid2obs_conus_sfc': {
+                'SL1L2': {
+                    'plot_stats_list': ('bias, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GMC', 'APL', 'NAK', 'SAK', 
+                        'G003', 'NHEM', 'SHEM', 'TROPICS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska' 
+                    ],
+                    'var_dict': {
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'RH2m': {'fcst_var_names': ['RH'],
+                                 'fcst_var_levels': ['Z2'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['RH'],
+                                 'obs_var_levels': ['Z2'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'TCDC': {'fcst_var_names': ['TCDC'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': 'GRIB_lvl_typ = 200;',
+                                 'obs_var_names': ['TCDC'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'PRMSL': {'fcst_var_names': ['PRMSL','MSLET'],
+                                  'fcst_var_levels': ['Z0','L0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL'],
+                                  'obs_var_levels': ['Z0','L0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'VISsfc': {'fcst_var_names': ['VIS'],
+                                   'fcst_var_levels': ['L0'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['VIS'],
+                                   'obs_var_levels': ['L0'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'sfc_upper'},
+                        'HGTcldceil': {'fcst_var_names': ['HGT','HGTcldceil'],
+                                       'fcst_var_levels': ['L0'],
+                                       'fcst_var_thresholds': '',
+                                       'fcst_var_options': ('GRIB_lvl_typ ='
+                                                            + ' 215;'),
+                                       'obs_var_names': ['CEILING','HGT','HGTcldceil'],
+                                       'obs_var_levels': ['L0'],
+                                       'obs_var_thresholds': '',
+                                       'obs_var_options': '',
+                                       'plot_group':'sfc_upper'},
+                        'CAPEsfc': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['CAPE'],
+                                    'obs_var_levels': ['L100000-0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                        'GUSTsfc': {'fcst_var_names': ['GUST'],
+                                    'fcst_var_levels': ['Z0','L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['GUST'],
+                                    'obs_var_levels': ['Z0','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'WIND10m': {'fcst_var_names': ['WIND'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['WIND'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'HPBL': {'fcst_var_names': ['HPBL'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['HPBL'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'UGRD10m': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD10m': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                    }
+                },
+                'VL1L2': {
+                    'plot_stats_list': ('bias, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GMC', 'APL', 'NAK', 'SAK',
+                        'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes', 'Mezquital',
+                        'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies', 'PacificNW', 'PacificSW',
+                        'Prairie', 'Southeast', 'Southwest', 'SPlains', 'SRockies'
+                    ],
+                    'var_dict': {
+                        'UGRD_VGRD10m': {'fcst_var_names': ['UGRD_VGRD'],
+                                         'fcst_var_levels': ['Z10'],
+                                         'fcst_var_thresholds': '',
+                                         'fcst_var_options': '',
+                                         'obs_var_names': ['UGRD_VGRD'],
+                                         'obs_var_levels': ['Z10'],
+                                         'obs_var_thresholds': '',
+                                         'obs_var_options': '',
+                                         'plot_group':'sfc_upper'},
+                    }
+                },
+                'CTC': {
+                    'plot_stats_list': ('ets, csi, fbias, fss, pod,'
+                                        + ' faratio, sratio'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'G221', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GMC', 'APL', 'NAK', 'SAK',
+                        'G003', 'NHEM', 'SHEM', 'TROPICS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes', 'Mezquital', 'MidAtlantic', 'NorthAtlantic', 
+                        'NPlains', 'NRockies', 'PacificNW', 'PacificSW', 'Prairie', 'Southeast', 'Southwest', 'SPlains', 'SRockies',
+                        'DAY1_MRGL', 'DAY2_MRGL', 'DAY3_MRGL', 
+                        'DAY1_TSTM', 'DAY2_TSTM', 'DAY3_TSTM', 
+                        'DAY1_SLGT', 'DAY2_SLGT', 'DAY3_SLGT', 
+                        'DAY1_ENH',  'DAY2_ENH',  'DAY3_ENH', 
+                        'DAY1_MDT',  'DAY2_MDT',  'DAY3_MDT', 
+                        'DAY1_HIGH', 'DAY2_HIGH', 'DAY3_HIGH'
+                    ],
+                    'var_dict': {
+                         'RH2m': {'fcst_var_names': ['RH'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': (' <=15, <=20,'
+                                                          + ' <=25, <=30'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['RH'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': (' <=15, <=20,'
+                                                         + ' <=25, <=30'),
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                         'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': (' >=4.4, >=10,'
+                                                          + ' >=15.55, >=21.11,'
+                                                          + ' >=277.59, >=283.15, >=288.71, >=294.26'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TDO', 'DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': (' >=4.4, >=10,'
+                                                         + ' >=15.55, >=21.11'
+                                                         + ' >=277.59, >=283.15, >=288.71, >=294.26'),
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'VISsfc': {'fcst_var_names': ['VIS'],
+                                   'fcst_var_levels': ['L0'],
+                                   'fcst_var_thresholds': ('<=800, <805, <=1600, <1609,'
+                                                           + ' <=4800, <4828, <=8000, <8045,'
+                                                           + ' >=8045,'
+                                                           + ' <=16000, <16090'),
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['VIS'],
+                                   'obs_var_levels': ['L0'],
+                                   'obs_var_thresholds': ('<=800, <805, <=1600, <1609,'
+                                                          + ' <=4800, <4828, <=8000, <8045,'
+                                                          + ' >=8045,'
+                                                          + ' <=16000, <16090'),
+                                   'obs_var_options': '',
+                                   'plot_group':'sfc_upper'},
+                        'HGTcldceil': {'fcst_var_names': ['HGT','HGTcldceil'],
+                                       'fcst_var_levels': ['L0'],
+                                       'fcst_var_thresholds': ('<152, <=152, <305,'
+                                                               + ' <=305, <914,'
+                                                               + ' >=914, <=916,'
+                                                               + ' <1524, <=1524, '
+                                                               + ' <3048, <=3048'),
+                                       'fcst_var_options': ('GRIB_lvl_typ ='
+                                                            + ' 215;'),
+                                       'obs_var_names': ['CEILING','HGT','HGTcldceil'],
+                                       'obs_var_levels': ['L0'],
+                                       'obs_var_thresholds': ('<152, <=152, <305,'
+                                                              + ' <=305, <914, '
+                                                              + '>=914, <=916, '
+                                                              + '<1524, <=1524, '
+                                                              + '<3048, <=3048'),
+                                       'obs_var_options': '',
+                                       'plot_group':'sfc_upper'},
+                        'CAPEsfc': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': ('>=250, >500, >=500, >1000, >=1000,'
+                                                            + ' >1500, >2000, >=2000,'
+                                                            + ' >3000,'
+                                                            + ' >4000'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['CAPE'],
+                                    'obs_var_levels': ['L100000-0','L0'],
+                                    'obs_var_thresholds': ('>=250, >500, >=500, >1000, >=1000,'
+                                                           + ' >1500, >2000, >=2000,'
+                                                           + ' >3000,'
+                                                           + ' >4000'),
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'MLCAPE': {'fcst_var_names': ['CAPE', 'MLCAPE'],
+                                    'fcst_var_levels': ['P90-0','ML'],
+                                    'fcst_var_thresholds': '>=250, >=500, >=1000, >=2000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['MLCAPE'],
+                                    'obs_var_levels': ['L90000-0','L100000-0','ML'],
+                                    'obs_var_thresholds': '>=250, >=500, >=1000, >=2000',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'TCDC': {'fcst_var_names': ['TCDC'],
+                                 'fcst_var_levels': ['L0','TOTAL'],
+                                 'fcst_var_thresholds': ('<10, >=10, >=20, >=30, >=40, >=50,'
+                                                         + ' >=60, >=70, >=80, >=90'),
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['TCDC'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': ('<10, >=10, >=20, >=30, >=40, >=50,'
+                                                        + ' >=60, >=70, >=80, >=90'),
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                    }
+                },
+                #Added for Global_ens,  Binbin Zhou
+                'SAL1L2': {
+                    'plot_stats_list': 'acc',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'G003','NHEM','SHEM','TROPICS','CONUS', 'CONUS_East', 
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'PRMSL': {'fcst_var_names': ['PRMSL','MSLET'],
+                                  'fcst_var_levels': ['Z0','L0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL','MSL'],
+                                  'obs_var_levels': ['Z0','L0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'UGRD10m': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD10m': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                    }
+                },
+                #Added for ensemble,  Binbin Zhou
+                'ECNT':{
+                    'plot_stats_list': ('crps, crpss, rmse, spread, me, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'G003','NHEM','SHEM','TROPICS','CONUS', 'CONUS_East',
+                        'CONUS_West', 'CONUS_Central', 'CONUS_South', 'Alaska',
+                        'Appalachia', 'CPlains', 'DeepSouth', 'GreatBasin', 'GreatLakes', 'Mezquital', 
+                        'MidAtlantic', 'NorthAtlantic', 'NPlains', 'NRockies', 'PacificNW', 'PacificSW', 
+                        'Prairie', 'Southeast', 'Southwest', 'SPlains', 'SRockies'
+                    ],
+                    'var_dict': {
+                        'PRMSL': {'fcst_var_names': ['PRMSL','MSLET'],
+                                  'fcst_var_levels': ['Z0','L0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL','MSL'],
+                                  'obs_var_levels': ['Z0','L0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'RH2m': {'fcst_var_names': ['RH'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['RH'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'GUSTsfc': {'fcst_var_names': ['GUST'],
+                                    'fcst_var_levels': ['Z0','L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['GUST'],
+                                    'obs_var_levels': ['Z0','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'HPBL': {'fcst_var_names': ['HPBL'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['PBL'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'WIND10m': {'fcst_var_names': ['WIND'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['WIND'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'UGRD10m': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD10m': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'}
+                    }
+                }
+            },
+            'grid2obs_aq': {
+                'CTC': {
+                    'plot_stats_list': ('csi, fbias, fss, pod,'
+                                        + ' faratio, sratio'),
+                    'interp': 'BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GMC', 'APL', 'NAK', 'SAK'
+                    ],
+                    'var_dict': {
+                        'OZCON1': {'fcst_var_names': ['OZCON1'],
+                                  'fcst_var_levels': ['A1'],
+                                  'fcst_var_thresholds': ('>50, >60, >65, >70,'
+                                                          + '>75, >85, >105,'
+                                                          + '>125, >150'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['COPO'],
+                                  'obs_var_levels': ['A1'],
+                                  'obs_var_thresholds': ('>50, >60, >65, >70,'
+                                                         + '>75, >85, >105,'
+                                                         + '>125, >150'),
+                                  'obs_var_options': '',
+                                  'plot_group':'aq'},
+                        'OZCON8': {'fcst_var_names': ['OZCON8'],
+                                  'fcst_var_levels': ['A8'],
+                                  'fcst_var_thresholds': ('>50, >60, >65, >70,'
+                                                          + '>75, >85, >105,'
+                                                          + '>125, >150'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['COPO'],
+                                  'obs_var_levels': ['A8'],
+                                  'obs_var_thresholds': ('>50, >60, >65, >70,'
+                                                         + '>75, >85, >105,'
+                                                         + '>125, >150'),
+                                  'obs_var_options': '',
+                                  'plot_group':'aq'},
+                    }
+                }
+            },
+            'grid2obs_polar_sfc': {
+                'SL1L2': {
+                    'plot_stats_list': 'bias, rmse, fbar_obar',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : ['ARCTIC'],
+                    'var_dict': {
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'TMPsfc': {'fcst_var_names': ['TMP'],
+                                   'fcst_var_levels': ['Z0'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['TMP'],
+                                   'obs_var_levels': ['Z0'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'sfc_upper'},
+                        'PRESsfc': {'fcst_var_names': ['PRES'],
+                                    'fcst_var_levels': ['Z0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['PRES'],
+                                    'obs_var_levels': ['Z0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'}
+                    }
+                }
+            },
+            'grid2grid_rtofs_sfc': {
+                'SL1L2': {
+                    'plot_stats_list': 'bias, rmse, fbar_obar, estdev',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'Global','North_Atlantic','South_Atlantic','Equatorial_Atlantic',
+                        'North_Pacific','South_Pacific','Equatorial_Pacific','Indian',
+                        'Southern','Arctic','Mediterranean','Antarctic'
+                    ],
+                    'var_dict': {
+                        'SST': {'fcst_var_names': ['sst'],
+                                  'fcst_var_levels': ['0,*,*'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['analysed_sst'],
+                                  'obs_var_levels': ['0,*,*'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'rtofs_sfc'},
+                        'SSS': {'fcst_var_names': ['sss'],
+                                  'fcst_var_levels': ['0,*,*'],
+                                  'fcst_var_thresholds':'',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['sss'],
+                                  'obs_var_levels': ['0,0,*,*'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group': 'rtofs_sfc'},
+                        'SSH': {'fcst_var_names': ['ssh'],
+                                   'fcst_var_levels': ['0,*,*'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['adt'],
+                                   'obs_var_levels': ['0,*,*'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'rtofs_sfc'},
+                        'SIC': {'fcst_var_names': ['ice_coverage'],
+                                    'fcst_var_levels': ['0,*,*'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ice_conc'],
+                                    'obs_var_levels': ['0,*,*'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'rtofs_sfc'}
+                    }
+                },
+                'SAL1L2': {
+                    'plot_stats_list': 'acc',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'Global','North_Atlantic','South_Atlantic','Equatorial_Atlantic',
+                        'North_Pacific','South_Pacific','Equatorial_Pacific','Indian',
+                        'Southern','Arctic','Mediterranean'
+                    ],
+                    'var_dict': {
+                        'SST': {'fcst_var_names': ['sst'],
+                                  'fcst_var_levels': ['0,*,*'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['analysed_sst'],
+                                  'obs_var_levels': ['0,*,*'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'rtofs_sfc'},
+                        'SSS': {'fcst_var_names': ['sss'],
+                                  'fcst_var_levels': ['0,*,*'],
+                                  'fcst_var_thresholds':'',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['sss'],
+                                  'obs_var_levels': ['0,0,*,*'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group': 'rtofs_sfc'},
+                        'SSH': {'fcst_var_names': ['ssh'],
+                                   'fcst_var_levels': ['0,*,*'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['adt'],
+                                   'obs_var_levels': ['0,*,*'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'rtofs_sfc'},
+                        'SIC': {'fcst_var_names': ['ice_coverage'],
+                                    'fcst_var_levels': ['0,*,*'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ice_conc'],
+                                    'obs_var_levels': ['0,*,*'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'rtofs_sfc'}
+                    }
+                },
+                'CTC': {
+                    'plot_stats_list': 'sratio, pod, csi, hss',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'Global','North_Atlantic','South_Atlantic','Equatorial_Atlantic',
+                        'North_Pacific','South_Pacific','Equatorial_Pacific','Indian',
+                        'Southern','Arctic','Mediterranean','Antarctic'
+                    ],
+                    'var_dict': {
+                        'SST': {'fcst_var_names': ['sst'],
+                                  'fcst_var_levels': ['0,*,*'],
+                                  'fcst_var_thresholds': '>=0, >=26.5',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['analysed_sst'],
+                                  'obs_var_levels': ['0,*,*'],
+                                  'obs_var_thresholds': '>=0, >=26.5',
+                                  'obs_var_options': '',
+                                  'plot_group':'rtofs_sfc'},
+                        'SIC': {'fcst_var_names': ['ice_coverage'],
+                                    'fcst_var_levels': ['0,*,*'],
+                                    'fcst_var_thresholds': '>=15, >=40, >=80',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ice_conc'],
+                                    'obs_var_levels': ['0,*,*'],
+                                    'obs_var_thresholds': '>=15, >=40, >=80',
+                                    'obs_var_options': '',
+                                    'plot_group':'rtofs_sfc'}
+                    }
+                }
+            },
+            'precip_ccpa': {
+                'SL1L2': {
+                    'plot_stats_list': ('bias, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 
+                        'CONUS_South', 'Alaska', 'G130', 'G214', 'WEST', 'EAST', 
+                        'MDW', 'NPL', 'SPL', 'NEC', 'SEC', 'NWC', 'SWC', 'NMT', 
+                        'SMT', 'SWD', 'GRB', 'LMV', 'GMC', 'APL', 'NAK', 'SAK'
+                    ],
+                    'var_dict': {
+                        'APCP_01': {'fcst_var_names': ['APCP', 'APCP_01'],
+                                    'fcst_var_levels': ['A01','A1'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_01', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A01','A1','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_03': {'fcst_var_names': ['APCP', 'APCP_03'],
+                                    'fcst_var_levels': ['A03','A3'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_03', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A03','A3','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_06': {'fcst_var_names': ['APCP', 'APCP_06'],
+                                    'fcst_var_levels': ['A06','A6'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_06', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A06','A6','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_24': {'fcst_var_names': ['APCP', 'APCP_24'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_24', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A24','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'}
+                    }
+                },
+                'NBRCNT': {
+                    'plot_stats_list': ('fss, afss, ufss'),
+                    'interp': 'NEAREST, NBRHD_SQUARE, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central',
+                        'CONUS_South', 'Alaska', 'G130', 'G214', 'WEST', 'EAST',
+                        'MDW', 'NPL', 'SPL', 'NEC', 'SEC', 'NWC', 'SWC', 'NMT',
+                        'SMT', 'SWD', 'GRB', 'LMV', 'GMC', 'APL', 'NAK', 'SAK'
+                    ],
+                    'var_dict': {
+                        'APCP_01': {'fcst_var_names': ['APCP', 'APCP_01'],
+                                    'fcst_var_levels': ['A01','A1'],
+                                    'fcst_var_thresholds': '>=0.254, >=2.54, >=6.35, >=12.7, >=25.4',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_01', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A01','A1','L0'],
+                                    'obs_var_thresholds': '>=0.254, >=2.54, >=6.35, >=12.7, >=25.4',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_03': {'fcst_var_names': ['APCP', 'APCP_03'],
+                                    'fcst_var_levels': ['A03','A3'],
+                                    'fcst_var_thresholds': '>=2.54, >=6.35, >=12.7, >=25.4, >=50.8',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_03', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A03','A3','L0'],
+                                    'obs_var_thresholds': '>=2.54, >=6.35, >=12.7, >=25.4, >=50.8',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_06': {'fcst_var_names': ['APCP', 'APCP_06'],
+                                    'fcst_var_levels': ['A06','A6'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_06', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A06','A6','L0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_24': {'fcst_var_names': ['APCP', 'APCP_24'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '>1, >2, >5, >10, >20, >25, >35, >50, >75, >=12.7, >=25.4, >=50.8, >=76.2',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_24', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A24','L0'],
+                                    'obs_var_thresholds': '>1, >2, >5, >10, >20, >25, >35, >50, >75, >=12.7, >=25.4, >=50.8, >=76.2',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                          'WEASD': {'fcst_var_names': ['WEASD_L0','WEASD'],
+                                    'fcst_var_levels': ['L0','A06','A24'],
+                                    'fcst_var_thresholds': '>=0.0254, >=0.1016, >=0.2032, >=0.3048',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A06','A24'],
+                                    'obs_var_thresholds': '>=0.0254, >=0.1016, >=0.2032, >=0.3048',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'SNOD_24': {'fcst_var_names': ['SNOD_L0'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '>0.0254, >0.1016, >0.2032, >0.3048',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>0.0254, >0.1016, >0.2032, >0.3048',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'}
+                    }
+                },
+                'CTC': {
+                    'plot_stats_list': ('bias, ets, fss, csi, fbias, fbar,'
+                                        + ' obar, pod, faratio, farate, sratio'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'CONUS_East', 'CONUS_West', 'CONUS_Central', 
+                        'CONUS_South', 'Alaska', 'G130', 'G214', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GMC', 'APL', 'NAK', 'SAK'
+                    ],
+                    'var_dict': {
+                        'APCP_01': {'fcst_var_names': ['APCP_01'],
+                                    'fcst_var_levels': ['A01','A1'],
+                                    'fcst_var_thresholds': ('>=0.254, >=1.27,'
+                                                            + ' >=2.54,'
+                                                            + ' >=6.35,'
+                                                            + ' >=12.7,'
+                                                            + ' >=19.05,'
+                                                            + ' >=25.4,'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_01', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A01','A1','L0'],
+                                    'obs_var_thresholds': ('>=0.254, >=1.27,'
+                                                           + ' >=2.54,'
+                                                           + ' >=6.35,'
+                                                           + ' >=12.7,'
+                                                           + ' >=19.05,'
+                                                           + ' >=25.4,'),
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_03': {'fcst_var_names': ['APCP_03'],
+                                    'fcst_var_levels': ['A03','A3'],
+                                    'fcst_var_thresholds': ('>=0.254, >=1.27,'
+                                                            + ' >=2.54,'
+                                                            + ' >=6.35,'
+                                                            + ' >=12.7,'
+                                                            + ' >=19.05,'
+                                                            + ' >=25.4,'
+                                                            + ' >=50.8,'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_03', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A03','A3','L0'],
+                                    'obs_var_thresholds': ('>=0.254, >=1.27,'
+                                                           + ' >=2.54,'
+                                                           + ' >=6.35,'
+                                                           + ' >=12.7,'
+                                                           + ' >=19.05,'
+                                                           + ' >=25.4,'
+                                                           + ' >=50.8,'),
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_06': {'fcst_var_names': ['APCP', 'APCP_06'],
+                                    'fcst_var_levels': ['A06','A6'],
+                                    'fcst_var_thresholds': ('>=0.254, >=2.54,'
+                                                            + ' >=6.35,'
+                                                            + ' >=12.7,'
+                                                            + ' >=19.05,'
+                                                            + ' >=25.4,'
+                                                            + ' >=38.1,'
+                                                            + ' >=50.8,'
+                                                            + ' >=76.2,'
+                                                            + ' >=101.6'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_06', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A06','A6','L0'],
+                                    'obs_var_thresholds': ('>=0.254, >=2.54,'
+                                                           + ' >=6.35,'
+                                                           + ' >=12.7,'
+                                                           + ' >=19.05,'
+                                                           + ' >=25.4,'
+                                                           + ' >=38.1,'
+                                                           + ' >=50.8,'
+                                                           + ' >=76.2,'
+                                                           + ' >=101.6'),
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_24': {'fcst_var_names': ['APCP', 'APCP_24'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': ('>=0.254, >=2.54,>1,>2,>5,>10,>20,>25,>50,>75'
+                                                            + ' >=6.35,'
+                                                            + ' >=12.7,'
+                                                            + ' >=25.4,'
+                                                            + ' >=38.1,'
+                                                            + ' >=50.8,'
+                                                            + ' >=76.2,'
+                                                            + ' >=101.6'
+                                                            + ' >=152.4'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_24', 'APCP_01_Z0'],
+                                    'obs_var_levels': ['A24','L0'],
+                                    'obs_var_thresholds': ('>=0.254, >=2.54,>1,>2,>5,>10,>20,>25,>50,>75'
+                                                           + ' >=6.35,'
+                                                           + ' >=12.7,'
+                                                           + ' >=25.4,'
+                                                           + ' >=38.1,'
+                                                           + ' >=50.8,'
+                                                           + ' >=76.2,'
+                                                           + ' >=101.6'
+                                                           + ' >=152.4'),
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'WEASD_24': {'fcst_var_names': ['WEASD_L0'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '>0.0254, >0.1016, >0.2032, >0.3048',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>0.0254, >0.1016, >0.2032, >0.3048',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        
+                        'WEASD':   {'fcst_var_names': ['WEASD'],
+                                    'fcst_var_levels': ['A24','A06'],
+                                    'fcst_var_thresholds': '>=0.0254, >=0.1016, >=0.2032, >=0.3048',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A24','A06'],
+                                    'obs_var_thresholds': '>=0.0254, >=0.1016, >=0.2032, >=0.3048',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'SNOD_24': {'fcst_var_names': ['SNOD_L0'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '>0.0254, >0.1016, >0.2032, >0.3048',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>0.0254, >0.1016, >0.2032, >0.3048',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'}
+                    }
+                },
+               #Added for ensemble: Binbin Zhou
+                'ECNT': {
+                    'plot_stats_list': ('crps, crpss, rmse, spread, me, mae'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [ 
+                        'CONUS', 'CONUS_East', 'CONUS_West',
+                        'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'APCP_06': {'fcst_var_names': ['APCP', 'APCP_06'],
+                                    'fcst_var_levels': ['A06','A6'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_06'],
+                                    'obs_var_levels': ['A06','A6'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP_24': {'fcst_var_names': ['APCP', 'APCP_24'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP', 'APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'WEASD_24': {'fcst_var_names': ['WEASD_L0'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'SNOD_24': {'fcst_var_names': ['SNOD_L0'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['ASNOW'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'}
+                    }
+                },
+                #added for ensemble Binbin Zhou
+                'PSTD': {
+                    'plot_stats_list': ('bs'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [ 
+                        'CONUS', 'CONUS_East', 'CONUS_West',
+                        'CONUS_Central', 'CONUS_South', 'Alaska'
+                    ],
+                    'var_dict': {
+                        'APCP24_gt1': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt1'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>1',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP24_gt2': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt2'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>2',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP24_gt5': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt5'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>5',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP24_gt10': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt10'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>10',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP24_gt20': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt20'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>20',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP24_gt25': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt25'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>25',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'},
+                        'APCP24_gt50': {'fcst_var_names': ['APCP_24_ENS_FREQ_gt50'],
+                                    'fcst_var_levels': ['A24'],
+                                    'fcst_var_thresholds': '==0.10000',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['APCP_24'],
+                                    'obs_var_levels': ['A24'],
+                                    'obs_var_thresholds': '>50',
+                                    'obs_var_options': '',
+                                    'plot_group':'precip'}
+                    }
+                }
+            },
+            'satellite_ghrsst_ncei_avhrr_anl': {
+                'SL1L2': {
+                    'plot_stats_list': 'bias, rmse',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'NH', 'SH', 'POLAR', 'ARCTIC', 'SEA_ICE', 
+                        'SEA_ICE_FREE', 'SEA_ICE_POLAR', 'SEA_ICE_FREE_POLAR'
+                    ],
+                    'var_dict': {
+                        'SST': {'fcst_var_names': ['TMP_Z0_mean'],
+                                'fcst_var_levels': ['Z0'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['analysed_sst'],
+                                'obs_var_levels': ['Z0'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'ICEC': {'fcst_var_names': ['ICEC_Z0_mean'],
+                                 'fcst_var_levels': ['Z0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options':  '',
+                                 'obs_var_names': ['sea_ice_fraction'],
+                                 'obs_var_levels': ['Z0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'}
+                    }
+                },
+                'ECNT': {
+                    'plot_stats_list': 'rmse, me, mae',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [ 'ARCTIC', 'ANTARCTIC' 
+                    ], 
+                    'var_dict': {
+                        'ICEC': {'fcst_var_names': ['ICEC_Z0_mean'],
+                                 'fcst_var_levels': ['Z0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options':  '',
+                                 'obs_var_names': ['ice_conc'],
+                                 'obs_var_levels': ['*,*'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'}
+                    }            
+                },
+                'CTC': {
+                    'plot_stats_list': 'csi, fbias, pod, sratio',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [ 'ARCTIC', 'ANTARCTIC' 
+                    ],   
+                    'var_dict': {
+                        'ICEC': {'fcst_var_names': ['ICEC_Z0_mean'],
+                                 'fcst_var_levels': ['Z0'],
+                                 'fcst_var_thresholds': '>10, >40, >80',
+                                 'fcst_var_options':  '',
+                                 'obs_var_names': ['ice_conc'],
+                                 'obs_var_levels': ['*,*'],
+                                 'obs_var_thresholds': '>10, >40, >80',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'}
+                    }            
+                }  
+            },
+            'satellite_ghrsst_ospo_geopolar_anl': {
+                'SL1L2': {
+                    'plot_stats_list': 'bias, rmse',
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'NH', 'SH', 'POLAR', 'ARCTIC', 'SEA_ICE', 
+                        'SEA_ICE_FREE', 'SEA_ICE_POLAR', 'SEA_ICE_FREE_POLAR'
+                    ],
+                    'var_dict': {
+                        'SST': {'fcst_var_names': ['TMP_Z0_mean'],
+                                'fcst_var_levels': ['Z0'],
+                                'fcst_var_thresholds': '',
+                                'fcst_var_options': '',
+                                'obs_var_names': ['analysed_sst'],
+                                'obs_var_levels': ['Z0'],
+                                'obs_var_thresholds': '',
+                                'obs_var_options': '',
+                                'plot_group':'sfc_upper'},
+                        'ICEC': {'fcst_var_names': ['ICEC_Z0_mean'],
+                                 'fcst_var_levels': ['Z0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['sea_ice_fraction'],
+                                 'obs_var_levels': ['Z0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'}
+                    }
+                }
+            },
+            'aviation_analysis': {
+                'CTC': {
+                    'plot_stats_list': ('bias, ets, fss, csi, fbias, fbar,'
+                                        + ' obar, pod, farate, faratio, sratio'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'AR2','ASIA','AUNZ','EAST','NAMR','NHM','NPCF','SHM','TRP'
+                    ],
+                    'var_dict': {
+                        'ICESEV': {'fcst_var_names': ['ICESEV'],
+                                  'fcst_var_levels': ['P812','P696.8','P595.2','P506','P392.7'],
+                                  'fcst_var_thresholds': '>=1, >=2, >=3, >=4',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['ICESEV'],
+                                  'obs_var_levels': ['P800','P700','P600','P500','P400'],
+                                  'obs_var_thresholds': '>=1, >=2, >=3, >=4',
+                                  'obs_var_options': '',
+                                  'plot_group':'aviation'},
+                    }
+                }
+            },
+        }
+
+    '''
+    Each formula in the formulas class needs to have the capability of providing three things.
+    1) Simply, the complete conversion of the input quantity into the output units
+    2) The rounded conversion of the input to the output (e.g., for displaying some thresholds)
+    3) The coefficient and the constant that composes the formula (for converting base stats)
+    '''        
+    class formulas():
+        def mm_to_in(mm_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = np.divide(1., 25.4)
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    inch_vals = np.divide(mm_vals, 25.4).round(decimals=2)
+                else:
+                    inch_vals = np.divide(mm_vals, 25.4)
+                return inch_vals
+        def mm_to_mm(mm_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = 1.
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    inch_vals = np.divide(mm_vals, 1.).round(decimals=2)
+                else:
+                    inch_vals = np.divide(mm_vals, 1.)
+                return inch_vals
+        def K_to_F(K_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = np.divide(9., 5.)
+                C = ((-273.15)*9./5.)+32.
+                return M, C
+            else:
+                if rounding:
+                    F_vals = (((np.array(K_vals)-273.15)*9./5.)+32.).round()
+                else:
+                    F_vals = ((np.array(K_vals)-273.15)*9./5)+32.
+                return F_vals
+        def C_to_F(C_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = np.divide(9., 5.)
+                C = 32.
+                return M, C
+            else:
+                if rounding:
+                    F_vals = ((np.array(C_vals)*9./5.)+32.).round()
+                else:
+                    F_vals = (np.array(C_vals)*9./5.)+32.
+                return F_vals
+        def mps_to_kt(mps_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = 1.94384449412
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    kt_vals = (np.multiply(mps_vals, 1.94384449412)).round()
+                else:
+                    kt_vals = np.multiply(mps_vals, 1.94384449412)
+                return kt_vals
+        def PA_to_hPa(PA_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = 0.01
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    hPa_vals = (np.array(PA_vals) * 0.01).round()
+                else:
+                    hPa_vals = np.array(PA_vals) * 0.01
+                return hPa_vals
+        def gpm_to_kft(gpm_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = np.divide(1., 304.8)
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    kft_vals = (np.divide(gpm_vals, 304.8)).round(decimals=2)
+                else:
+                    kft_vals = np.divide(gpm_vals, 304.8)
+                return kft_vals
+        def m_to_mi(m_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = np.divide(1., 1609.34)
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    mi_vals = (np.divide(m_vals, 1609.34)).round(decimals=2)
+                else:
+                    mi_vals = np.divide(m_vals, 1609.34)
+                return mi_vals
+        def m_snow_to_in(m_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = 39.3701
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    in_vals = (np.multiply(m_vals, 39.37)).round(decimals=2)
+                else:
+                    in_vals = np.multiply(m_vals, 39.37)
+                return in_vals
+        def dec_to_perc(dec_vals, rounding=False, return_terms=False):
+            if return_terms:
+                M = 100.
+                C = 0.
+                return M, C
+            else:
+                if rounding:
+                    perc_vals = (np.multiply(dec_vals, 100.)).round()
+                else:
+                    perc_vals = np.multiply(dec_vals, 100.)
+                return perc_vals
+

--- a/ush/cam/ush_refs_plot_py/stat_by_level.py
+++ b/ush/cam/ush_refs_plot_py/stat_by_level.py
@@ -1,0 +1,1372 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          stat_by_level.py
+# Contact(s):    Marcel Caron
+# Developed:     Oct. 14, 2021 by Marcel Caron 
+# Last Modified: Nov. 02, 2022 by Marcel Caron             
+# Title:         Line plot of pressure level as a function of 
+#                verification metric
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                stratified by pressure level, which represents the y-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(18., 14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def plot_stat_by_level(df: pd.DataFrame, logger: logging.Logger, 
+                       date_range: tuple, model_list: list, num: int = 0, 
+                       flead='all', metric1_name: str = 'BCRMSE', 
+                       metric2_name: str = 'ME', x_min_limit: float = -10., 
+                       x_max_limit: float = 10., x_lim_lock: bool = False, 
+                       y_min_limit: float = 50., y_max_limit: float = 1000., 
+                       y_lim_lock: bool = False,  
+                       ylabel: str = 'Pressure Level (hPa)', 
+                       date_type: str = 'VALID', line_type: str = 'SL1L2',
+                       date_hours: list = [0,6,12,18], save_dir: str = '.', 
+                       dpi: int = 300, confidence_intervals: bool = False,
+                       interp_pts: list = [],
+                       bs_nrep: int = 5000, bs_method: str = 'MATCHED_PAIRS',
+                       bs_min_samp: int = 300, ci_lev: float = .95, 
+                       eval_period: str = 'TEST', save_header: str = '', 
+                       display_averages: bool = True, 
+                       plot_group: str = 'sfc_upper',
+                       sample_equalization: bool = True,
+                       plot_logo_left: bool = False,
+                       plot_logo_right: bool = False, path_logo_left: str = '.',
+                       path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                       zoom_logo_right: float = 1.):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+   
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by forecast lead times
+    if str(flead).upper() == 'ALL':
+        frange_string = 'All Available Forecasts'
+        frange_save_string = 'ALL_LEADS'
+        pass
+    elif isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
+            frange_save_phrase = f'{flead[0]}-TO-F{flead[-1]}'
+        frange_string = f'Forecast Hour{frange_phrase}'
+        frange_save_string = f'F{frange_save_phrase}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        frange_string = (f'Forecast Hours {flead[0]:02d}'
+                         +u'\u2013'+f'{flead[1]:02d}')
+        frange_save_string = f'F{flead[0]:02d}-F{flead[1]:02d}'
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        frange_string = f'Forecast Hour {flead:02d}'
+        frange_save_string = f'F{flead:02d}'
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads"
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(intep_pts, np.int):
+            interp_pts_string = f'(Wifth {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    plevs = df['OBS_LEV'].str[1:].astype(int)
+    df['PLEV'] = plevs.tolist()
+
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model) 
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL','PLEV']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    if str(line_type).upper() == 'CTC':
+        df_aggregated = df_groups.sum()
+    else:
+        df_aggregated = df_groups.mean()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    # Remove data if they exist for some but not all models at some value of 
+    # the indep. variable. Otherwise plot_util.calculate_stat will throw an 
+    # error
+    df_split = [df_aggregated.xs(str(model)) for model in model_list]
+    df_reduced = reduce(
+        lambda x,y: pd.merge(
+            x, y, on='PLEV', how='inner'
+        ), 
+        df_split
+    )
+    df_aggregated = df_aggregated[
+        df_aggregated.index.get_level_values('PLEV').isin(df_reduced.index)
+    ]
+
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    coef, const = (None, None)
+    units = df['FCST_UNITS'].tolist()[0]
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR','SPREAD',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        var_long_name_key = df['FCST_VAR'].tolist()[0]
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m', 'gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        elif str(var_long_name_key).upper() == 'TMP':
+            unit_convert = False
+        if unit_convert:
+            if metric2_name is not None:
+                if (str(metric1_name).upper() in metrics_using_var_units
+                    and str(metric2_name).upper() in metrics_using_var_units):
+                    coef, const = (    
+                        reference.unit_conversions[units]['formula'](
+                            None,
+                            return_terms=True
+                        )
+                    )
+            elif str(metric1_name).upper() in metrics_using_var_units:
+                coef, const = (
+                    reference.unit_conversions[units]['formula'](
+                        None,
+                        return_terms=True
+                    )
+                )
+    # Calculate desired metrics
+    metric_long_names = []
+    for stat in [metric1_name, metric2_name]:
+        if stat:
+            stat_output = plot_util.calculate_stat(
+                logger, df_aggregated, str(stat).lower(), [coef, const]
+            )
+            df_aggregated[str(stat).upper()] = stat_output[0]
+            metric_long_names.append(stat_output[2])
+            if confidence_intervals:
+                ci_output = df_groups.apply(
+                    lambda x: plot_util.calculate_bootstrap_ci(
+                        logger, bs_method, x, str(stat).lower(), bs_nrep,
+                        ci_lev, bs_min_samp, [coef, const]
+                    )
+                )
+                if any(ci_output['STATUS'] == 1):
+                    logger.warning(f"Failed attempt to compute bootstrap"
+                                   + f" confidence intervals.  Sample size"
+                                   + f" for one or more groups is too small."
+                                   + f" Minimum sample size can be changed"
+                                   + f" in settings.py.")
+                    logger.warning(f"Confidence intervals will not be"
+                                   + f" plotted.")
+                    confidence_intervals = False
+                    continue
+                ci_output = ci_output.reset_index(level=2, drop=True)
+                ci_output = (
+                    ci_output
+                    .reindex(df_aggregated.index)
+                    .reindex(ci_output.index)
+                )
+                df_aggregated[str(stat).upper()+'_BLERR'] = ci_output[
+                    'CI_LOWER'
+                ].values
+                df_aggregated[str(stat).upper()+'_BUERR'] = ci_output[
+                    'CI_UPPER'
+                ].values
+
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    if metric2_name is not None:
+        df_aggregated[str(metric2_name).upper()] = (
+            df_aggregated[str(metric2_name).upper()]
+        ).astype(float).tolist()
+
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index='PLEV'
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL', 
+            index='PLEV'
+        )
+    if metric2_name:
+        pivot_metric2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+            index='PLEV'
+        )
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index='PLEV'
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index='PLEV'
+        )
+        if metric2_name:
+            pivot_ci_lower2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+                columns='MODEL', index='PLEV'
+            )
+            pivot_ci_upper2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+                columns='MODEL', index='PLEV'
+            )
+    if (metric2_name and (pivot_metric1.empty or pivot_metric2.empty)):
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any pressure"
+            + f" level. This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    elif not metric2_name and pivot_metric1.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name}"
+            + f" stats for {print_varname} at any pressure level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected=False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model')!=-1):
+                    need_to_rename = models_sharing_colors[
+                        np.flatnonzero(np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1)[0]
+                    ]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model'+str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+
+    # Plot data
+    logger.info("Begin plotting ...")
+    if confidence_intervals:
+        indices_in_common1 = list(set.intersection(*map(
+            set, 
+            [
+                pivot_metric1.index, 
+                pivot_ci_lower1.index, 
+                pivot_ci_upper1.index
+            ]
+        )))
+        pivot_metric1 = pivot_metric1[pivot_metric1.index.isin(indices_in_common1)]
+        pivot_ci_lower1 = pivot_ci_lower1[pivot_ci_lower1.index.isin(indices_in_common1)]
+        pivot_ci_upper1 = pivot_ci_upper1[pivot_ci_upper1.index.isin(indices_in_common1)]
+        if sample_equalization:
+            pivot_counts = pivot_counts[pivot_counts.index.isin(indices_in_common1)]
+        if metric2_name is not None:
+            indices_in_common2 = list(set.intersection(*map(
+                set, 
+                [
+                    pivot_metric2.index, 
+                    pivot_ci_lower2.index, 
+                    pivot_ci_upper2.index
+                ]
+            )))
+            pivot_metric2 = pivot_metric2[pivot_metric2.index.isin(indices_in_common2)]
+            pivot_ci_lower2 = pivot_ci_lower2[pivot_ci_lower2.index.isin(indices_in_common2)]
+            pivot_ci_upper2 = pivot_ci_upper2[pivot_ci_upper2.index.isin(indices_in_common2)]
+    y_vals1 = pivot_metric1.index
+    if metric2_name is not None:
+        y_vals2 = pivot_metric2.index
+    plev_incr = np.abs(np.diff(y_vals1))
+    if plev_incr.size == 0:
+        min_incr = 100
+    else:
+        min_incr = np.min(plev_incr) 
+    x_min = x_min_limit
+    x_max = x_max_limit
+    plot_reference = [False, False]
+    ref_metrics = ['OBAR']
+    if str(metric1_name).upper() in ref_metrics:
+        plot_reference[0] = True
+        pivot_reference1 = pivot_metric1
+        reference1 = pivot_reference1.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower1 = pivot_ci_lower1.mean(axis=1)
+            reference_ci_upper1 = pivot_ci_upper1.mean(axis=1)
+        if not np.any((pivot_reference1.T/reference1).T == 1.):
+            logger.warning(
+                f"{str(metric1_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[0] = False
+    if metric2_name is not None and str(metric2_name).upper() in ref_metrics:
+        plot_reference[1] = True
+        pivot_reference2 = pivot_metric2
+        reference2 = pivot_reference2.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower2 = pivot_ci_lower2.mean(axis=1)
+            reference_ci_upper2 = pivot_ci_upper2.mean(axis=1)
+        if not np.any((pivot_reference2.T/reference2).T == 1.):
+            logger.warning(
+                f"{str(metric2_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[1] = False
+    if np.any(plot_reference):
+        plotted_reference = [False, False]
+        if confidence_intervals:
+            plotted_reference_CIs = [False, False]
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms
+    )[0]
+    if metric2_name is not None:
+        if np.any(plot_reference):
+            ref_color_dict = model_colors.get_color_dict('obs')
+            handles = []
+            labels = []
+            line_settings = ['solid','dashed']
+            metric_names = [metric1_name, metric2_name]
+            for p, rbool in enumerate(plot_reference):
+                if rbool:
+                    handles += [
+                        f('', ref_color_dict['color'], line_settings[p], 5., 0, 'white')
+                    ]
+                else:
+                    handles += [
+                        f('', 'black', line_settings[p], 5., 0, 'white')
+                    ]
+                labels += [
+                    str(metric_names[p]).upper()
+                ]
+        else:
+            handles = [
+                f('', 'black', line_setting, 5., 0, 'white') 
+                for line_setting in ['solid','dashed']
+            ]
+            labels = [
+                str(metric_name).upper() 
+                for metric_name in [metric1_name, metric2_name]
+            ]
+    else:
+        handles = []
+        labels = []
+    n_mods = 0
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        x_vals_metric1 = pivot_metric1[str(model_list[m])].values
+        x_vals_metric1_mean = np.nanmean(x_vals_metric1)
+        if metric2_name is not None:
+            x_vals_metric2 = pivot_metric2[str(model_list[m])].values
+            x_vals_metric2_mean = np.nanmean(x_vals_metric2)
+        if confidence_intervals:
+            x_vals_ci_lower1 = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            x_vals_ci_upper1 = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            if metric2_name is not None:
+                x_vals_ci_lower2 = pivot_ci_lower2[
+                    str(model_list[m])
+                ].values
+                x_vals_ci_upper2 = pivot_ci_upper2[
+                    str(model_list[m])
+                ].values
+        if not x_lim_lock:
+            if metric2_name is not None:
+                x_vals_metric_min = np.nanmin([
+                    x_vals_metric1, x_vals_metric2
+                ])
+                x_vals_metric_max = np.nanmax([
+                    x_vals_metric1, x_vals_metric2
+                ])
+            else:
+                x_vals_metric_min = np.nanmin(x_vals_metric1)
+                x_vals_metric_max = np.nanmax(x_vals_metric1)
+            if n_mods == 0:
+                x_mod_min = x_vals_metric_min
+                x_mod_max = x_vals_metric_max
+                n_mods+=1
+            else:
+                x_mod_min = np.nanmin([x_mod_min, x_vals_metric_min])
+                x_mod_max = np.nanmax([x_mod_max, x_vals_metric_max])
+            if (x_vals_metric_min > x_min_limit 
+                    and x_vals_metric_min <= x_mod_min):
+                x_min = x_vals_metric_min
+            if (x_vals_metric_max < x_max_limit 
+                    and x_vals_metric_max >= x_mod_max):
+                x_max = x_vals_metric_max
+        if np.abs(x_vals_metric1_mean) < 1E4:
+            metric1_mean_fmt_string = f'{x_vals_metric1_mean:.2f}'
+        else:
+            metric1_mean_fmt_string = f'{x_vals_metric1_mean:.2E}'
+        if plot_reference[0]:
+            if not plotted_reference[0]:
+                ref_color_dict = model_colors.get_color_dict('obs')
+                plt.plot(
+                    reference1, y_vals1.tolist(),
+                    marker=ref_color_dict['marker'],
+                    c=ref_color_dict['color'], mew=2., mec='white',
+                    figure=fig, ms=ref_color_dict['markersize'], ls='solid',
+                    lw=ref_color_dict['linewidth']
+                )
+                plotted_reference[0] = True
+        else:
+            plt.plot(
+                x_vals_metric1, y_vals1.tolist(), 
+                marker=mod_setting_dicts[m]['marker'], 
+                c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='solid', 
+                lw=mod_setting_dicts[m]['linewidth']
+            )
+        if metric2_name is not None:
+            if np.abs(x_vals_metric2_mean) < 1E4:
+                metric2_mean_fmt_string = f'{x_vals_metric2_mean:.2f}'
+            else:
+                metric2_mean_fmt_string = f'{x_vals_metric2_mean:.2E}'
+            if plot_reference[1]:
+                if not plotted_reference[0]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.plot(
+                        reference2, y_vals2.tolist(),
+                        marker=ref_color_dict['marker'],
+                        c=ref_color_dict['color'], mew=2., mec='white',
+                        figure=fig, ms=ref_color_dict['markersize'], ls='dashed',
+                        lw=ref_color_dict['linewidth']
+                    )
+                    plotted_reference[1] = True
+            else:
+                plt.plot(
+                    x_vals_metric2, y_vals2.tolist(), 
+                    marker=mod_setting_dicts[m]['marker'], 
+                    c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                    figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='dashed', 
+                    lw=mod_setting_dicts[m]['linewidth']
+                )
+        if confidence_intervals:
+            if plot_reference[0]:
+                if not plotted_reference_CIs[0]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.errorbar(
+                        reference1, y_vals1.tolist(),
+                        xerr=[np.abs(reference_ci_lower1), reference_ci_upper1],
+                        fmt='none', ecolor=ref_color_dict['color'],
+                        elinewidth=ref_color_dict['linewidth']/1.5,
+                        capsize=9., capthick=ref_color_dict['linewidth']/1.5,
+                        alpha=.70, zorder=0
+                    )
+                    plotted_reference_CIs[0] = True
+            else:
+                plt.errorbar(
+                    x_vals_metric1, y_vals1.tolist(),
+                    xerr=[np.abs(x_vals_ci_lower1), x_vals_ci_upper1],
+                    fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                    elinewidth=mod_setting_dicts[m]['linewidth']/1.5,
+                    capsize=9., capthick=mod_setting_dicts[m]['linewidth']/1.5,
+                    alpha=.70, zorder=0
+                )
+            if metric2_name is not None:
+                if plot_reference[1]:
+                    if not plotted_reference_CIs[1]:
+                        ref_color_dict = model_colors.get_color_dict('obs')
+                        plt.errorbar(
+                            reference2, y_vals2.tolist(),
+                            xerr=[np.abs(reference_ci_lower2), reference_ci_upper2],
+                            fmt='none', ecolor=ref_color_dict['color'],
+                            elinewidth=ref_color_dict['linewidth']/1.5,
+                            capsize=9., capthick=ref_color_dict['linewidth']/1.5,
+                            alpha=.70, zorder=0
+                        )
+                        plotted_reference_CIs[1] = True
+                else:
+                    plt.errorbar(
+                        x_vals_metric2, y_vals2.tolist(),
+                        xerr=[np.abs(x_vals_ci_lower2), x_vals_ci_upper2],
+                        fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                        elinewidth=mod_setting_dicts[m]['linewidth']/1.5,
+                        capsize=9., capthick=mod_setting_dicts[m]['linewidth']/1.5,
+                        alpha=.70, zorder=0
+                    )
+        handles+=[
+            f(
+                mod_setting_dicts[m]['marker'], mod_setting_dicts[m]['color'], 
+                'solid', mod_setting_dicts[m]['linewidth'], 
+                mod_setting_dicts[m]['markersize'], 'white'
+            )
+        ]
+        if display_averages:
+            if metric2_name is not None:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string},'
+                    + f' {metric2_mean_fmt_string})'
+                ]
+            else:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string})'
+                ]
+        else:
+            labels+=[f'{model_plot_name}']
+
+    # Zero line
+    plt.axvline(x=0, color='black', linestyle='--', linewidth=1, zorder=0) 
+
+    # Configure axis ticks
+    yticks = [1000, 925, 850, 700, 500, 300, 250, 200, 100, 50, 10, 1]
+    if metric2_name is not None:
+        yticks = np.array([
+            ytick 
+            for ytick in yticks 
+            if (
+                ytick>=min([min(y_vals1),min(y_vals2)]) 
+                and ytick<=max([max(y_vals1),max(y_vals2)])
+            )
+        ])
+    else:
+        yticks = np.array([
+            ytick 
+            for ytick in yticks 
+            if (
+                ytick>=min(y_vals1) 
+                and ytick<=max(y_vals1)
+            )
+        ])
+    ytick_labels = yticks.astype(str)
+    # x ticks and axis limits adjust based on the size of the x_range 
+    x_range_categories = np.array([
+        [np.power(10.,x), 2.*np.power(10.,x)] 
+        for x in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+    ]).flatten()
+    round_to_nearest_categories = x_range_categories/20.
+    x_range = x_max-x_min
+    round_to_nearest =  round_to_nearest_categories[
+        np.digitize(x_range, x_range_categories[:-1])
+    ]
+    xlim_min = np.floor(x_min/round_to_nearest)*round_to_nearest
+    xlim_max = round(np.ceil(x_max/round_to_nearest)*round_to_nearest, len(str(round_to_nearest))-1)
+    if len(str(xlim_min)) > 5 and np.abs(xlim_min) < 1E5:
+        xlim_min = float(
+            np.format_float_scientific(xlim_min, unique=False, precision=3)
+        )
+    xticks_og = np.arange(xlim_min, xlim_max+round_to_nearest, round_to_nearest)
+    xticks = [round(xtick,len(str(round_to_nearest))-1) for xtick in xticks_og]
+    if any([len(str(xtick)) > 5 and np.abs(xtick) < 1E5 for xtick in xticks]):
+        xtick_labels = []
+        for xtick in xticks:
+            xtick_labels.append(float(np.format_float_scientific(
+                xtick, unique=False, precision=3
+            )))
+    else:
+        xtick_labels = [str(xtick) for xtick in xticks]
+    if len(xticks) < 20:
+        if max([len(str(xtick)) for xtick in xticks]) < 5:
+            show_xtick_every = 1
+        else:
+            show_xtick_every = 2
+    else:
+        show_xtick_every = 2
+    xtick_labels_with_blanks = ['' for item in xtick_labels]
+    for i, item in enumerate(xtick_labels[::int(show_xtick_every)]):
+        xtick_labels_with_blanks[int(show_xtick_every)*i] = item
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    if units in reference.unit_conversions:
+        do_unit_conversion = True
+        if var_long_name_key == 'TMP':
+            do_unit_conversion = False
+    else:
+        do_unit_conversion = False
+    if do_unit_conversion:
+        units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    if metric2_name is not None:
+        metric1_string, metric2_string = metric_long_names
+        if (str(metric1_name).upper() in metrics_using_var_units 
+                and str(metric2_name).upper() in metrics_using_var_units):
+            if units:
+                xlabel = f'{var_long_name} ({units})'
+            else:
+                xlabel = f'{var_long_name} (unitless)'
+        else:
+            xlabel = f'{metric1_string} and {metric2_string}'
+    else:
+        metric1_string = metric_long_names[0]
+        if str(metric1_name).upper() in metrics_using_var_units:
+            if units:
+                xlabel = f'{var_long_name} ({units})'
+            else:
+                xlabel = f'{var_long_name} (unitless)'
+        else:
+            xlabel = f'{metric1_string}'
+    ax.set_xlim(xlim_min, xlim_max)
+    if y_lim_lock:
+        y_min, y_max = [y_min_limit, y_max_limit]
+    else:
+        if metric2_name is not None:
+            y_min, y_max = [
+                min([min(y_vals1),min(y_vals2)]), 
+                max([max(y_vals1),max(y_vals2)])
+            ]
+        else:
+            y_min, y_max = [
+                min(y_vals1), 
+                max(y_vals1)
+            ]
+        if y_min < y_min_limit:
+            y_min = y_min_limit
+        if y_max > y_max_limit:
+            y_max = y_max_limit
+    y_buffer_size = .015
+    ylim_min = np.exp(np.log(y_min)-y_buffer_size)
+    ylim_max = np.exp(np.log(y_max)+y_buffer_size)
+    ax.set_ylim(ylim_min, ylim_max)
+    # Y-values should decrease upward; set the following after setting ax 
+    # limits
+    ax.invert_yaxis()
+    # Pressure decreases logarithmically with height
+    ax.set_yscale('log')
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel) 
+    ax.set_yticklabels(ytick_labels)
+    ax.set_xticklabels(xtick_labels_with_blanks)
+    ax.set_xticks(xticks)
+    ax.set_yticks(yticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', axis='y'
+    )
+
+    ax.legend(
+        handles, labels, loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=4, frameon=True, numpoints=2, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    fig.subplots_adjust(bottom=.15, wspace=0., hspace=0)
+    fig.subplots_adjust(top=0.85)
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.5, linestyle='--', 
+        linewidth=.5, zorder=0
+    )
+
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        for count, yval in zip(counts, y_vals1.tolist()):
+            if not isinstance(count, str):
+                count = str(int(count))
+            ax.annotate(
+                f'{count}', xy=(1.,yval),
+                xycoords=('axes fraction','data'), xytext=(9,0),
+                textcoords='offset points', va='center', fontsize=16,
+                color='dimgrey', ha='left'
+            )
+        ax.annotate(
+            '#SAMPLES', xy=(1.,1.), xycoords='axes fraction',
+            xytext=(9,5), textcoords='offset points', va='bottom',
+            fontsize=11, color='dimgrey', ha='right'
+        )
+        fig.subplots_adjust(right=.95)
+        fig.subplots_adjust(top=.85)
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if metric2_name is not None:
+        title1 = f'{metric1_string} and {metric2_string}'
+    else:
+        title1 = f'{metric1_string}'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    if units:
+        title2 = f'{var_long_name} ({units}), {domain_string}'
+    else:
+        title2 = f'{var_long_name} (unitless), {domain_string}'
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string}'
+              + f' {date_start_string} to {date_end_string}, {frange_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    ax.set_title(title_center, loc=plotter.title_loc) 
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left*0.9)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction',
+                xybox=(0, 3), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            if sample_equalization:
+                right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right*0.65)
+                ab_right = AnnotationBbox(
+                    right_image_box, xy=(1.,1.), xycoords='axes fraction',
+                    xybox=(0, 20), boxcoords='offset points', frameon = False,
+                    box_alignment=(1,0)
+                )
+            else:
+                right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right*0.9)
+                ab_right = AnnotationBbox(
+                    right_image_box, xy=(1.,1.), xycoords='axes fraction',
+                    xybox=(0, 3), boxcoords='offset points', frameon = False,
+                    box_alignment=(1,0)
+                )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving 
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'stat_by_level_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(var_savename).lower()}_'
+                 + f'{str(metric1_name).lower()}')
+    if metric2_name is not None:
+        save_name+=f'_{str(metric2_name).lower()}'
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    save_name+=f'_{str(frange_save_string).lower()}'
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (
+            f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+            + f" VALID or INIT"
+        )
+        logger.error(e)
+        raise ValueError(e)
+
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: {X_MIN_LIMIT}")
+    logger.debug(f"X_MAX_LIMIT: {X_MAX_LIMIT}")
+    logger.debug(f"X_LIM_LOCK: {X_LIM_LOCK}")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    if len(METRICS) == 1:
+        metrics = (METRICS[0], None)
+    elif len(METRICS) > 1:
+        metrics = METRICS[:2]
+    else:
+        e = (f"FATAL ERROR: Received no list of metrics.  Check that, for the METRICS"
+             + f" setting, a comma-separated string of at least one metric is"
+             + f" provided")
+        logger.error(e)
+        raise ValueError(e)
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    if (str(INTERP).upper()
+            not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    for metric in metrics:
+        if metric is not None:
+            if (str(metric).lower()
+                    not in case_specs['plot_stats_list']
+                    .replace(' ','').split(',')):
+                e = (f"FATAL ERROR: The requested metric is not valid for the"
+                     + f" requested case type ({VERIF_CASETYPE}) and"
+                     + f" line type ({LINE_TYPE}): {metric}")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f"{requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds']
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds']
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for domain in DOMAINS:
+            if str(domain) not in case_specs['vx_mask_list']:
+                e = (f"The requested domain is not valid for the requested"
+                     + f" case type ({VERIF_CASETYPE}) and line_type"
+                     + f" ({LINE_TYPE}): {domain}")
+                logger.warning(e)
+                logger.warning("Continuing ...")
+                continue
+            df = df_preprocessing.get_preprocessed_data(
+                logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                date_hours, FLEADS, requested_var, fcst_var_names, obs_var_names, 
+                MODELS, domain, INTERP, MET_VERSION, clear_prune_dir
+            )
+            if df is None:
+                continue
+            plot_stat_by_level(
+                df, logger, date_range, MODELS, num=num, flead=FLEADS, 
+                metric1_name=metrics[0], metric2_name=metrics[1], 
+                date_type=DATE_TYPE, x_min_limit=X_MIN_LIMIT, 
+                x_max_limit=X_MAX_LIMIT, x_lim_lock=X_LIM_LOCK, 
+                y_min_limit=Y_MIN_LIMIT, y_max_limit=Y_MAX_LIMIT, 
+                y_lim_lock=Y_LIM_LOCK, ylabel='Pressure Level (hPa)', 
+                line_type=LINE_TYPE, date_hours=date_hours, 
+                save_dir=SAVE_DIR, eval_period=EVAL_PERIOD,
+                display_averages=display_averages, save_header=URL_HEADER,
+                plot_group=plot_group, 
+                confidence_intervals=CONFIDENCE_INTERVALS, interp_pts=INTERP_PNTS,
+                bs_nrep=bs_nrep, bs_method=bs_method, ci_lev=ci_lev, 
+                bs_min_samp=bs_min_samp, sample_equalization=sample_equalization,
+                plot_logo_left=plot_logo_left, plot_logo_right=plot_logo_right,
+                path_logo_left=path_logo_left, path_logo_right=path_logo_right,
+                zoom_logo_left=zoom_logo_left, zoom_logo_right=zoom_logo_right
+            )
+            num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = list(filter(None, check_STATS(os.environ['STATS']).replace(' ','').split(',')))
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If X_LIM_LOCK == True, use X_MIN_LIMIT as the definitive lower 
+    # limit (ditto with X_MAX_LIMIT)
+    # If X_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome X_MIN_LIMIT or X_MAX_LIMIT 
+    X_MIN_LIMIT = toggle.plot_settings['x_min_limit']
+    X_MAX_LIMIT = toggle.plot_settings['x_max_limit']
+    X_LIM_LOCK = toggle.plot_settings['x_lim_lock']
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+
+    # configure CIs
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    bs_method = toggle.plot_settings['bs_method']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove
+    # samples used to aggregate each statistic if the samples are not shared
+    # by all models.  Required to display sample sizes
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/string_template_substitution.py
+++ b/ush/cam/ush_refs_plot_py/string_template_substitution.py
@@ -1,0 +1,839 @@
+#! /usr/bin/env python3
+
+"""
+
+Program Name: string_template_substitution.py
+Contact(s): Julie Prestopnik, NCAR RAL DTC, jpresto@ucar.edu, George McCabe
+Abstract: Supporting functions for parsing and creating filename templates
+History Log:  Initial version for METPlus
+Usage: Usually imported in other Python code for individual function calls
+Parameters: Varies
+Input Files: None
+Output Files: None
+Condition codes: Varies
+
+"""
+
+import sys
+import re
+import datetime
+from dateutil.relativedelta import relativedelta
+import time_util
+
+TEMPLATE_IDENTIFIER_BEGIN = "{"
+TEMPLATE_IDENTIFIER_END = "}"
+
+FORMATTING_DELIMITER = "?"
+FORMATTING_VALUE_DELIMITER = "="
+FORMAT_STRING = "fmt"
+
+SHIFT_STRING = "shift"
+TRUNCATE_STRING = "truncate"
+
+VALID_STRING = "valid"
+LEAD_STRING = "lead"
+INIT_STRING = "init"
+DA_INIT_STRING = "da_init"
+OFFSET_STRING = "offset"
+
+LENGTH_DICT = {'Y': 4,
+               'm': 2,
+               'd': 2,
+               'H': 2,
+               'M': 2,
+               'S': 2,
+               'j': 3,
+               'y': 2,
+               'b': 3,
+               }
+
+MAX_ATTEMPTS = 5
+
+def multiple_replace(replace_dict, text):
+    """Helper function for do_string_sub. Replace in 'text' all occurrences of any key in the
+    given dictionary by its corresponding value.  Returns the new string. """
+
+    # Create a regular expression  from the dictionary keys
+    regex = re.compile("(%s)" % "|".join(map(re.escape, replace_dict.keys())))
+
+    # For each match, look-up corresponding value in dictionary
+    return regex.sub(lambda mo: replace_dict[mo.string[mo.start():mo.end()]], text)
+
+def get_tags(template):
+    """!Parse template and pull out all wildcard characters (* or ?) and all
+        tags, i.e. {init?fmt=%H}. Used to pull out information from a template that
+        contains wildcards and add that information when filled out another template
+        Returns a list of wildcards and tag names found, i.e. [ '*', 'init', 'lead']
+    """
+    i = 0
+    template_len = len(template)
+    tags = []
+    # loop through template looking for wildcard characters or tags: {init?fmt=%H}
+    while i < template_len:
+        if template[i] == TEMPLATE_IDENTIFIER_BEGIN:
+            end_i = template.find(TEMPLATE_IDENTIFIER_END, i)
+            tag = template[i+1:end_i]
+            identifier = tag.split('?')[0]
+            tags.append(identifier)
+            i = end_i
+        elif template[i] == '*' or template[i] == '?':
+            tags.append(template[i])
+
+        i += 1
+    return tags
+
+def format_one_time_item(item, time_str, unit):
+    """!Helper function for do_string_sub. Determine precision of time offset value and format
+        Args:
+         @param item format to substitute, i.e. 3M or H
+         @param time_str time value that precision will be applied, i.e. 60
+         @param unit currently being processed, i.e. M or H or S
+        Returns: Padded value or empty string if unit is not found in item
+    """
+    count = item.count(unit)
+    if count > 0:
+        rest = ''
+        # get precision from number (%3H)
+        res = re.match(r"^\.*(\d+)"+unit+"(.*)", item)
+        if res:
+            padding = int(res.group(1))
+            rest = res.group(2)
+        else:
+            padding = count
+            res = re.match("^"+unit+"+(.*)", item)
+            if res:
+                rest = res.group(1)
+                if unit != 's':
+                    padding = max(2, count)
+
+        # add formatted time
+        return str(time_str).zfill(padding)+rest
+
+    # return empty string if no match
+    return ''
+
+def format_hms(fmt, obj):
+    """!Helper function for do_string_sub. For time offset values, get hour, minute, and
+        second values to format as necessary
+        Args:
+            @param fmt format to substitute, i.e. %3H or %2M or %S
+            @param obj time value in seconds to format, i.e. 3600
+        Returns: Formatted time value
+    """
+    out_str = ''
+    fmt_split = fmt.split('%')[1:]
+    # split time into days, hours, mins, and secs
+    # time should be relative to the next highest unit if higher units are specified
+    # i.e. 90 minutes %M => 90, but %H%M => 0130
+    days = obj // 86400
+    hours = obj // 3600
+    minutes = obj  // 60
+    seconds = obj
+
+    # if days are specified, change hours, minutes, and seconds to relative
+    if True in ['d' in x for x in fmt_split]:
+        hours = (obj % 86400) // 3600
+        minutes = (obj % 3600) // 60
+        seconds = (obj % 3600) % 60
+
+    # if hours are specified, change minutes and seconds to relative
+    if True in ['H' in x for x in fmt_split]:
+        minutes = (obj % 3600) // 60
+        seconds = (obj % 3600) % 60
+
+    # if minutes are specified, change seconds to relative
+    if True in ['M' in x for x in fmt_split]:
+        seconds = (obj % 3600) % 60
+
+    # parse format
+    for item in fmt_split:
+        out_str += format_one_time_item(item, hours, 'H')
+        out_str += format_one_time_item(item, minutes, 'M')
+        out_str += format_one_time_item(item, seconds, 'S')
+        out_str += format_one_time_item(item, obj, 's')
+        out_str += format_one_time_item(item, days, 'd')
+
+    return out_str
+
+def set_output_dict_from_time_info(time_dict, output_dict, key):
+    """!Create datetime object from time data,
+        get month and day from julian date if applicable"""
+    # if 2 digit year is set, get full year
+    if time_dict['Y'] == -1 and time_dict['y'] != -1:
+        time_dict['Y'] = int(datetime.datetime.strptime(str(time_dict['y']), '%y').strftime('%Y'))
+
+    # if month as 3 letter string is set, get month number
+    if time_dict['m'] == -1 and time_dict['b'] != -1:
+        time_dict['m'] = int(datetime.datetime.strptime(str(time_dict['b']), '%b').strftime('%m'))
+
+    if time_dict['Y'] != -1 and time_dict['j'] != -1:
+        date_t = datetime.datetime.strptime(str(time_dict['Y'])+'_'+str(time_dict['j']),
+                                            '%Y_%j')
+        time_dict['m'] = int(date_t.strftime('%m'))
+        time_dict['d'] = int(date_t.strftime('%d'))
+
+    if time_dict['Y'] != -1 and time_dict['m'] != -1 and time_dict['d'] != -1:
+        output_dict[key] = datetime.datetime(time_dict['Y'],
+                                             time_dict['m'],
+                                             time_dict['d'],
+                                             time_dict['H'],
+                                             time_dict['M'])
+
+def add_to_dict(match, match_dict, filepath, new_len):
+    """!Add extracted information to match dictionary
+        Args:
+            @param match key for match dictionary containing tag name and units
+                   i.e. 'init+H' or 'lead+S'
+            @param match_dict dictionary of info extracted from filename
+            @param filepath rest of filename string to be parsed
+            @param new_len length of filepath to extract
+        Returns: True if info was added to dictionary or it already exists and
+                 matched newly parsed info, False if info could not be extracted or
+                 if info differed from info already in match dictionary
+    """
+    # if the time info being extracted is not a number, do not add to dict
+    if not filepath[0:new_len].isdigit():
+        return False
+
+    # if match is not already in match dictionary, add it
+    # if it exists and is different than what is attempted to be stored
+    #  return False
+    if match not in match_dict.keys():
+        match_dict[match] = filepath[0:new_len]
+    elif match_dict[match].zfill(new_len) != filepath[0:new_len]:
+        return False
+
+    # item was added or already existed in match dictionary
+    return True
+
+def get_seconds_from_template(split_string, element_name, kwargs):
+    """!Get seconds value from tag that contains a shift or truncate item
+         Args:
+             @param split_string list of key/value from string sub tag to evalute, i.e. shift=-1H
+             @param element_name information to extract, i.e. shift or truncate
+             @returns integer number of seconds that correspond to the item, i.e. -3600
+     """
+    # if shift is set, get that value before handling formatting
+    for split_item in split_string:
+        if split_item.startswith(element_name):
+
+            shift_split_string = split_item.split(FORMATTING_VALUE_DELIMITER)
+
+            if len(shift_split_string) != 2:
+                return None
+
+            valid_time = kwargs.get('valid',
+                                    kwargs.get('now',
+                                               None))
+
+            seconds = shift_split_string[1]
+            return int(time_util.get_seconds_from_string(seconds,
+                                                         default_unit='S',
+                                                         valid_time=valid_time))
+
+    # if not found, return 0
+    return 0
+
+def round_time_down(obj, truncate_seconds):
+    """!If template value needs to be truncated, round the value down
+        to the given truncate interval"""
+    if truncate_seconds == 0:
+        return obj
+
+    trunc = truncate_seconds
+    seconds = (obj.replace(tzinfo=None) - obj.min).seconds
+    rounding = seconds // trunc * trunc
+    new_obj = obj + datetime.timedelta(0, rounding-seconds,
+                                       -obj.microsecond)
+    return new_obj
+
+def handle_format_delimiter(split_string, idx, shift_seconds, truncate_seconds, kwargs):
+    """!Check for formatting/length request by splitting on
+        FORMATTING_VALUE_DELIMITER
+        split_string[1]
+        Args:
+            @param split_string holds the formatting/length
+              information (e.g. "fmt=%Y%m%d", "len=3")
+            @param idx index in split_string of the format item
+        Returns: Formatted string
+    """
+    format_split_string = \
+        split_string[idx].split(FORMATTING_VALUE_DELIMITER)
+
+    # Check for requested FORMAT_STRING
+    # format_split_string[0] holds the formatting/length
+    # value delimiter (e.g. "fmt", "len")
+    if format_split_string[0] == FORMAT_STRING:
+        obj = kwargs.get(split_string[0], None)
+
+        fmt = format_split_string[idx]
+        # if input is datetime object, format appropriately
+        if isinstance(obj, datetime.datetime):
+            # shift date time if set
+            obj = obj + datetime.timedelta(seconds=shift_seconds)
+
+            # truncate date time if set
+            obj = round_time_down(obj, truncate_seconds)
+            return obj.strftime(fmt)
+
+        # if input is relativedelta
+        if isinstance(obj, relativedelta):
+            seconds = time_util.ti_get_seconds_from_relativedelta(obj)
+            if seconds is None:
+                return time_util.ti_get_lead_string(obj, letter_only=True)
+
+            return format_hms(fmt, seconds)
+
+        # if input is integer, format with H, M, and S
+        if isinstance(obj, int):
+            obj += shift_seconds
+            return format_hms(fmt, obj)
+
+        # if string, format if possible
+        if isinstance(obj, str):
+            return '{}'.format(obj)
+
+        raise TypeError('Could not format item {} with format {} in {}'
+                        .format(obj, fmt, split_string))
+
+    return None
+
+def do_string_sub(tmpl,
+                  skip_missing_tags=False,
+                  recurse=False,
+                  attempt=MAX_ATTEMPTS,
+                  **kwargs):
+    """ Perform string substitution on a template. Replace filename template
+        tags (found within curly braces) with values passed into the function
+        as arguments. In some cases, the template keys can have parameters
+        containing formatting information. datetime objects
+        set as the value of an argument can be formatted using Python datetime
+        strftime format syntax, i.e. {init?fmt=%Y%m%d}. Integers and
+        relativedelta objects passed as the value of an argument can be
+        formatted with %H, %M, %S, or %d (hour, minute, second, or day
+        respectively). Integers are assumed to be seconds.
+
+        @param tmpl template to substitute values into
+        @param skip_missing_tags (Optional) argument to allow the function to
+         not fail if a tag cannot be substituted. This is useful when a
+         developer wants to substitute some of the tags in a template but
+         leave others alone before substituting them later. This is also needed
+         if the template contains curly braces that are part of a dictionary
+         (i.e. in a MET config variable) that should not be substituted. If
+         set to False (default) and a key to be substituted was not passed into
+         the function call, a TypeError exception will be raised.
+        @param recurse If True, try to substitute values recursively until max
+         number of attempts have been made. If False, only try once. Default
+         value is False.
+        @param attempt Counter to prevent infinite recursion if a set of curly
+         braces are expected to not be substituted. This argument shouldn't be
+         defined in the call to this function.
+        @param kwargs any additional arguments that are passed to the function.
+         These will be used to replace values in the template. For example, if
+         my_arg=my_value is passed to the function, any occurence of {my_arg}
+         in the template will be substituted with 'my_value'.
+        @returns template with tags substituted with values
+    """
+    if recurse:
+        # set argument to another variable to avoid changing the input value
+        attempt_local = attempt
+        # if number of attempts provided is more than the max,
+        # set it to the max
+        if attempt_local > MAX_ATTEMPTS:
+            attempt_local = MAX_ATTEMPTS
+    else:
+        # if recursion is off, only attempt once
+        attempt_local = 0
+
+    # find inner most tags between nested curly braces
+    # match_list is a list with the contents being the data between the
+    # curly braces
+    match_list = re.findall(r'\{([^}{]*)\}', tmpl)
+
+    if len(match_list) == 0:
+        return tmpl
+
+    match_result = find_and_replace_tags_in_template(match_list,
+                                                     tmpl,
+                                                     kwargs,
+                                                     skip_missing_tags)
+
+    # if no more recursive attempts should be made, return the result
+    if attempt_local <= 0:
+        return match_result
+
+    return do_string_sub(match_result,
+                         skip_missing_tags=skip_missing_tags,
+                         attempt=attempt_local-1,
+                         **kwargs)
+
+def find_and_replace_tags_in_template(match_list, tmpl, kwargs, skip_missing_tags=False):
+    """! Loop through tags from template and replace them with the correct time values
+         @param match_list list of tags to process
+         @param template filename template to substitute values into
+         @param kwargs all
+
+    """
+    # A dictionary that will contain the string to replace (key)
+    # and the string to replace it with (value)
+    replacement_dict = {}
+    # Search for the FORMATTING_DELIMITER within the first string
+    for match in match_list:
+
+        string_to_replace = TEMPLATE_IDENTIFIER_BEGIN + match + \
+                            TEMPLATE_IDENTIFIER_END
+        split_string = match.split(FORMATTING_DELIMITER)
+
+        # valid, init, lead, etc.
+        # print split_string[0]
+        # value e.g. 2016012606, 3
+
+        # split_string[0] holds the key (e.g. "init", "valid", etc)
+        if split_string[0] not in kwargs.keys():
+            # if skip_missing_tags is True, leave template tag if key was not found
+            if skip_missing_tags:
+                continue
+
+            # otherwise log and exit
+            raise TypeError("The key " + split_string[0] +
+                            " was not passed to do_string_sub " +
+                            " for template: " + tmpl + ": " + str(kwargs))
+
+        # if shift is set, get that value before handling formatting
+        shift_seconds = get_seconds_from_template(split_string, SHIFT_STRING, kwargs)
+
+        # if truncate is set, get that value before handling formatting
+        truncate_seconds = get_seconds_from_template(split_string, TRUNCATE_STRING, kwargs)
+
+        # format times appropriately and add to replacement_dict
+        formatted = False
+        for idx, split_item in enumerate(split_string):
+            if split_item.startswith(FORMAT_STRING):
+                replacement_dict[string_to_replace] = \
+                    handle_format_delimiter(split_string,
+                                            idx,
+                                            shift_seconds,
+                                            truncate_seconds,
+                                            kwargs)
+                formatted = True
+
+        # No formatting or length is requested
+        if not formatted:
+            # Add back the template identifiers to the matched
+            # string to replace and add the key, value pair to the
+            # dictionary
+            value = kwargs.get(split_string[0], None)
+            if isinstance(value, int):
+                value = f"{value}S"
+            replacement_dict[string_to_replace] = value
+
+    # Replace regex with properly formatted information
+    if not replacement_dict:
+        return tmpl
+
+    return multiple_replace(replacement_dict, tmpl)
+
+def parse_template(template, filepath, logger=None):
+    """!Extract time information from path using the filename template
+         Args:
+             @param template filename template to use to extract time information
+             @param filepath path to examine
+             @returns time_info dictionary with time information if successful, None if not"""
+
+    match_dict, valid_shift = populate_match_dict(template, filepath, logger)
+    if match_dict is None:
+        return None
+
+    # combine common items and get datetime
+    output_dict = populate_output_dict(match_dict, valid_shift)
+
+    if not output_dict:
+        if logger:
+            logger.debug(f"Could not extract enough time information from {filepath}")
+        else:
+            print(f"DEBUG: Could not extract enough time information from {filepath}")
+
+        return None
+
+    # fill in the rest of the time info dictionary items with ti_calculate
+    time_info = time_util.ti_calculate(output_dict)
+
+    return time_info
+
+def populate_match_dict(template, filepath, logger=None):
+    """! Use template to extract time information from filepath, add each value to a dictionary.
+         Populates a dictionary with keys that contain tag name + time type, i.e. init+Y,
+         valid+M, or lead+S, with string values containing the number extracted from the filepath.
+         Also determines the shift amount  for valid time if it was found, i.e.
+         {valid?fmt=%Y%m%d?shift=-30}. Valid shift will be 0 if no shift.
+         Note: valid time values will not have the shift applied.
+         Args:
+             @param template filename template to use to find time information, i.e.
+                 file.{valid?fmt=%Y%m%d}.ext
+             @param filepath path to examine, i.e. file.20190201.ext
+             @returns tuple of match dictionary and valid shift value if success, i.e.
+                 ({'init+Y': '2019'}, -30)
+              Returns (None, None) if could not extract time info
+    """
+    # get the text before any tags, between tags, and after any tags
+    match = re.match(r'([^{]*)({.*})([^}]*)', template)
+    if not match:
+        # if there were no tags, we can't extract time info, so return None, None
+        if logger:
+            logger.debug("No tags found (1)")
+        return None, None
+
+    all_tags = match.group(2)
+
+    # check if text before and after tags matches template and strip off from file path
+    filepath = check_pre_text(filepath, match.group(1), logger)
+    filepath = check_post_text(filepath, match.group(3), logger)
+    if filepath is None:
+        return None, None
+
+    return process_match_tags(all_tags, filepath, logger)
+
+def process_match_tags(all_tags, filepath, logger):
+    """! Loop through tags and process each.
+         @param all_tags string containing all tags with non-tag text removed from
+         beginning and end.
+         @param filepath path to process
+         @param logger optional logger to output error information
+         @returns tuple containing dictionary with match information and valid shift
+             value if applicable, or (None, None) could not parse information
+    """
+    match_dict = {}
+    valid_shift = 0
+
+    match_tags = re.findall(r'{(.*?)}([^{]*)', all_tags)
+    if not match_tags:
+        if logger:
+            logger.debug("No tags found (2)")
+        return None, None
+
+    for match_tag in match_tags:
+        tag_content, extra_text = match_tag
+        fmt_len, valid_shift = get_format_and_shift(tag_content,
+                                                    filepath,
+                                                    match_dict,
+                                                    valid_shift,
+                                                    extra_text)
+
+        # if length of formatted text couldn't be determined
+        if fmt_len is None:
+            if logger:
+                logger.debug("Could not determine length of formatted text")
+            return None, None
+
+        # if length of formatted text is longer than remaining text in file path
+        if fmt_len > len(filepath):
+            if logger:
+                logger.debug("Length of formatted text is longer than remaining text in file path")
+            return None, None
+
+        # strip off length of formatted text from filepath
+        filepath = filepath[fmt_len:]
+
+        # check that any extra text matches the filepath
+        filepath = check_pre_text(filepath, extra_text, logger)
+        if filepath is None:
+            return None, None
+
+    return match_dict, valid_shift
+
+def check_pre_text(filepath, pre_text, logger=None):
+    """! Check if there is an text before all tags and if they match the template.
+         Strip off text from filepath.
+         @param filepath path to check
+         @param pre_text text before any tags
+         @param post_text text after all tags
+         @returns file path with pre text removed or None if text does not match template"""
+
+    if filepath is None:
+        return None
+
+    # if length of extra text is longer than remaining text in file path
+    if len(pre_text) > len(filepath):
+        # too much logging output comes from this - if verbose is added, this is a good candidate
+#        if logger:
+#            logger.debug("Length of pre text is longer than "
+#                         "remaining text in file path")
+        return None
+
+    # if there is text before any tags, check that the text in the template matches the file path
+    if pre_text:
+        if pre_text != filepath[0:len(pre_text)]:
+            # too much logging output comes from this - if verbose is added, this is a good candidate
+#            if logger:
+#                logger.debug("Text at beginning of filepath does not match template")
+            return None
+
+        # strip off pre text from file path
+        filepath = filepath[len(pre_text):]
+
+    return filepath
+
+def check_post_text(filepath, post_text, logger=None):
+    """! Check if there is an text after all tags and if they match the template.
+         Strip off text from filepath.
+         @param filepath path to check
+         @param post_text text after all tags
+         @returns file path with post text removed or None if text does not match template"""
+
+    if filepath is None:
+        return None
+
+    # do the same for text at the end of all tags
+    if post_text:
+        if post_text != filepath[-len(post_text):]:
+            # too much logging output comes from this - if verbose is added, this is a good candidate
+#            if logger:
+#                logger.debug("Text at end of filepath does not match template")
+            return None
+
+        # strip off post text from file path
+        filepath = filepath[0:-len(post_text)]
+
+    return filepath
+
+def get_format_and_shift(tag_content, filepath, match_dict, valid_shift, extra_text):
+    """! Extract format and shift information from tag. Raises TypeError if shift keyword
+         is applied to a tag other than valid or if 2 different shift values are found
+         Args:
+             @param tag_content text inside a tag, i.e. valid?fmt=%Y%m%d?shift=30
+             @param filepath rest of filepath to process, i.e. 20190201.ext
+             @param match_dict dictionary to add time info
+             @param valid_shift current numbers of seconds to shift valid time
+             @returns tuple of the length of the formatted time info (i.e. 8 for %Y%m%d) and
+                 valid shift value
+    """
+    fmt_len = 0
+
+    # identifier is time type, i.e. valid, init, lead, etc.
+    # sections is a list of key=values, i.e. fmt=%Y or shift=30
+    identifier, *sections = tag_content.split('?')
+
+    if identifier == 'storm_id':
+        fmt_len = filepath.find(extra_text)
+        if fmt_len < 0:
+            fmt_len = 0
+        return fmt_len, 0
+
+
+    for section in sections:
+        element_name, element_value = section.split('=')
+        if element_name == FORMAT_STRING:
+            fmt_len = get_fmt_info(element_value, filepath,
+                                   match_dict, identifier)
+            if fmt_len is None:
+                return None, None
+            # extract string that corresponds to format
+        elif element_name == SHIFT_STRING:
+            # don't allow shift on any identifier except valid
+            if identifier != VALID_STRING:
+                msg = 'Cannot apply a shift to template ' + \
+                      'item {} when processing inexact '.format(identifier) + \
+                      'times. Only {} is accepted'.format(VALID_STRING)
+                raise TypeError(msg)
+
+            # convert time string (i.e. 3600S, 60M, 1H, etc.) to seconds
+            shift = int(time_util.get_seconds_from_string(element_value, default_unit='S'))
+
+            # if shift has been set before (other than 0) and
+            # this shift differs, raise exception
+            if valid_shift not in (0, shift):
+                raise TypeError('Found multiple shifts for valid time' +
+                                '{} differs from {}'
+                                .format(shift, valid_shift))
+
+            # save valid shift to apply to valid time later
+            valid_shift = shift
+
+    return fmt_len, valid_shift
+
+def get_fmt_info(fmt, filepath, match_dict, identifier):
+    """!Helper function for parse_template. Reads format information from tag and
+        populates dictionary with extracted values.
+        Args:
+            @param fmt formatting values from template tag, i.e. %Y%m%d
+            @param filepath rest of text from filename that can be parsed
+            @param match_dict dictionary of extracted information. Key is made up
+                   of the identifier and the format tag, i.e. init_H or valid_M.
+                   Value is the extracted information, i.e. 19870201
+            @param identifier tag name, i.e. 'init' or 'lead'
+            @returns Number of characters processed from the filename if success,
+                 -1 if failed to parse all format items in template tag"""
+    length = 0
+    # find all items that start with %, i.e. %Y or %3H, %10S, or %.2d
+    # group 1 is optional number, i.e. 3 in %3H or 2 in %.2d
+    # group 2 is letters with extra characters at the end,
+    #  i.e. HH in %HH or S: in %10S:
+    match_list = re.findall(r'%\.?(\d*)([^%]+)', fmt)
+    for match in match_list:
+        # letter identifier for time - may be duplicate letters
+        # i.e. H in %3H or HHH in %HHH or H: in %H: (can have trailing characters)
+        time_letter = match[1][0]
+
+        # optional number for specifying zero padding, i.e. 3 in %3H
+        time_number = match[0]
+
+        # if first letter is not found in time identifier length dictionary
+        if time_letter not in LENGTH_DICT.keys():
+            return None
+
+        # get length of time type
+        new_len = LENGTH_DICT.get(time_letter)
+
+        # find how many times the first letter is found in the time letters
+        # i.e. HHH: should be 3
+        match_len = re.match(r'([' + time_letter + ']+)(.*)', match[1])
+        if not match_len:
+            return None
+
+        # if there are multiple letters, update length if it is more than
+        # the standard length for that time type
+        time_letter_count = len(match_len.group(1))
+        extra_len = len(match_len.group(2))
+        if time_letter_count > 1:
+            # if multiple letters and a number is specifed, i.e. 3HH, then fail
+            if time_number:
+                return None
+
+            new_len = time_letter_count
+
+        # if number was provided and it is different than the
+        # standard length use that number instead
+        elif time_number and int(time_number) != new_len:
+            new_len = int(time_number)
+
+        # if lead or level hours are found
+        if (match[1] == 'H' and
+                (identifier in ('lead', 'level'))):
+            # look forward until non-digit is found
+            new_len = 0
+            while new_len < len(filepath) and filepath[new_len].isdigit():
+                new_len += 1
+
+        # add the length specified plus any additional characters
+        length += new_len + extra_len
+
+        if not add_to_dict(identifier + '+' + time_letter,
+                           match_dict,
+                           filepath,
+                           new_len):
+            return None
+
+        filepath = filepath[new_len+extra_len:]
+
+    return length
+
+def populate_output_dict(match_dict, valid_shift):
+    """! Get all time values in match dictionary to add to the output dictionary
+          Args:
+              @param match_dict dictionary containing matches found with keys named
+              @param valid_shift number of seconds to shift the valid time
+              @returns output dictionary containing the extracted time information
+    """
+    output_dict = {}
+
+    for time_type in [VALID_STRING, INIT_STRING, DA_INIT_STRING]:
+        if time_type == VALID_STRING:
+            time_shift = valid_shift
+        else:
+            time_shift = 0
+
+        add_date_matches_to_output_dict(match_dict, output_dict, time_type, time_shift)
+
+    add_lead_matches_to_output_dict(match_dict, output_dict)
+    add_offset_matches_to_output_dict(match_dict, output_dict)
+
+    extracted_time_info = False
+    for time_type in [VALID_STRING, INIT_STRING, DA_INIT_STRING]:
+        if time_type in output_dict:
+            extracted_time_info = True
+
+    if extracted_time_info:
+        return output_dict
+
+    return None
+
+def add_date_matches_to_output_dict(match_dict, output_dict, time_type, valid_shift=0):
+    """! Look for time values in match dictionary add combine the values to add to the
+         output dictionary. Apply shift value for valid time only.
+         Args:
+             @param match_dict dictionary containing matches found with keys named
+                 'valid+Y','init+m', 'da_init+d', etc. and values are the number of
+                  years, months, hours, etc.
+             @param output_dict time dictionary to set valid, init, or da_init
+             @param time_type type of time item to process. Valid options are:
+                 VALID_STRING, INIT_STRING, or DA_INIT_STRING
+             @param valid_shift amount of time (in seconds) to shift the valid time
+                 Not applicable for any time type besides valid
+    """
+    time_values = {
+        'Y': -1,
+        'y': -1,
+        'm': -1,
+        'd': -1,
+        'j': -1,
+        'H': 0,
+        'M': 0,
+        'b': -1,
+    }
+
+    for key, value in match_dict.items():
+        if key.startswith(time_type):
+            time_values[key.split('+')[1]] = int(value)
+
+    set_output_dict_from_time_info(time_values, output_dict, time_type)
+
+    # shift valid time if applicable
+    if valid_shift:
+        output_dict[time_type] -= datetime.timedelta(seconds=valid_shift)
+
+def add_lead_matches_to_output_dict(match_dict, output_dict):
+    """! Look for forecast lead values in match dictionary add combine the values
+         to add to the output dictionary
+         Args:
+             @param match_dict dictionary containing matches found with keys named
+                 'lead+H','lead+M', or 'lead+S' and values are the number of hours,
+                  minutes, or seconds in the forecast lead
+             @param output_dict time dictionary to set lead
+    """
+    lead = {
+        'H': 0,
+        'M': 0,
+        'S': 0,
+    }
+
+    for key, value in match_dict.items():
+        if key.startswith(LEAD_STRING):
+            lead[key.split('+')[1]] = int(value)
+
+    lead_seconds = lead['H'] * 3600 + lead['M'] * 60 + lead['S']
+    output_dict['lead'] = lead_seconds
+
+def add_offset_matches_to_output_dict(match_dict, output_dict):
+    """! Look for offset value in match dictionary and add the value to the
+         output dictionary
+         Args:
+             @param match_dict dictionary containing matches found with keys named
+                 'offset+H' (only hours are supported for offset) and value is number
+                 of hours in the offset
+             @param output_dict time dictionary to set offset_hours
+    """
+    offset = 0
+
+    for key, value in match_dict.items():
+        if key.startswith(OFFSET_STRING):
+            offset = int(value)
+
+    output_dict['offset_hours'] = offset
+
+def extract_lead(template, filename):
+    new_template = template
+    new_template = new_template.replace('/', '\/').replace('.', '\.')
+    match_tags = re.findall(r'{(.*?)}', new_template)
+    for match_tag in match_tags:
+        if match_tag.split('?') != 'lead':
+            new_template = new_template.replace('{' + match_tag + '}', '.*')

--- a/ush/cam/ush_refs_plot_py/threshold_average.py
+++ b/ush/cam/ush_refs_plot_py/threshold_average.py
@@ -1,0 +1,1299 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          threshold_average.py
+# Contact(s):    Marcel Caron
+# Developed:     Nov. 22, 2021 by Marcel Caron 
+# Last Modified: Dec. 2, 2021 by Marcel Caron             
+# Title:         Line plot of verification metric as a function of 
+#                forecast threshold
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                varying by forecast threshold, which represents the x-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import math
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+from decimal import Decimal
+
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(28.,14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def plot_threshold_average(df: pd.DataFrame, logger: logging.Logger, 
+                      date_range: tuple, model_list: list, num: int = 0, 
+                      level: str = '500', flead='all', thresh: list = ['<20'], 
+                      metric_name: str = 'BCRMSE', 
+                      y_min_limit: float = -10., y_max_limit: float = 10., 
+                      y_lim_lock: bool = False, ylabel: str = '',  
+                      date_type: str = 'VALID', date_hours: list = [0,6,12,18], 
+                      verif_type: str = 'pres', save_dir: str = '.',
+                      requested_var: str = 'HGT', line_type: str = 'SL1L2',
+                      dpi: int = 100, confidence_intervals: bool = False,
+                      interp_pts: list = [],
+                      bs_nrep: int = 5000, bs_method: str = 'MATCHED_PAIRS', 
+                      ci_lev: float = .95, bs_min_samp: int = 30,
+                      eval_period: str = 'TEST', save_header: str = '', 
+                      display_averages: bool = True, 
+                      plot_group: str = 'sfc_upper',
+                      sample_equalization: bool = True,
+                      plot_logo_left: bool = False,
+                      plot_logo_right: bool = False, path_logo_left: str = '.',
+                      path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                      zoom_logo_right: float = 1.):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+   
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    if str(line_type).upper() == 'CTC' and np.array(thresh).size == 0:
+        logger.warning(f"Empty list of thresholds. Continuing onto next"
+                       + f" plot...")
+        logger.info("========================================")
+        return None
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
+            frange_save_phrase = f'{flead[0]}_TO_F{flead[-1]}'
+        frange_string = f'Forecast Hour{frange_phrase}'
+        frange_save_string = f'F{frange_save_phrase}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        frange_string = (f'Forecast Hours {flead[0]:02d}'
+                         + u'\u2013' + f'{flead[1]:02d}')
+        frange_save_string = f'F{flead[0]:02d}-F{flead[1]:02d}'
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        frange_string = f'Forecast Hour {flead:02d}'
+        frange_save_string = f'F{flead:02d}'
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads."
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(intep_pts, np.int):
+            interp_pts_string = f'(Wifth {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    requested_thresh_symbol, requested_thresh_letter = list(
+        zip(*[plot_util.format_thresh(t) for t in thresh])
+    )
+    requested_thresh_value = [float(str(item)[2:]) for item in requested_thresh_letter]
+    symbol_found = False
+    for opt in ['>=', '>', '==','!=','<=', '<']:
+        if any(opt in t for t in requested_thresh_symbol):
+            if all(opt in t for t in requested_thresh_symbol):
+                symbol_found = True
+                break
+            else:
+                e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                    + f" thresholds.")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+    if not symbol_found:
+        e = "FATAL ERROR: None of the requested thresholds contain a valid symbol."
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    
+    df_thresh_symbol, df_thresh_letter = list(
+        zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+    )
+    df['FCST_THRESH_SYMBOL'] = df_thresh_symbol
+    df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_thresh_letter]
+    df = df[df['FCST_THRESH_SYMBOL'].isin(requested_thresh_symbol)]
+    thresholds_removed = (
+        np.array(requested_thresh_symbol)[
+            ~np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+        ]
+    )
+    requested_thresh_symbol = (
+        np.array(requested_thresh_symbol)[
+            np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+        ]
+    )
+    if thresholds_removed.size > 0:
+        thresholds_removed_string = ', '.join(thresholds_removed)
+        if len(thresholds_removed) > 1:
+            warning_string = (f"{thresholds_removed_string} thresholds were"
+                              + f" not found and will not be plotted.")
+        else:
+            warning_string = (f"{thresholds_removed_string} threshold was"
+                              + f" not found and will not be plotted.")
+        logger.warning(warning_string)
+        logger.warning("Continuing ...")
+
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model) 
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    
+    group_by = ['MODEL','FCST_THRESH_VALUE']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    if str(line_type).upper() == 'CTC':
+        df_aggregated = df_groups.sum()
+    else:
+        df_aggregated = df_groups.mean()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    # Remove data if they exist for some but not all models at some value of 
+    # the indep. variable. Otherwise plot_util.calculate_stat will throw an 
+    # error
+    df_split = [df_aggregated.xs(str(model)) for model in model_list]
+    df_reduced = reduce(
+        lambda x,y: pd.merge(
+            x, y, on='FCST_THRESH_VALUE', how='inner'
+        ), 
+        df_split
+    )
+    df_aggregated = df_aggregated[
+        df_aggregated.index.get_level_values('FCST_THRESH_VALUE')
+        .isin(df_reduced.index)
+    ]
+
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    units = df['FCST_UNITS'].tolist()[0]
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'PROB_MXUPHL25_A24_GEHWT':
+        units = 'decimal'
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    coef, const = (None, None)
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        var_long_name_key = df['FCST_VAR'].tolist()[0]
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m', 'gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        if unit_convert:
+            if str(metric_name).upper() in metrics_using_var_units:
+                coef, const = (
+                    reference.unit_conversions[units]['formula'](
+                        None,
+                        return_terms=True
+                    )
+                )
+
+    # Calculate desired metric
+    stat_output = plot_util.calculate_stat(
+        logger, df_aggregated, str(metric_name).lower(), [coef, const]
+    )
+    df_aggregated[str(metric_name).upper()] = stat_output[0]
+    metric_long_name = stat_output[2]
+    if confidence_intervals:
+        ci_output = df_groups.apply(
+            lambda x: plot_util.calculate_bootstrap_ci(
+                logger, bs_method, x, str(metric_name).lower(), bs_nrep,
+                ci_lev, bs_min_samp, [coef, const]
+            )
+        )
+        if any(ci_output['STATUS'] == 1):
+            logger.warning(f"Failed attempt to compute bootstrap"
+                           + f" confidence intervals.  Sample size"
+                           + f" for one or more groups is too small."
+                           + f" Minimum sample size can be changed"
+                           + f" in settings.py.")
+            logger.warning(f"Confidence intervals will not be"
+                           + f" plotted.")
+            confidence_intervals = False
+        else:
+            ci_output = ci_output.reset_index(level=2, drop=True)
+            ci_output = (
+                ci_output
+                .reindex(df_aggregated.index)
+                .reindex(ci_output.index)
+            )
+            df_aggregated[str(metric_name).upper()+'_BLERR'] = ci_output[
+                'CI_LOWER'
+            ].values
+            df_aggregated[str(metric_name).upper()+'_BUERR'] = ci_output[
+                'CI_UPPER'
+            ].values
+
+    df_aggregated[str(metric_name).upper()] = (
+        df_aggregated[str(metric_name).upper()]
+    ).astype(float).tolist()
+
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+
+    pivot_metric = pd.pivot_table(
+        df_aggregated, values=str(metric_name).upper(), columns='MODEL',
+        index='FCST_THRESH_VALUE'
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index='FCST_THRESH_VALUE'
+        )
+    pivot_metric = pivot_metric.dropna()
+    if confidence_intervals:
+        pivot_ci_lower = pd.pivot_table(
+            df_aggregated, values=str(metric_name).upper()+'_BLERR', 
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+        pivot_ci_upper = pd.pivot_table(
+            df_aggregated, values=str(metric_name).upper()+'_BUERR', 
+            columns='MODEL', index='FCST_THRESH_VALUE'
+        )
+    if pivot_metric.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric_name}"
+            + f" stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected = False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model')!=-1):
+                    need_to_rename = models_sharing_colors[
+                        np.flatnonzero(np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1)[0]
+                    ]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model'+str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+
+    # Plot data
+    logger.info("Begin plotting ...")
+
+    if confidence_intervals:
+        indices_in_common = list(set.intersection(*map(
+            set, 
+            [
+                pivot_metric.index, 
+                pivot_ci_lower.index, 
+                pivot_ci_upper.index
+            ]
+        )))
+        pivot_metric = pivot_metric[pivot_metric.index.isin(indices_in_common)]
+        pivot_ci_lower = pivot_ci_lower[pivot_ci_lower.index.isin(indices_in_common)]
+        pivot_ci_upper = pivot_ci_upper[pivot_ci_upper.index.isin(indices_in_common)]
+        if sample_equalization:
+            pivot_counts = pivot_counts[pivot_counts.index.isin(indices_in_common)]
+    units = df['FCST_UNITS'].tolist()[0]
+    x_vals = pivot_metric.index.astype(float).tolist()
+    if unit_convert:
+        x_vals = reference.unit_conversions[units]['formula'](
+            x_vals,
+            rounding=True
+        ) 
+        requested_thresh_value = reference.unit_conversions[units]['formula'](
+            requested_thresh_value,
+            rounding=True
+        )
+    if units == '-':
+        units = ''
+    x_vals_argsort = np.argsort(x_vals)
+    x_vals = np.sort(x_vals)
+    x_vals_incr = np.diff(x_vals)
+    if len(x_vals) > 1:
+        min_incr = np.min(x_vals_incr)
+    else:
+        min_incr = 0
+    incrs = [.05,.1,.5,1.,5.,10.,50.,100.,500.,1E3,5E3,1E4,5E4,1E5,5E5]
+    incr_idx = np.digitize(min_incr, incrs)
+    if incr_idx < 1:
+        incr_idx = 1
+    incr = incrs[incr_idx-1]
+    y_min = y_min_limit
+    y_max = y_max_limit
+    if np.all([val==1 for val in pivot_metric.count(axis=1)]):
+        connect_points = True
+    else:
+        connect_points = False
+    n_mods = 0
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        y_vals_metric = pivot_metric[str(model_list[m])].values
+        y_vals_metric = np.array([y_vals_metric[i] for i in x_vals_argsort])
+        y_vals_metric_mean = np.nanmean(y_vals_metric)
+        if confidence_intervals:
+            y_vals_ci_lower = pivot_ci_lower[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper = pivot_ci_upper[
+                str(model_list[m])
+            ].values
+        if not y_lim_lock:
+            if np.any(y_vals_metric != np.inf):
+                y_vals_metric_min = np.nanmin(y_vals_metric[y_vals_metric != np.inf])
+                y_vals_metric_max = np.nanmax(y_vals_metric[y_vals_metric != np.inf])
+            else:
+                y_vals_metric_min = np.nanmin(y_vals_metric)
+                y_vals_metric_max = np.nanmax(y_vals_metric)
+            if n_mods == 0:
+                y_mod_min = y_vals_metric_min
+                y_mod_max = y_vals_metric_max
+                n_mods+=1
+            else:
+                if math.isinf(y_mod_min):
+                    y_mod_min = y_vals_metric_min
+                else:
+                    y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
+                if math.isinf(y_mod_max):
+                    y_mod_max = y_vals_metric_max
+                else:
+                    y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])
+            if (y_vals_metric_min > y_min_limit 
+                    and y_vals_metric_min <= y_mod_min):
+                y_min = y_vals_metric_min
+            if (y_vals_metric_max < y_max_limit 
+                    and y_vals_metric_max >= y_mod_max):
+                y_max = y_vals_metric_max
+        if display_averages:
+            if np.abs(y_vals_metric_mean) < 1E4:
+                metric_mean_fmt_string = (f'{model_plot_name}'
+                                          + f' ({y_vals_metric_mean:.2f})')
+            else:
+                metric_mean_fmt_string = (f'{model_plot_name}'
+                                          + f' ({y_vals_metric_mean:.2E})')
+        else:
+            metric_mean_fmt_string = f'{model_plot_name}'
+        if connect_points:
+            x_vals_plot = x_vals[~np.isnan(y_vals_metric)]
+            y_vals_plot = y_vals_metric[~np.isnan(y_vals_metric)]
+        else:
+            x_vals_plot = x_vals
+            y_vals_plot = y_vals_metric
+        plt.plot(
+            x_vals_plot, y_vals_plot, 
+            marker='o', c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+            figure=fig, ms=12, ls=mod_setting_dicts[m]['linestyle'], 
+            lw=mod_setting_dicts[m]['linewidth'],
+            label=f'{metric_mean_fmt_string}'
+        )
+        if confidence_intervals:
+            plt.errorbar(
+                x_vals.tolist(), y_vals_metric,
+                yerr=[np.abs(y_vals_ci_lower), y_vals_ci_upper],
+                fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                elinewidth=mod_setting_dicts[m]['linewidth'],
+                capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                alpha=.70, zorder=0
+            )
+    # Zero line
+    plt.axhline(y=0, color='black', linestyle='--', linewidth=1, zorder=0) 
+    metrics_with_axline_at_1 = [
+        'FBIAS','RSD'
+    ]
+    if str(metric_name).upper() in metrics_with_axline_at_1:
+        plt.axhline(y=1, color='black', linestyle='--', linewidth=1, zorder=0)
+
+    # Configure axis ticks
+    if units in reference.unit_conversions:
+        x_vals_incr = reference.unit_conversions[units]['formula'](x_vals)
+        units = reference.unit_conversions[units]['convert_to']
+
+    xticks_min = np.min(x_vals)
+    xticks_max = np.max(x_vals)
+    xlim_min = np.floor(xticks_min/incr)*incr
+    xlim_max = np.ceil(xticks_max/incr)*incr
+    if incr < 1.:
+        precision_scale = 100/incr
+    else:
+        precision_scale = 1.
+    xticks = [
+        x_val for x_val 
+        in np.arange(
+            xlim_min*precision_scale, 
+            xlim_max*precision_scale+incr*precision_scale, 
+            incr*precision_scale
+        )
+    ]
+    xticks=np.divide(xticks,precision_scale)
+    xtick_labels = [f'{opt}{xtick}' for xtick in xticks]
+    number_of_ticks_dig = [25,50,75,100,125,150,175,200]
+    show_xtick_every = np.ceil((
+        np.digitize(len(xtick_labels), number_of_ticks_dig) + 2
+    )/2.)*2
+    xtick_labels_with_blanks = ['' for item in xtick_labels]
+     
+    replace_xticks = [
+        xtick for xtick in xticks 
+        if np.any([
+            np.absolute(xtick-x_val) < incr/2.*show_xtick_every 
+            for x_val in x_vals.tolist()
+        ])
+    ]
+    res_xticks = [val for val in xticks if val not in replace_xticks]
+    res_xlabels = [
+        xtick_labels_with_blanks[v] if val not in replace_xticks
+        else '' for v, val in enumerate(xticks)  
+    ]
+    add_labels = [
+        f'{opt}{np.round(x_val)/precision_scale}' for x_val in x_vals*precision_scale
+    ]
+    xticks_argsort = np.argsort(np.concatenate((xticks, x_vals.tolist())))
+    xticks = np.concatenate((
+        xticks, x_vals.tolist()
+    ))[xticks_argsort]
+    xtick_labels_with_blanks = np.concatenate((
+        res_xlabels, add_labels
+    ))[xticks_argsort]
+    res_diff = np.diff(
+        [xtick for x, xtick in enumerate(xticks) if xtick_labels_with_blanks[x]]
+    )
+    arg_xtick_labels = [
+        i for i, lab in enumerate(xtick_labels_with_blanks) if lab
+    ]
+    for i, d in enumerate(res_diff):
+        if d < (incr/2.*show_xtick_every):
+            xtick_labels_with_blanks[arg_xtick_labels[i+1]] = ''
+
+    x_buffer_size = .015
+    ax.set_xlim(
+        xlim_min-incr*x_buffer_size, xlim_max+incr*x_buffer_size
+    )
+    y_range_categories = np.array([
+        [np.power(10.,y), 2.*np.power(10.,y)] 
+        for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+    ]).flatten()
+    round_to_nearest_categories = y_range_categories/20.
+    if math.isinf(y_min):
+        y_min = y_min_limit
+    if math.isinf(y_max):
+        y_max = y_max_limit
+    y_range = y_max-y_min
+    round_to_nearest =  round_to_nearest_categories[
+        np.digitize(y_range, y_range_categories[:-1])
+    ]
+    ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
+    ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
+    if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
+        ylim_min = float(
+            np.format_float_scientific(ylim_min, unique=False, precision=3)
+        )
+    yticks = np.arange(ylim_min, ylim_max+round_to_nearest, round_to_nearest)
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    if str(metric_name).upper() in metrics_using_var_units:
+        if units:
+            ylabel = f'{var_long_name} ({units})'
+        else:
+            ylabel = f'{var_long_name} (unitless)'
+    else:       
+        ylabel = f'{metric_long_name}'
+    ax.set_ylim(ylim_min, ylim_max)
+    ax.set_ylabel(ylabel)
+    if units:
+        ax.set_xlabel(f'Forecast Threshold ({units})') 
+    else:
+        ax.set_xlabel(f'Forecast Threshold (unitless)')
+    ax.set_xticklabels(xtick_labels_with_blanks)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', axis='y', pad=15
+    )
+    majticks = [i for i, item in enumerate(xtick_labels_with_blanks) if item]
+    for mt in majticks:
+        ax.xaxis.get_major_ticks()[mt].tick1line.set_markersize(8)
+    ax.legend(
+        loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=4, frameon=True, numpoints=2, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    fig.subplots_adjust(bottom=.15, wspace=0, hspace=0)
+    fig.subplots_adjust(top=0.85)
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.5, linestyle='--', 
+        linewidth=.5, zorder=0
+    )
+
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        for count, xval in zip(counts, x_vals.tolist()):
+            if not isinstance(count, str):
+                count = str(int(count))
+            ax.annotate(
+                f'{count}', xy=(xval,1.),
+                xycoords=('data','axes fraction'), xytext=(0,18),
+                textcoords='offset points', va='top', fontsize=16,
+                color='dimgrey', ha='center'
+            )
+        ax.annotate(
+            '#SAMPLES', xy=(0.,1.), xycoords='axes fraction',
+            xytext=(-50, 21), textcoords='offset points', va='top',
+            fontsize=11, color='dimgrey', ha='center'
+        )
+        fig.subplots_adjust(top=.85)
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    metric_string = metric_long_name
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = ''
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = ''
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'ML'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level_num}MB_'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'SB'
+        else:
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['sfc', 'conus_sfc', 'polar_sfc', 'mrms','metar']:
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = ''
+                else:
+                    level_string = 'Surface '
+                    level_savename = 'SFC_'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM_'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level_num}M_'
+        elif 'L' in str(level) or 'A' in str(level):
+            level_string = ''
+            level_savename = ''
+
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}_'
+    elif str(verif_type).lower() in ['ccpa']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'{level_num}H_'
+        else:
+            level_string = f''
+            level_savename = f''
+    else:
+        level_string = f'{level} '
+        level_savename = f'{level}_'
+    title1 = f'{metric_string}'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    if units:
+        title2 = f'{level_string}{var_long_name} ({units}), {domain_string}'
+    else:
+        title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}, {frange_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    if sample_equalization:
+        title_pad=30
+    else:
+        title_pad=None
+    ax.set_title(title_center, loc=plotter.title_loc, pad=title_pad) 
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction',
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.), xycoords='axes fraction',
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'threshold_average_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(level_savename).lower()}'
+                 + f'{str(var_savename).lower()}_{str(metric_name).lower()}')
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    save_name+=f'_{str(frange_save_string).lower()}'
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: Ignored for series by threshold")
+    logger.debug(f"X_MAX_LIMIT: Ignored for series by threshold")
+    logger.debug(f"X_LIM_LOCK: Ignored for series by threshold")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    metrics = METRICS
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    if (str(INTERP).upper()
+           not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    for metric in metrics:
+        if (str(metric).lower()
+                not in case_specs['plot_stats_list']
+                .replace(' ','').split(',')):
+            e = (f"FATAL ERROR: The requested metric is not valid for the"
+                 + f" requested case type ({VERIF_CASETYPE}) and"
+                 + f" line_type ({LINE_TYPE}): {metric}")
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e+"\nQuitting ...")
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds'] 
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds'] 
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for l, fcst_level in enumerate(FCST_LEVELS):
+            if len(FCST_LEVELS) != len(OBS_LEVELS):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+            if (FCST_LEVELS[l] not in var_specs['fcst_var_levels'] 
+                    or OBS_LEVELS[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid:"
+                     + f" {requested_var}/{fcst_level}")
+                logger.warning(e)
+                logger.warning("Continuing ...")
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the requested"
+                         + f" case type ({VERIF_CASETYPE}) and line_type"
+                         + f" ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, VERIF_TYPE, 
+                    LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, date_hours, 
+                    FLEADS, requested_var, fcst_var_names, obs_var_names, MODELS, 
+                    domain, INTERP, MET_VERSION, clear_prune_dir
+                )
+                if df is None:
+                    continue
+                for metric in metrics:
+                    if (str(metric).lower()
+                            not in case_specs['plot_stats_list']
+                            .replace(' ','').split(',')):
+                        e = (f"The requested metric is not valid for the"
+                             + f" requested case type ({VERIF_CASETYPE}) and"
+                             + f" line_type ({LINE_TYPE}): {metric}")
+                        logger.warning(e)
+                        logger.warning("Continuing ...")
+                        continue
+                    df_metric = df
+                    plot_threshold_average(
+                        df_metric, logger, date_range, MODELS, num=num, 
+                        flead=FLEADS, level=fcst_level, thresh=fcst_thresh, 
+                        metric_name=metric, date_type=DATE_TYPE, 
+                        y_min_limit=Y_MIN_LIMIT, y_max_limit=Y_MAX_LIMIT, 
+                        y_lim_lock=Y_LIM_LOCK, ylabel='Metric (unitless)', 
+                        line_type=LINE_TYPE, verif_type=VERIF_TYPE, 
+                        date_hours=date_hours, save_dir=SAVE_DIR, 
+                        eval_period=EVAL_PERIOD,
+                        display_averages=display_averages, 
+                        save_header=URL_HEADER, plot_group=plot_group,
+                        confidence_intervals=CONFIDENCE_INTERVALS, 
+                        interp_pts=INTERP_PNTS,
+                        bs_nrep=bs_nrep, bs_method=bs_method, ci_lev=ci_lev,
+                        bs_min_samp=bs_min_samp,
+                        sample_equalization=sample_equalization,
+                        plot_logo_left=plot_logo_left,
+                        plot_logo_right=plot_logo_right,
+                        path_logo_left=path_logo_left,
+                        path_logo_right=path_logo_right,
+                        zoom_logo_left=zoom_logo_left,
+                        zoom_logo_right=zoom_logo_right
+                    )
+                    num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = check_STATS(os.environ['STATS']).replace(' ','').split(',')
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+
+
+    # Still need to configure CIs (doesn't work yet)
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    bs_method = toggle.plot_settings['bs_method']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove
+    # samples used to aggregate each statistic if the samples are not shared
+    # by all models.  Required to display sample sizes
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    FCST_LEVELS = [str(level) for level in FCST_LEVELS]
+    OBS_LEVELS = [str(level) for level in OBS_LEVELS]
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/time_series.py
+++ b/ush/cam/ush_refs_plot_py/time_series.py
@@ -1,0 +1,1544 @@
+#! /usr/bin/env python3
+
+###############################################################################
+#
+# Name:          time_series.py
+# Contact(s):    Marcel Caron
+# Developed:     Oct. 14, 2021 by Marcel Caron 
+# Last Modified: Nov. 28, 2022 by Marcel Caron             
+# Title:         Line plot of verification metric as a function of 
+#                valid or init time
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                varying by valid or init time, which represents the x-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+
+import os
+import sys
+import numpy as np
+import math
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter(fig_size=(28.,14.))
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def daterange(start: datetime, end: datetime, td: td) -> datetime:
+    curr = start
+    while curr <= end:
+        yield curr
+        curr+=td
+
+def plot_time_series(df: pd.DataFrame, logger: logging.Logger, 
+                     date_range: tuple, model_list: list, num: int = 0, 
+                     level: str = '500', flead='all', thresh: list = ['<20'], 
+                     metric1_name: str = 'BCRMSE', metric2_name: str = 'BIAS',
+                     y_min_limit: float = -10., y_max_limit: float = 10., 
+                     y_lim_lock: bool = False,
+                     xlabel: str = 'Valid Date', date_type: str = 'VALID', 
+                     date_hours: list = [0,6,12,18], verif_type: str = 'pres', 
+                     save_dir: str = '.', requested_var: str = 'HGT', 
+                     line_type: str = 'SL1L2', dpi: int = 100, 
+                     confidence_intervals: bool = False, interp_pts: list = [],
+                     bs_nrep: int = 5000, bs_method: str = 'MATCHED_PAIRS',
+                     ci_lev: float = .95, bs_min_samp: int = 30,
+                     eval_period: str = 'TEST', save_header='', 
+                     display_averages: bool = True, 
+                     keep_shared_events_only: bool = False,
+                     plot_group: str = 'sfc_upper',
+                     sample_equalization: bool = True,
+                     plot_logo_left: bool = False,
+                     plot_logo_right: bool = False, path_logo_left: str = '.',
+                     path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                     zoom_logo_right: float = 1.):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+   
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([str(f) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
+            frange_save_phrase = f'{flead[0]}_TO_F{flead[-1]}'
+        frange_string = f'Forecast Hour{frange_phrase}'
+        frange_save_string = f'F{frange_save_phrase}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        frange_string = (f'Forecast Hours {flead[0]:02d}'
+                         + u'\u2013' + f'{flead[1]:02d}')
+        frange_save_string = f'F{flead[0]:02d}-F{flead[1]:02d}'
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        frange_string = f'Forecast Hour {flead:02d}'
+        frange_save_string = f'F{flead:02d}'
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        error_string = (
+            f"FATAL ERROR: Invalid forecast lead: \'{flead}\'\nPlease check settings for"
+            + f" forecast leads."
+        )
+        logger.error(error_string)
+        raise ValueError(error_string)
+
+    # Remove from date_hours the valid/init hours that don't exist in the 
+    # dataframe
+    date_hours = np.array(date_hours)[[
+        str(x) in df[str(date_type).upper()].dt.hour.astype(str).tolist() 
+        for x in date_hours
+    ]]
+    
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name"
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(interp_pts, np.int):
+            interp_pts_string = f'(Width {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+    
+    if thresh and '' not in thresh:
+        requested_thresh_symbol, requested_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_thresh_symbol):
+                if all(opt in t for t in requested_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e+"\nQuitting ...")
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e+"\nQuitting ...")
+        df_thresh_symbol, df_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+        )
+        df['FCST_THRESH_SYMBOL'] = df_thresh_symbol
+        df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_thresh_letter]
+        requested_thresh_value = [
+            str(item)[2:] for item in requested_thresh_letter
+        ]
+        df = df[df['FCST_THRESH_SYMBOL'].isin(requested_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_thresh_symbol)[
+                ~np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        requested_thresh_symbol = (
+            np.array(requested_thresh_symbol)[
+                np.isin(requested_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+    
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model) 
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        logger.warning(
+            f"{models_removed_string} data were not found and will not be"
+            + f" plotted."
+        )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL',str(date_type).upper()]
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    if str(line_type).upper() == 'CTC':
+        df_aggregated = df_groups.sum()
+    else:
+        df_aggregated = df_groups.mean()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    if keep_shared_events_only:
+        # Remove data if they exist for some but not all models at some value of 
+        # the indep. variable. Otherwise plot_util.calculate_stat will throw an 
+        # error
+        df_split = [
+            df_aggregated.xs(str(model)) for model in model_list
+        ]
+        df_reduced = reduce(
+            lambda x,y: pd.merge(
+                x, y, on=str(date_type).upper(), how='inner'
+            ), 
+            df_split
+        )
+    
+        df_aggregated = df_aggregated[
+            df_aggregated.index.get_level_values(str(date_type).upper())
+            .isin(df_reduced.index)
+        ]
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    units = df['FCST_UNITS'].tolist()[0]
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR','SPREAD',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    coef, const = (None, None)
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        var_long_name_key = df['FCST_VAR'].tolist()[0]
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m','gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif str(var_long_name_key).upper() == 'TMP' and level[0] == 'P':
+            unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        if unit_convert:
+            if metric2_name is not None:
+                if (str(metric1_name).upper() in metrics_using_var_units
+                        and str(metric2_name).upper() in metrics_using_var_units):
+                    coef, const = (
+                        reference.unit_conversions[units]['formula'](
+                            None,
+                            return_terms=True
+                        )
+                    )
+            elif str(metric1_name).upper() in metrics_using_var_units:
+                coef, const = (
+                    reference.unit_conversions[units]['formula'](
+                        None,
+                        return_terms=True
+                    )
+                )
+    # Calculate desired metric
+    metric_long_names = []
+    for stat in [metric1_name, metric2_name]:
+        if stat:
+            stat_output = plot_util.calculate_stat(
+                logger, df_aggregated, str(stat).lower(), [coef, const]
+            )
+            df_aggregated[str(stat).upper()] = stat_output[0]
+            metric_long_names.append(stat_output[2])
+            '''if confidence_intervals:
+                logger.warning(
+                    f"Confidence intervals are turned on but are not currently"
+                    + f" allowed on time series plots. None will be plotted"
+                    + f" for {str(stat).upper()}."
+                )
+                confidence_intervals = False
+            # Remove the above section to re-enable CIs for time series''' 
+            if confidence_intervals:
+                ci_output = df_groups.apply(
+                    lambda x: plot_util.calculate_bootstrap_ci(
+                        logger, bs_method, x, str(stat).lower(), bs_nrep,
+                        ci_lev, bs_min_samp, [coef, const]
+                    )
+                )
+                if any(ci_output['STATUS'] == 1):
+                    logger.warning(f"Failed attempt to compute bootstrap"
+                                   + f" confidence intervals.  Sample size"
+                                   + f" for one or more groups is too small."
+                                   + f" Minimum sample size can be changed"
+                                   + f" in settings.py.")
+                    logger.warning(f"Confidence intervals will not be"
+                                   + f" plotted.")
+                    confidence_intervals = False
+                    continue
+                ci_output = ci_output.reset_index(level=2, drop=True)
+                ci_output = (
+                    ci_output
+                    .reindex(df_aggregated.index)
+                    .reindex(ci_output.index)
+                )
+                df_aggregated[str(stat).upper()+'_BLERR'] = ci_output[
+                    'CI_LOWER'
+                ].values
+                df_aggregated[str(stat).upper()+'_BUERR'] = ci_output[
+                    'CI_UPPER'
+                ].values
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    if metric2_name is not None:
+        df_aggregated[str(metric2_name).upper()] = (
+            df_aggregated[str(metric2_name).upper()]
+        ).astype(float).tolist()
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index=str(date_type).upper(), dropna=False
+    )
+    if sample_equalization:
+        pivot_counts = pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index=str(date_type).upper()
+        )
+    if keep_shared_events_only:
+        pivot_metric1 = pivot_metric1.dropna() 
+    if metric2_name is not None:
+        pivot_metric2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+            index=str(date_type).upper(), dropna=False
+        )
+        if keep_shared_events_only:
+            pivot_metric2 = pivot_metric2.dropna()
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index=str(date_type).upper()
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index=str(date_type).upper()
+        )
+        if metric2_name is not None:
+            pivot_ci_lower2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+                columns='MODEL', index=str(date_type).upper()
+            )
+            pivot_ci_upper2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+                columns='MODEL', index=str(date_type).upper()
+            )
+    # Reindex pivot table with full list of dates, introducing NaNs 
+    date_hours_incr = np.diff(date_hours)
+    if date_hours_incr.size == 0:
+        min_incr = 24
+    else:
+        min_incr = np.min(date_hours_incr)
+    incrs = [1,6,12,24]
+    incr_idx = np.digitize(min_incr, incrs)
+    if incr_idx < 1:
+        incr_idx = 1
+    incr = incrs[incr_idx-1]
+    idx = [
+        item 
+        for item in daterange(
+            date_range[0].replace(hour=np.min(date_hours)), 
+            date_range[1].replace(hour=np.max(date_hours)), 
+            td(hours=incr)
+        )
+    ]
+    pivot_metric1 = pivot_metric1.reindex(idx, fill_value=np.nan)
+    if sample_equalization:
+        pivot_counts = pivot_counts.reindex(idx, fill_value=np.nan)
+    if confidence_intervals:
+        pivot_ci_lower1 = pivot_ci_lower1.reindex(idx, fill_value=np.nan)
+        pivot_ci_upper1 = pivot_ci_upper1.reindex(idx, fill_value=np.nan)
+    if metric2_name is not None:
+        pivot_metric2 = pivot_metric2.reindex(idx, fill_value=np.nan)
+        if confidence_intervals:
+            pivot_ci_lower2 = pivot_ci_lower2.reindex(idx, fill_value=np.nan)
+            pivot_ci_upper2 = pivot_ci_upper2.reindex(idx, fill_value=np.nan)
+    if (metric2_name and (pivot_metric1.empty or pivot_metric2.empty)):
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    elif not metric2_name and pivot_metric1.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name}"
+            + f" stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected=False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model')!=-1):
+                    need_to_rename = models_sharing_colors[np.flatnonzero(
+                        np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1)[0]
+                    ]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model'+str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+
+    # Plot data
+    logger.info("Begin plotting ...")
+    if confidence_intervals:
+        indices_in_common1 = list(set.intersection(*map(
+            set, 
+            [
+                pivot_metric1.index, 
+                pivot_ci_lower1.index, 
+                pivot_ci_upper1.index
+            ]
+        )))
+        pivot_metric1 = pivot_metric1[pivot_metric1.index.isin(indices_in_common1)]
+        pivot_ci_lower1 = pivot_ci_lower1[pivot_ci_lower1.index.isin(indices_in_common1)]
+        pivot_ci_upper1 = pivot_ci_upper1[pivot_ci_upper1.index.isin(indices_in_common1)]
+        if sample_equalization:
+            pivot_counts = pivot_counts[pivot_counts.index.isin(indices_in_common1)]
+        if metric2_name is not None:
+            indices_in_common2 = list(set.intersection(*map(
+                set, 
+                [
+                    pivot_metric2.index, 
+                    pivot_ci_lower2.index, 
+                    pivot_ci_upper2.index
+                ]
+            )))
+            pivot_metric2 = pivot_metric2[pivot_metric2.index.isin(indices_in_common2)]
+            pivot_ci_lower2 = pivot_ci_lower2[pivot_ci_lower2.index.isin(indices_in_common2)]
+            pivot_ci_upper2 = pivot_ci_upper2[pivot_ci_upper2.index.isin(indices_in_common2)]
+    x_vals1 = pivot_metric1.index
+    if metric2_name is not None:
+        x_vals2 = pivot_metric2.index
+    y_min = y_min_limit
+    y_max = y_max_limit
+    if thresh and '' not in thresh:
+        thresh_labels = np.unique(df['FCST_THRESH_VALUE'])
+        thresh_argsort = np.argsort(thresh_labels.astype(float))
+        requested_thresh_argsort = np.argsort([
+            float(item) for item in requested_thresh_value
+        ])
+        thresh_labels = [thresh_labels[i] for i in thresh_argsort]
+        requested_thresh_labels = [
+            requested_thresh_value[i] for i in requested_thresh_argsort
+        ]
+    plot_reference = [False, False]
+    ref_metrics = ['OBAR']
+    if str(metric1_name).upper() in ref_metrics:
+        plot_reference[0] = True
+        pivot_reference1 = pivot_metric1
+        reference1 = pivot_reference1.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower1 = pivot_ci_lower1.mean(axis=1)
+            reference_ci_upper1 = pivot_ci_upper1.mean(axis=1)
+        if not np.any((pivot_reference1.T/reference1).T == 1.):
+            logger.warning(
+                f"{str(metric1_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[0] = False
+    if metric2_name is not None and str(metric2_name).upper() in ref_metrics:
+        plot_reference[1] = True
+        pivot_reference2 = pivot_metric2
+        reference2 = pivot_reference2.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower2 = pivot_ci_lower2.mean(axis=1)
+            reference_ci_upper2 = pivot_ci_upper2.mean(axis=1)
+        if not np.any((pivot_reference2.T/reference2).T == 1.):
+            logger.warning(
+                f"{str(metric2_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[1] = False
+    if np.any(plot_reference):
+        plotted_reference = [False, False]
+        if confidence_intervals:
+            plotted_reference_CIs = [False, False]
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms
+    )[0]
+    if metric2_name is not None:
+        if np.any(plot_reference):
+            ref_color_dict = model_colors.get_color_dict('obs')
+            handles = []
+            labels = []
+            line_settings = ['solid','dashed']
+            metric_names = [metric1_name, metric2_name]
+            for p, rbool in enumerate(plot_reference):
+                if rbool:
+                    handles += [
+                        f('', ref_color_dict['color'], line_settings[p], 5., 0, 'white')
+                    ]
+                else:
+                    handles += [
+                        f('', 'black', line_settings[p], 5., 0, 'white')
+                    ]
+                labels += [
+                    str(metric_names[p]).upper()
+                ]
+        else:
+            handles = [
+                f('', 'black', line_setting, 5., 0, 'white')
+                for line_setting in ['solid','dashed']
+            ]
+            labels = [
+                str(metric_name).upper()
+                for metric_name in [metric1_name, metric2_name]
+            ]
+    else:
+        handles = []
+        labels = []
+    n_mods = 0
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        y_vals_metric1 = pivot_metric1[str(model_list[m])].values
+        y_vals_metric1_mean = np.nanmean(y_vals_metric1)
+        if metric2_name is not None:
+            y_vals_metric2 = pivot_metric2[str(model_list[m])].values
+            y_vals_metric2_mean = np.nanmean(y_vals_metric2)
+        if confidence_intervals:
+            y_vals_ci_lower1 = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper1 = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            if metric2_name is not None:
+                y_vals_ci_lower2 = pivot_ci_lower2[
+                    str(model_list[m])
+                ].values
+                y_vals_ci_upper2 = pivot_ci_upper2[
+                    str(model_list[m])
+                ].values
+        if not y_lim_lock:
+            if metric2_name is not None:
+                y_vals_both_metrics = np.concatenate((y_vals_metric1, y_vals_metric2))
+                if np.any(y_vals_both_metrics != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics)
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics)
+            else:
+                if np.any(y_vals_metric1 != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_metric1[y_vals_metric1 != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_metric1[y_vals_metric1 != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_metric1)
+                    y_vals_metric_max = np.nanmax(y_vals_metric1)
+            if n_mods == 0:
+                y_mod_min = y_vals_metric_min
+                y_mod_max = y_vals_metric_max
+                counts = pivot_counts[str(model_list[m])].values
+                n_mods+=1
+            else:
+                if math.isinf(y_mod_min):
+                    y_mod_min = y_vals_metric_min
+                else:
+                    y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
+                if math.isinf(y_mod_max):
+                    y_mod_max = y_vals_metric_max
+                else:
+                    y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])
+            if (y_vals_metric_min > y_min_limit 
+                    and y_vals_metric_min <= y_mod_min):
+                y_min = y_vals_metric_min
+            if (y_vals_metric_max < y_max_limit 
+                    and y_vals_metric_max >= y_mod_max):
+                y_max = y_vals_metric_max
+        if np.abs(y_vals_metric1_mean) < 1E4:
+            metric1_mean_fmt_string = f'{y_vals_metric1_mean:.2f}'
+        else:
+            metric1_mean_fmt_string = f'{y_vals_metric1_mean:.2E}'
+        if plot_reference[0]:
+            if not plotted_reference[0]:
+                ref_color_dict = model_colors.get_color_dict('obs')
+                plt.plot(
+                    x_vals1.tolist(), reference1,
+                    marker=ref_color_dict['marker'],
+                    c=ref_color_dict['color'], mew=2., mec='white',
+                    figure=fig, ms=ref_color_dict['markersize'], ls='solid',
+                    lw=ref_color_dict['linewidth']
+                )
+                plotted_reference[0] = True
+        else:
+            plt.plot(
+                x_vals1.tolist(), y_vals_metric1, 
+                marker=mod_setting_dicts[m]['marker'], 
+                c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='solid', 
+                lw=mod_setting_dicts[m]['linewidth']
+            )
+        if metric2_name is not None:
+            if np.abs(y_vals_metric2_mean) < 1E4:
+                metric2_mean_fmt_string = f'{y_vals_metric2_mean:.2f}'
+            else:
+                metric2_mean_fmt_string = f'{y_vals_metric2_mean:.2E}'
+            if plot_reference[1]:
+                if not plotted_reference[1]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.plot(
+                        x_vals2.tolist(), reference2,
+                        marker=ref_color_dict['marker'],
+                        c=ref_color_dict['color'], mew=2., mec='white',
+                        figure=fig, ms=ref_color_dict['markersize'], ls='dashed',
+                        lw=ref_color_dict['linewidth']
+                    )
+                    plotted_reference[1] = True
+            else:
+                plt.plot(
+                    x_vals2.tolist(), y_vals_metric2, 
+                    marker=mod_setting_dicts[m]['marker'], 
+                    c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                    figure=fig, ms=mod_setting_dicts[m]['markersize'], 
+                    ls='dashed', lw=mod_setting_dicts[m]['linewidth']
+                )
+        if confidence_intervals:
+            if plot_reference[0]:
+                if not plotted_reference_CIs[0]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.errorbar(
+                        x_vals1.tolist(), reference1,
+                        yerr=[np.abs(reference_ci_lower1), reference_ci_upper1],
+                        fmt='none', ecolor=ref_color_dict['color'],
+                        elinewidth=ref_color_dict['linewidth'],
+                        capsize=10., capthick=ref_color_dict['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+                    plotted_reference_CIs[0] = True
+            else:
+                plt.errorbar(
+                    x_vals1.tolist(), y_vals_metric1,
+                    yerr=[np.abs(y_vals_ci_lower1), y_vals_ci_upper1],
+                    fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                    elinewidth=mod_setting_dicts[m]['linewidth'],
+                    capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                    alpha=.70, zorder=0
+                )
+            if metric2_name is not None:
+                if plot_reference[1]:
+                    if not plotted_reference_CIs[1]:
+                        ref_color_dict = model_colors.get_color_dict('obs')
+                        plt.errorbar(
+                            x_vals2.tolist(), reference2,
+                            yerr=[np.abs(reference_ci_lower2), reference_ci_upper2],
+                            fmt='none', ecolor=ref_color_dict['color'],
+                            elinewidth=ref_color_dict['linewidth'],
+                            capsize=10., capthick=ref_color_dict['linewidth'],
+                            alpha=.70, zorder=0
+                        )
+                        plotted_reference_CIs[1] = True
+                else:
+                    plt.errorbar(
+                        x_vals2.tolist(), y_vals_metric2,
+                        yerr=[np.abs(y_vals_ci_lower2), y_vals_ci_upper2],
+                        fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                        elinewidth=mod_setting_dicts[m]['linewidth'],
+                        capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+        handles+=[
+            f(
+                mod_setting_dicts[m]['marker'], mod_setting_dicts[m]['color'],
+                'solid', mod_setting_dicts[m]['linewidth'], 
+                mod_setting_dicts[m]['markersize'], 'white'
+            )
+        ]
+        if display_averages:
+            if metric2_name is not None:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string},'
+                    + f' {metric2_mean_fmt_string})'
+                ]
+            else:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string})'
+                ]
+        else:
+            labels+=[f'{model_plot_name}']
+
+    # Zero line
+    plt.axhline(y=0, color='black', linestyle='--', linewidth=1, zorder=0) 
+
+    # Configure axis ticks
+    xticks = [
+        x_val for x_val in daterange(x_vals1[0], x_vals1[-1], td(hours=incr))
+    ] 
+    xtick_labels = [xtick.strftime('%HZ %m/%d') for xtick in xticks]
+    number_of_ticks_dig = [15,30,45,60,75,90,105,120,135,150,165,180,195,210,225]
+    show_xtick_every = np.ceil((
+        np.digitize(len(xtick_labels), number_of_ticks_dig) + 2
+    )/2.)*2
+    xtick_labels_with_blanks = ['' for item in xtick_labels]
+    for i, item in enumerate(xtick_labels[::int(show_xtick_every)]):
+         xtick_labels_with_blanks[int(show_xtick_every)*i] = item
+    y_range_categories = np.array([
+        [np.power(10.,y), 2.*np.power(10.,y)] 
+        for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+    ]).flatten()
+    round_to_nearest_categories = y_range_categories/20.
+    y_range = y_max-y_min
+    round_to_nearest =  round_to_nearest_categories[
+        np.digitize(y_range, y_range_categories[:-1])
+    ]
+    ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
+    ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
+    if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
+        ylim_min = float(
+            np.format_float_scientific(ylim_min, unique=False, precision=3)
+        )
+    yticks = np.arange(ylim_min, ylim_max+round_to_nearest, round_to_nearest)
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    if unit_convert:
+        if thresh and '' not in thresh:
+            thresh_labels = [float(tlab) for tlab in thresh_labels]
+            thresh_labels = reference.unit_conversions[units]['formula'](
+                thresh_labels,
+                rounding=True
+            )
+            thresh_labels = [str(tlab) for tlab in thresh_labels]
+        units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    if metric2_name is not None:
+        metric1_string, metric2_string = metric_long_names
+        if (str(metric1_name).upper() in metrics_using_var_units
+                and str(metric2_name).upper() in metrics_using_var_units):
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string} and {metric2_string}'
+    else:
+        metric1_string = metric_long_names[0]
+        if str(metric1_name).upper() in metrics_using_var_units:
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string}'
+    ax.set_xlim(xticks[0], xticks[-1])
+    ax.set_ylim(ylim_min, ylim_max)
+    ax.set_ylabel(ylabel)
+    ax.set_xlabel(xlabel)
+    ax.set_xticklabels(xtick_labels_with_blanks)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', axis='y', pad=15
+    )
+    majticks = [i for i, item in enumerate(xtick_labels_with_blanks) if item]
+    for mt in majticks:
+        ax.xaxis.get_major_ticks()[mt].tick1line.set_markersize(8)
+
+    ax.legend(
+        handles, labels, loc='upper center', fontsize=15, framealpha=1, 
+        bbox_to_anchor=(0.5, -0.08), ncol=4, frameon=True, numpoints=2, 
+        borderpad=.8, labelspacing=2., columnspacing=3., handlelength=3., 
+        handletextpad=.4, borderaxespad=.5) 
+    fig.subplots_adjust(bottom=.15, wspace=0, hspace=0)
+    fig.subplots_adjust(top=0.85)
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.5, linestyle='--', 
+        linewidth=.5, zorder=0
+    )
+    
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        for count, xval in zip(counts, x_vals1.tolist()):
+            if not isinstance(count, str):
+                count = str(int(count))
+            ax.annotate(
+                f'{count}', xy=(xval,1.), 
+                xycoords=('data','axes fraction'), xytext=(0,18), 
+                textcoords='offset points', va='top', fontsize=16, 
+                color='dimgrey', ha='center'
+            )
+        ax.annotate(
+            '#SAMPLES', xy=(0.,1.), xycoords='axes fraction', 
+            xytext=(-50, 21), textcoords='offset points', va='top', 
+            fontsize=11, color='dimgrey', ha='center'
+        )
+        #fig.subplots_adjust(top=.9)
+        fig.subplots_adjust(top=.85)
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]
+    else:
+        domain_string = domain
+    '''
+    date_hours_string = ' '.join([
+        f'{date_hour:02d}Z,' for date_hour in date_hours
+    ])
+    '''
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = ''
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = ''
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'ML'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level_num}MB_'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'SB'
+        else:
+            level_string = ''
+            level_savename = ''
+    elif str(verif_type).lower() in ['sfc', 'conus_sfc', 'polar_sfc', 'metar', 'anom', 'pres']:
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = ''
+                else:
+                    level_string = 'Surface '
+                    level_savename = 'SFC_'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM_'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level_num}M_'
+        elif 'L' in str(level) or 'A' in str(level):
+            level_string = ''
+            level_savename = ''
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}_'
+    elif str(verif_type).lower() in ['ccpa']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'{level_num}H_'
+        else:
+            level_string = f''
+            level_savename = f''
+    else:
+        level_string = f'{level}'
+        level_savename = f'{level}_'
+    if var_savename == 'ICEC_Z0_mean':
+        level_string = ''
+    if var_savename == 'TMP_Z0_mean':
+        level_string = 'Sea Surface '
+    if metric2_name is not None:
+        title1 = f'{metric1_string} and {metric2_string}'
+    else:
+        title1 = f'{metric1_string}'
+    if metric1_string == 'Brier Score':
+        thresh = ''
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    if thresh and '' not in thresh:
+        thresholds_phrase = ', '.join([
+            f'{opt}{thresh_label}' for thresh_label in thresh_labels
+        ])
+        thresholds_save_phrase = ''.join([
+            f'{opt_letter}{thresh_label}' 
+            for thresh_label in requested_thresh_labels
+        ])
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({thresholds_phrase}'
+                      + f' {units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({thresholds_phrase}'
+                      + f' unitless), {domain_string}')
+    else:
+        if units:
+            title2 = f'{level_string}{var_long_name} ({units}), {domain_string}'
+        else:
+            title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}, {frange_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    if sample_equalization:
+        #title_pad=40
+        title_pad=30
+    else:
+        title_pad=None
+    ax.set_title(title_center, loc=plotter.title_loc, pad=title_pad) 
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction',
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.), xycoords='axes fraction',
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+    save_name = (f'time_series_regional_'
+                 + f'{str(domain).lower()}_{str(date_type).lower()}_'
+                 + f'{str(date_hours_savename).lower()}_'
+                 + f'{str(level_savename).lower()}'
+                 + f'{str(var_savename).lower()}_{str(metric1_name).lower()}')
+    if metric2_name is not None:
+        save_name+=f'_{str(metric2_name).lower()}'
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    save_name+=f'_{str(frange_save_string).lower()}'
+    if thresh and '' not in thresh:
+        save_name+=f'_{str(thresholds_save_phrase).lower()}'
+    if save_header:
+        save_name = f'{save_header}_'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_METPLUS.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_METPLUS)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_METPLUS, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_METPLUS}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        date_beg = valid_beg
+        date_end = valid_end
+        date_hours = VALID_HOURS
+        date_type_string = DATE_TYPE
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        date_type_string = 'Initialization'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: Ignored for time series plots")
+    logger.debug(f"X_MAX_LIMIT: Ignored for time series plots")
+    logger.debug(f"X_LIM_LOCK: Ignored for time series plots")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    if len(METRICS) == 1:
+        metrics = (METRICS[0], None)
+    elif len(METRICS) > 1:
+        metrics = METRICS[:2]
+    else:
+        e = (f"FATAL ERROR: Received no list of metrics.  Check that, for the METRICS"
+             + f" setting, a comma-separated string of at least one metric is"
+             + f" provided")
+        logger.error(e)
+        raise ValueError(e)
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    if (str(INTERP).upper()
+            not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    for metric in metrics:
+        if metric is not None:
+            if (str(metric).lower() 
+                    not in case_specs['plot_stats_list']
+                    .replace(' ','').split(',')):
+                e = (f"The requested metric is not valid for the"
+                     + f" requested case type ({VERIF_CASETYPE}) and"
+                     + f" line_type ({LINE_TYPE}): {metric}")
+                logger.warning(e)
+                logger.warning("Continuing ...")
+                continue
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds']
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds']
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        for l, fcst_level in enumerate(FCST_LEVELS):
+            if len(FCST_LEVELS) != len(OBS_LEVELS):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+            if (FCST_LEVELS[l] not in var_specs['fcst_var_levels'] 
+                    or OBS_LEVELS[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid: "
+                     + f"{requested_var}/{level}")
+                logger.warning(e)
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the"
+                         + f" requested case type ({VERIF_CASETYPE}) and"
+                         + f" line_type ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    date_hours, FLEADS, requested_var, fcst_var_names, 
+                    obs_var_names, MODELS, domain, INTERP, MET_VERSION, 
+                    clear_prune_dir
+                )
+                if df is None:
+                    continue
+                plot_time_series(
+                    df, logger, date_range, MODELS, num=num, flead=FLEADS, 
+                    level=fcst_level, thresh=fcst_thresh, 
+                    metric1_name=metrics[0], metric2_name=metrics[1], 
+                    date_type=DATE_TYPE, y_min_limit=Y_MIN_LIMIT, 
+                    y_max_limit=Y_MAX_LIMIT, y_lim_lock=Y_LIM_LOCK, 
+                    xlabel=f'{str(date_type_string).capitalize()} Date', 
+                    verif_type=VERIF_TYPE, date_hours=date_hours, 
+                    line_type=LINE_TYPE, save_dir=SAVE_DIR, 
+                    eval_period=EVAL_PERIOD, 
+                    display_averages=display_averages, 
+                    keep_shared_events_only=keep_shared_events_only,
+                    save_header=URL_HEADER, plot_group=plot_group,
+                    confidence_intervals=CONFIDENCE_INTERVALS,
+                    interp_pts=INTERP_PNTS,
+                    bs_nrep=bs_nrep, bs_method=bs_method, ci_lev=ci_lev,
+                    bs_min_samp=bs_min_samp,
+                    sample_equalization=sample_equalization,
+                    plot_logo_left=plot_logo_left,
+                    plot_logo_right=plot_logo_right,
+                    path_logo_left=path_logo_left,
+                    path_logo_right=path_logo_right,
+                    zoom_logo_left=zoom_logo_left,
+                    zoom_logo_right=zoom_logo_right
+                )
+                num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODEL(os.environ['MODEL']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = re.split(r',(?![0*])', check_FCST_LEVEL(os.environ['FCST_LEVEL']).replace(' ',''))
+    OBS_LEVELS = re.split(r',(?![0*])', check_OBS_LEVEL(os.environ['OBS_LEVEL']).replace(' ',''))
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = list(filter(None, check_STATS(os.environ['STATS']).replace(' ','').split(',')))
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+
+
+    # configure CIs
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    bs_method = toggle.plot_settings['bs_method']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove
+    # samples used to aggregate each statistic if the samples are not shared
+    # by all models.  Required to display sample sizes
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # Whether or not to display events shared among some but not all models
+    keep_shared_events_only = toggle.plot_settings['keep_shared_events_only']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_METPLUS = str(LOG_METPLUS)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    FCST_LEVELS = [str(level) for level in FCST_LEVELS]
+    OBS_LEVELS = [str(level) for level in OBS_LEVELS]
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()

--- a/ush/cam/ush_refs_plot_py/time_util.py
+++ b/ush/cam/ush_refs_plot_py/time_util.py
@@ -1,0 +1,416 @@
+#! /usr/bin/env python3
+
+"""
+Program Name: time_util.py
+Contact(s): George McCabe
+Abstract:
+History Log:  Initial version
+Usage: Create a subclass
+Parameters: None
+Input Files: N/A
+Output Files: N/A
+"""
+
+import datetime
+from dateutil.relativedelta import relativedelta
+import re
+
+'''!@namespace TimeInfo
+@brief Utility to handle timing in METplus wrappers
+@code{.sh}
+Cannot be called directly. These are helper functions
+to be used in other METplus wrappers
+@endcode
+'''
+
+# dictionary where key is letter of time unit, i.e. Y and value is
+# the string representation of it, i.e. year
+TIME_LETTER_TO_STRING = {
+    'Y': 'year',
+    'm': 'month',
+    'd': 'day',
+    'H': 'hour',
+    'M': 'minute',
+    'S': 'second',
+}
+
+def get_relativedelta(value, default_unit='S'):
+    """!Converts time values ending in Y, m, d, H, M, or S to relativedelta object
+        Args:
+          @param value time value optionally ending in Y,m,d,H,M,S
+            Valid options match format 3600, 3600S, 60M, or 1H
+          @param default_unit unit to assume if no letter is found at end of value
+          @return relativedelta object containing offset time"""
+    if isinstance(value, int):
+        return get_relativedelta(str(value), default_unit)
+
+    mult = 1
+    reg = r'(-*)(\d+)([a-zA-Z]*)'
+    match = re.match(reg, value)
+    if match:
+        if match.group(1) == '-':
+            mult = -1
+        time_value = int(match.group(2)) * mult
+        unit_value = match.group(3)
+
+        # create relativedelta (dateutil) object for unit
+        # if no units specified, use seconds unless default_unit is specified
+        if unit_value == '':
+            if default_unit == 'S':
+                return relativedelta(seconds=time_value)
+            else:
+                unit_value = default_unit
+
+        if unit_value == 'H':
+            return relativedelta(hours=time_value)
+
+        if unit_value == 'M':
+            return relativedelta(minutes=time_value)
+
+        if unit_value == 'S':
+            return relativedelta(seconds=time_value)
+
+        if unit_value == 'd':
+            return relativedelta(days=time_value)
+
+        if unit_value == 'm':
+            return relativedelta(months=time_value)
+
+        if unit_value == 'Y':
+            return relativedelta(years=time_value)
+
+        # unsupported time unit specified, return None
+        return None
+
+def get_seconds_from_string(value, default_unit='S', valid_time=None):
+    """!Convert string of time (optionally ending with time letter, i.e. HMSyMD to seconds
+        Args:
+          @param value string to convert, i.e. 3M, 4H, 17
+          @param default_unit units to apply if not specified at end of string
+          @returns time in seconds if successfully parsed, None if not"""
+    rd_obj = get_relativedelta(value, default_unit)
+    return ti_get_seconds_from_relativedelta(rd_obj, valid_time)
+
+def time_string_to_met_time(time_string, default_unit='S'):
+    """!Convert time string (3H, 4M, 7, etc.) to format expected by the MET
+        tools ([H]HH[MM[SS]])"""
+    total_seconds = get_seconds_from_string(time_string, default_unit)
+    return seconds_to_met_time(total_seconds)
+
+def seconds_to_met_time(total_seconds):
+    seconds_time_string = str(total_seconds % 60).zfill(2)
+    minutes_time_string = str(total_seconds // 60 % 60).zfill(2)
+    hour_time_string = str(total_seconds // 3600).zfill(2)
+
+    # if hour is 6 or more digits, we need to add minutes and seconds
+    # also if minutes and/or seconds they are defined
+    # add minutes if seconds are defined as well
+    if len(hour_time_string) > 5 or minutes_time_string != '00' or seconds_time_string != '00':
+        return hour_time_string + minutes_time_string + seconds_time_string
+    else:
+        return hour_time_string
+
+def ti_get_hours_from_relativedelta(lead, valid_time=None):
+    """! Get hours from relativedelta. Simply calls get seconds function and
+         divides the result by 3600.
+
+         @param lead relativedelta object to convert
+         @param valid_time (optional) valid time required to convert values
+          that contain months or years
+         @returns integer value of hours or None if cannot compute
+    """
+    lead_seconds = ti_get_seconds_from_relativedelta(lead, valid_time)
+    if lead_seconds is None:
+        return None
+
+    # integer division doesn't handle negative numbers properly
+    # (result is always -1) so handle appropriately
+    if lead_seconds < 0:
+        return - (-lead_seconds // 3600)
+
+    return lead_seconds // 3600
+
+def ti_get_seconds_from_relativedelta(lead, valid_time=None):
+    """!Check relativedelta object contents and compute the total number of seconds
+        in the time. Return None if years or months are set, because the exact number
+        of seconds cannot be calculated without a relative time"""
+
+    # return None if input is not relativedelta object
+    if not isinstance(lead, relativedelta):
+        return None
+
+    # if valid time is specified, use it to determine seconds
+    if valid_time is not None:
+        return int((valid_time - (valid_time - lead)).total_seconds())
+
+    if lead.months != 0 or lead.years != 0:
+        return None
+
+    total_seconds = 0
+
+    if lead.days != 0:
+        total_seconds += lead.days * 86400
+
+    if lead.hours != 0:
+        total_seconds += lead.hours * 3600
+
+    if lead.minutes != 0:
+        total_seconds += lead.minutes * 60
+
+    if lead.seconds != 0:
+        total_seconds += lead.seconds
+
+    return total_seconds
+
+def ti_get_seconds_from_lead(lead, valid='*'):
+    if isinstance(lead, int):
+        return lead
+
+    if valid == '*':
+        valid_time = None
+    else:
+        valid_time = valid
+
+    return ti_get_seconds_from_relativedelta(lead, valid_time)
+
+def ti_get_hours_from_lead(lead, valid='*'):
+    lead_seconds = ti_get_seconds_from_lead(lead, valid)
+    if lead_seconds is None:
+        return None
+
+    return lead_seconds // 3600
+
+def get_time_suffix(letter, letter_only):
+    if letter_only:
+        return letter
+
+    return f" {TIME_LETTER_TO_STRING[letter]} "
+
+def format_time_string(lead, letter, plural, letter_only):
+    if letter == 'Y':
+        value = lead.years
+    elif letter == 'm':
+        value = lead.months
+    elif letter == 'd':
+        value = lead.days
+    elif letter == 'H':
+        value = lead.hours
+    elif letter == 'M':
+        value = lead.minutes
+    elif letter == 'S':
+        value = lead.seconds
+    else:
+        return None
+
+    if value == 0:
+        return None
+
+    abs_value = abs(value)
+    suffix = get_time_suffix(letter, letter_only)
+    output = f"{abs_value}{suffix}"
+    if abs_value != 1 and plural and not letter_only:
+        output = f"{output.strip()}s "
+
+    return output
+
+def ti_get_lead_string(lead, plural=True, letter_only=False):
+    """!Check relativedelta object contents and create string representation
+        of the highest unit available (year, then, month, day, hour, minute, second).
+        This assumes that only one unit has been set in the object"""
+    # if integer, assume seconds
+    if isinstance(lead, int):
+        return ti_get_lead_string(relativedelta(seconds=lead), plural=plural)
+
+    # return None if input is not relativedelta object
+    if not isinstance(lead, relativedelta):
+        return None
+
+    # if any of the values are negative, add - before the final result
+    if (lead.years < 0 or lead.months < 0 or lead.days < 0 or lead.hours < 0 or
+            lead.minutes < 0 or lead.seconds < 0):
+        negative = '-'
+    else:
+        negative = ''
+
+    output_list = []
+    for time_letter in TIME_LETTER_TO_STRING.keys():
+        output = format_time_string(lead, time_letter, plural, letter_only)
+        if output is not None:
+            output_list.append(output)
+
+    # if nothing was found, return 0 hour(s) or 0H
+    if not output_list:
+        if letter_only:
+            return '0H'
+
+        return f"0 hour{'s' if plural else ''}"
+
+    output = ''.join(output_list)
+    # remove whitespace from beginning and end of string
+    output = output.strip()
+
+    return f"{negative}{output}"
+
+def ti_calculate(input_dict_preserve):
+    out_dict = {}
+    input_dict = input_dict_preserve.copy()
+
+    KEYS_TO_COPY = ['custom', 'instance']
+
+    # set output dictionary to input items
+    if 'now' in input_dict.keys():
+        out_dict['now'] = input_dict['now']
+        out_dict['today'] = out_dict['now'].strftime('%Y%m%d')
+
+    # copy over values of some keys if it is set in input dictionary
+    for key in KEYS_TO_COPY:
+        if key in input_dict.keys():
+            out_dict[key] = input_dict[key]
+
+    # read in input dictionary items and compute missing items
+    # valid inputs: valid, init, lead, offset
+
+    # look for forecast lead information in input
+    # set forecast lead to 0 if not specified
+    if 'lead' in input_dict.keys():
+        # if lead is relativedelta, pass it through
+        # if lead is not, treat it as seconds
+        if isinstance(input_dict['lead'], relativedelta):
+            out_dict['lead'] = input_dict['lead']
+        elif input_dict['lead'] == '*':
+            out_dict['lead'] = input_dict['lead']
+        else:
+            out_dict['lead'] = relativedelta(seconds=input_dict['lead'])
+
+    elif 'lead_seconds' in input_dict.keys():
+        out_dict['lead'] = relativedelta(seconds=input_dict['lead_seconds'])
+
+    elif 'lead_minutes' in input_dict.keys():
+        out_dict['lead'] = relativedelta(minutes=input_dict['lead_minutes'])
+
+    elif 'lead_hours' in input_dict.keys():
+        lead_hours = int(input_dict['lead_hours'])
+        lead_days = 0
+        # if hours is more than a day, pull out days and relative hours
+        if lead_hours > 23:
+            lead_days = lead_hours // 24
+            lead_hours = lead_hours % 24
+
+        out_dict['lead'] = relativedelta(hours=lead_hours, days=lead_days)
+
+    else:
+        out_dict['lead'] = relativedelta(seconds=0)
+
+
+    # set offset to 0 if not specified
+    if 'offset_hours' in input_dict.keys():
+        out_dict['offset'] = datetime.timedelta(hours=input_dict['offset_hours'])
+    elif 'offset' in input_dict.keys():
+        out_dict['offset'] = datetime.timedelta(seconds=input_dict['offset'])
+    else:
+        out_dict['offset'] = datetime.timedelta(seconds=0)
+
+
+    # if init and valid are set, check which was set first via loop_by
+    # remove the other to recalculate
+    if 'init' in input_dict.keys() and 'valid' in input_dict.keys():
+        if 'loop_by' in input_dict.keys():
+            if input_dict['loop_by'] == 'init':
+                del input_dict['valid']
+            elif input_dict['loop_by'] == 'valid':
+                del input_dict['init']
+
+    if 'init' in input_dict.keys():
+        out_dict['init'] = input_dict['init']
+
+        if 'valid' in input_dict.keys():
+            print("FATAL ERROR: Cannot specify both valid and init to time utility")
+            return None
+
+        # compute valid from init and lead if lead is not wildcard
+        if out_dict['lead'] == '*':
+            out_dict['valid'] = '*'
+        else:
+            out_dict['valid'] = out_dict['init'] + out_dict['lead']
+
+        # set loop_by to init or valid to be able to see what was set first
+        out_dict['loop_by'] = 'init'
+
+    # if valid is provided, compute init and da_init
+    elif 'valid' in input_dict:
+        out_dict['valid'] = input_dict['valid']
+
+        # compute init from valid and lead if lead is not wildcard
+        if out_dict['lead'] == '*':
+            out_dict['init'] = '*'
+        else:
+            out_dict['init'] = out_dict['valid'] - out_dict['lead']
+
+        # set loop_by to init or valid to be able to see what was set first
+        out_dict['loop_by'] = 'valid'
+
+    # if da_init is provided, compute init and valid
+    elif 'da_init' in input_dict.keys():
+        out_dict['da_init'] = input_dict['da_init']
+
+        if 'valid' in input_dict.keys():
+            print("FATAL ERROR: Cannot specify both valid and da_init to time utility")
+            return None
+
+        # compute valid from da_init and offset
+        out_dict['valid'] = out_dict['da_init'] - out_dict['offset']
+
+        # compute init from valid and lead if lead is not wildcard
+        if out_dict['lead'] == '*':
+            out_dict['init'] = '*'
+        else:
+            out_dict['init'] = out_dict['valid'] - out_dict['lead']
+    else:
+        print("FATAl ERROR: Need to specify valid, init, or da_init to time utility")
+        return None
+
+    # calculate da_init from valid and offset
+    if out_dict['valid'] != '*':
+        out_dict['da_init'] = out_dict['valid'] + out_dict['offset']
+
+        # add common formatted items
+        out_dict['da_init_fmt'] = out_dict['da_init'].strftime('%Y%m%d%H%M%S')
+        out_dict['valid_fmt'] = out_dict['valid'].strftime('%Y%m%d%H%M%S')
+
+    if out_dict['init'] != '*':
+        out_dict['init_fmt'] = out_dict['init'].strftime('%Y%m%d%H%M%S')
+
+    # get string representation of forecast lead
+    if out_dict['lead'] == '*':
+        out_dict['lead_string'] = 'ALL'
+    else:
+        out_dict['lead_string'] = ti_get_lead_string(out_dict['lead'])
+
+    out_dict['offset'] = int(out_dict['offset'].total_seconds())
+    out_dict['offset_hours'] = int(out_dict['offset'] // 3600)
+
+    # set synonyms for items
+    if 'da_init' in out_dict:
+        out_dict['date'] = out_dict['da_init']
+
+    # if lead is wildcard, skip updating other lead values
+    if out_dict['lead'] == '*':
+        return out_dict
+
+    # get difference between valid and init to get total seconds since relativedelta
+    # does not have a fixed number of seconds
+    total_seconds = int((out_dict['valid'] - out_dict['init']).total_seconds())
+
+    # change relativedelta to integer seconds unless months or years are used
+    # if they are, keep lead as a relativedelta object to be handled differently
+    if out_dict['lead'].months == 0 and out_dict['lead'].years == 0:
+        out_dict['lead'] = total_seconds
+
+    # add common uses for relative times
+    # Specifying integer division // Python 3,
+    # assuming that was the intent in Python 2.
+    out_dict['lead_hours'] = int(total_seconds // 3600)
+    out_dict['lead_minutes'] = int(total_seconds // 60)
+    out_dict['lead_seconds'] = total_seconds
+
+    return out_dict

--- a/ush/cam/ush_refs_plot_py/valid_hour_average.py
+++ b/ush/cam/ush_refs_plot_py/valid_hour_average.py
@@ -1,0 +1,1746 @@
+#!/usr/bin/env python3
+###############################################################################
+#
+# Name:          valid_hour_average.py
+# Contact(s):    Marcel Caron
+# Developed:     Nov. 22, 2021 by Marcel Caron 
+# Last Modified: Jul. 05, 2023 by Marcel Caron             
+# Title:         Line plot of verification metric as a function of 
+#                valid or init hour
+# Abstract:      Plots METplus output (e.g., BCRMSE) as a line plot, 
+#                varying by valid or init hour, which represents the x-axis. 
+#                Line colors and styles are unique for each model, and several
+#                models can be plotted at once.
+#
+###############################################################################
+import os
+import sys
+import numpy as np
+import math
+import pandas as pd
+import logging
+from functools import reduce
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+import matplotlib.image as mpimg
+from matplotlib.offsetbox import OffsetImage, AnnotationBbox
+from datetime import datetime, timedelta as td
+import shutil
+
+SETTINGS_DIR = os.environ['USH_DIR']
+valid_src = os.environ['obsv']
+sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
+from settings import Toggle, Templates, Paths, Presets, ModelSpecs, Reference
+from plotter import Plotter
+from prune_stat_files import prune_data
+import plot_util
+import df_preprocessing
+from check_variables import *
+
+
+# ================ GLOBALS AND CONSTANTS ================
+
+plotter = Plotter()
+plotter.set_up_plots()
+toggle = Toggle()
+templates = Templates()
+paths = Paths()
+presets = Presets()
+model_colors = ModelSpecs()
+reference = Reference()
+
+
+# =================== FUNCTIONS =========================
+
+
+def plot_valid_hour_average(df: pd.DataFrame, logger: logging.Logger, 
+                      date_range: tuple, model_list: list, num: int = 0, 
+                      level: str = '500', flead='all', 
+                      fcst_thresh: list = ['<20'], obs_thresh: list = [''],
+                      metric1_name: str = 'BCRMSE', metric2_name: str = 'ME', 
+                      y_min_limit: float = -10., y_max_limit: float = 10., 
+                      y_lim_lock: bool = False,
+                      xlabel: str = 'Forecast Lead Hour', 
+                      date_type: str = 'VALID', date_hours: list = [0,6,12,18], 
+                      anti_date_hours: list = [0,3,6,9,12,15,18,21],
+                      verif_type: str = 'pres', save_dir: str = '.',
+                      restart_dir: str = '.',
+                      requested_var: str = 'HGT', line_type: str = 'SL1L2',
+                      dpi: int = 100, confidence_intervals: bool = False,
+                      interp_pts: list = [],
+                      bs_nrep: int = 5000, bs_method: str = 'MATCHED_PAIRS', 
+                      ci_lev: float = .95, bs_min_samp: int = 30,
+                      eval_period: str = 'TEST', save_header: str = '', 
+                      display_averages: bool = True, 
+                      plot_group: str = 'sfc_upper',
+                      sample_equalization: bool = True,
+                      plot_logo_left: bool = False,
+                      plot_logo_right: bool = False, path_logo_left: str = '.',
+                      path_logo_right: str = '.', zoom_logo_left: float = 1.,
+                      zoom_logo_right: float = 1.):
+
+    logger.info("========================================")
+    logger.info(f"Creating Plot {num} ...")
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        logger.info("========================================")
+        return None
+    if str(line_type).upper() == 'CTC' and np.array(fcst_thresh).size == 0:
+        logger.warning(f"Empty list of thresholds. Continuing onto next"
+                       + f" plot...")
+        logger.info("========================================")
+        return None
+
+    fig, ax = plotter.get_plots(num)  
+    variable_translator = reference.variable_translator
+    domain_translator = reference.domain_translator
+    model_settings = model_colors.model_settings
+
+    # filter by level
+    df = df[df['FCST_LEV'].astype(str).eq(str(level))]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    # filter by forecast lead times
+    if isinstance(flead, list):
+        if len(flead) <= 8:
+            if len(flead) > 1:
+                frange_phrase = 's '+', '.join([str(f) for f in flead])
+            else:
+                frange_phrase = ' '+', '.join([str(f) for f in flead])
+            frange_save_phrase = '-'.join([str(f).zfill(3) for f in flead])
+        else:
+            frange_phrase = f's {flead[0]}'+u'\u2013'+f'{flead[-1]}'
+            frange_save_phrase = f'{flead[0]:03d}-F{flead[-1]:03d}'
+        frange_string = f'Forecast Hour{frange_phrase}'
+        frange_save_string = f'F{frange_save_phrase}'
+        df = df[df['LEAD_HOURS'].isin(flead)]
+    elif isinstance(flead, tuple):
+        frange_string = (f'Forecast Hours {flead[0]:02d}'
+                         + u'\u2013' + f'{flead[1]:02d}')
+        frange_save_string = f'F{flead[0]:03d}-F{flead[1]:03d}'
+        df = df[
+            (df['LEAD_HOURS'] >= flead[0]) & (df['LEAD_HOURS'] <= flead[1])
+        ]
+    elif isinstance(flead, np.int):
+        frange_string = f'Forecast Hour {flead:02d}'
+        frange_save_string = f'F{flead:03d}'
+        df = df[df['LEAD_HOURS'] == flead]
+    else:
+        e1 = f"FATAL ERROR: Invalid forecast lead: \'{flead}\'"
+        e2 = f"Please check settings for forecast leads."
+        logger.error(e1)
+        logger.error(e2)
+        raise ValueError(e1+"\n"+e2)
+
+    if str(date_type).upper() == 'INIT':
+        anti_date_type = 'VALID'
+    elif str(date_type).upper() == 'VALID':
+        anti_date_type = 'INIT'
+
+    # Filter ANTI_DATE_HOURS column based on what is in anti_date_hours
+    # Remove from date_hours and anti_date_hours the init and valid hours that 
+    # don't exist in the dataframe.  
+    df['DATE_HOURS'] = df[str(date_type).upper()].dt.hour.astype(int)
+    df['ANTI_DATE_HOURS'] = df[str(anti_date_type).upper()].dt.hour.astype(int)
+    df = df[df['ANTI_DATE_HOURS'].isin([int(x) for x in anti_date_hours])]
+    date_hours = np.array(date_hours)[[
+        int(x) in df['DATE_HOURS'].tolist() for x in date_hours
+    ]]
+    anti_date_hours = np.array(anti_date_hours)[[
+        int(x) in df['ANTI_DATE_HOURS'].tolist() for x in anti_date_hours
+    ]]
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    if interp_pts and '' not in interp_pts:
+        interp_shape = list(df['INTERP_MTHD'])[0]
+        if 'SQUARE' in interp_shape:
+            widths = [int(np.sqrt(float(p))) for p in interp_pts]
+        elif 'CIRCLE' in interp_shape:
+            widths = [int(np.sqrt(float(p)+4)) for p in interp_pts]
+        elif np.all([int(p) == 1 for p in interp_pts]):
+            widths = [1 for p in interp_pts]
+        else:
+            error_string = (
+                f"FATAL ERROR: Unknown INTERP_MTHD used to compute INTERP_PNTS: {interp_shape}."
+                + f" Check the INTERP_MTHD column in your METplus stats files."
+                + f" INTERP_MTHD must have either \"SQUARE\" or \"CIRCLE\""
+                + f" in the name."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+        if isinstance(interp_pts, list):
+            if len(interp_pts) <= 8:
+                if len(interp_pts) > 1:
+                    interp_pts_phrase = 's '+', '.join([str(p) for p in widths])
+                else:
+                    interp_pts_phrase = ' '+', '.join([str(p) for p in widths])
+                interp_pts_save_phrase = '-'.join([str(p) for p in widths])
+            else:
+                interp_pts_phrase = f's {widths[0]}'+u'\u2013'+f'{widths[-1]}'
+                interp_pts_save_phrase = f'{widths[0]}-{widths[-1]}'
+            interp_pts_string = f'(Width{interp_pts_phrase})'
+            interp_pts_save_string = f'width{interp_pts_save_phrase}'
+            df = df[df['INTERP_PNTS'].isin(interp_pts)]
+        elif isinstance(interp_pts, np.int):
+            interp_pts_string = f'(Width {widths:d})'
+            interp_pts_save_string = f'width{widths:d}'
+            df = df[df['INTERP_PNTS'] == widths]
+        else:
+            error_string = (
+                f"FATAL ERROR: Invalid interpolation points entry: \'{interp_pts}\'\n"
+                + f"Please check settings for interpolation points."
+            )
+            logger.error(error_string)
+            raise ValueError(error_string)
+
+    if obs_thresh and '' not in obs_thresh:
+        requested_obs_thresh_symbol, requested_obs_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in obs_thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_obs_thresh_symbol):
+                if all(opt in t for t in requested_obs_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_obs_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" obs thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e+"\nQuitting ...")
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested obs thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e+"\nQuitting ...")
+        df_obs_thresh_symbol, df_obs_thresh_letter = list(
+            zip(*[
+                plot_util.format_thresh(t) 
+                for t in df['OBS_THRESH'].replace(np.nan, '', regex=True)
+            ])
+        )
+        df['OBS_THRESH_SYMBOL'] = df_obs_thresh_symbol
+        df['OBS_THRESH_VALUE'] = [str(item)[2:] for item in df_obs_thresh_letter]
+        requested_obs_thresh_value = [
+            str(item)[2:] for item in requested_obs_thresh_letter
+        ]
+        df = df[df['OBS_THRESH_SYMBOL'].isin(requested_obs_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_obs_thresh_symbol)[
+                ~np.isin(requested_obs_thresh_symbol, df['OBS_THRESH_SYMBOL'])
+            ]
+        )
+        requested_obs_thresh_symbol = (
+            np.array(requested_obs_thresh_symbol)[
+                np.isin(requested_obs_thresh_symbol, df['OBS_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} obs thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} obs threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+    if fcst_thresh and '' not in fcst_thresh:
+        requested_fcst_thresh_symbol, requested_fcst_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in fcst_thresh])
+        )
+        symbol_found = False
+        for opt in ['>=', '>', '==', '!=', '<=', '<']:
+            if any(opt in t for t in requested_fcst_thresh_symbol):
+                if all(opt in t for t in requested_fcst_thresh_symbol):
+                    symbol_found = True
+                    opt_letter = requested_fcst_thresh_letter[0][:2]
+                    break
+                else:
+                    e = ("FATAL ERROR: Threshold operands do not match among all requested"
+                         + f" fcst thresholds.")
+                    logger.error(e)
+                    logger.error("Quitting ...")
+                    raise ValueError(e+"\nQuitting ...")
+        if not symbol_found:
+            e = "FATAL ERROR: None of the requested fcst thresholds contain a valid symbol."
+            logger.error(e)
+            logger.error("Quitting ...")
+            raise ValueError(e+"\nQuitting ...")
+        df_fcst_thresh_symbol, df_fcst_thresh_letter = list(
+            zip(*[plot_util.format_thresh(t) for t in df['FCST_THRESH']])
+        )
+        df['FCST_THRESH_SYMBOL'] = df_fcst_thresh_symbol
+        df['FCST_THRESH_VALUE'] = [str(item)[2:] for item in df_fcst_thresh_letter]
+        requested_fcst_thresh_value = [
+            str(item)[2:] for item in requested_fcst_thresh_letter
+        ]
+        df = df[df['FCST_THRESH_SYMBOL'].isin(requested_fcst_thresh_symbol)]
+        thresholds_removed = (
+            np.array(requested_fcst_thresh_symbol)[
+                ~np.isin(requested_fcst_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        requested_fcst_thresh_symbol = (
+            np.array(requested_fcst_thresh_symbol)[
+                np.isin(requested_fcst_thresh_symbol, df['FCST_THRESH_SYMBOL'])
+            ]
+        )
+        if thresholds_removed.size > 0:
+            thresholds_removed_string = ', '.join(thresholds_removed)
+            if len(thresholds_removed) > 1:
+                warning_string = (f"{thresholds_removed_string} fcst thresholds"
+                                  + f" were not found and will not be"
+                                  + f" plotted.")
+            else:
+                warning_string = (f"{thresholds_removed_string} fcst threshold was"
+                                  + f" not found and will not be plotted.")
+            logger.warning(warning_string)
+            logger.warning("Continuing ...")
+
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    group_by = ['MODEL','ANTI_DATE_HOURS']
+    if sample_equalization:
+        df, bool_success = plot_util.equalize_samples(logger, df, group_by)
+        if not bool_success:
+            sample_equalization = False
+        if df.empty:
+            logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+            plt.close(num)
+            logger.info("========================================")
+            return None
+    # Remove from model_list the models that don't exist in the dataframe
+    cols_to_keep = [
+        str(model) 
+        in df['MODEL'].tolist() 
+        for model in model_list
+    ]
+    models_removed = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if not keep
+    ]
+    models_removed_string = ', '.join(models_removed)
+    model_list = [
+        str(m) 
+        for (m, keep) in zip(model_list, cols_to_keep) if keep
+    ]
+    if not all(cols_to_keep):
+        if not any(
+                group_name in str(models_removed_string) 
+                for group_name in ["group", "set"]
+            ):
+            logger.warning(
+                f"{models_removed_string} data were not found and will not be"
+                + f" plotted."
+            )
+    if df.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    df_groups = df.groupby(group_by)
+    # Aggregate unit statistics before calculating metrics
+    if str(line_type).upper() == 'CTC':
+        df_aggregated = df_groups.sum()
+    else:
+        df_aggregated = df_groups.mean()
+    if sample_equalization:
+        df_aggregated['COUNTS']=df_groups.size()
+    # Remove data if they exist for some but not all models at some value of 
+    # the indep. variable. Otherwise plot_util.calculate_stat will throw an 
+    # error
+    df_split = [df_aggregated.xs(str(model)) for model in model_list]
+    df_reduced = reduce(
+        lambda x,y: pd.merge(
+            x, y, on='ANTI_DATE_HOURS', how='inner'
+        ), 
+        df_split
+    )
+    df_aggregated = df_aggregated[
+        df_aggregated.index.get_level_values('ANTI_DATE_HOURS')
+        .isin(df_reduced.index)
+    ]
+
+    if df_aggregated.empty:
+        logger.warning(f"Empty Dataframe. Continuing onto next plot...")
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+    coef, const = (None, None)
+    units = df['FCST_UNITS'].tolist()[0]
+    metrics_using_var_units = [
+        'BCRMSE','RMSE','BIAS','ME','FBAR','OBAR','MAE','FBAR_OBAR',
+        'SPEED_ERR','DIR_ERR','RMSVE','VDIFF_SPEED','VDIF_DIR',
+        'FBAR_OBAR_SPEED','FBAR_OBAR_DIR','FBAR_SPEED','FBAR_DIR'
+    ]
+    unit_convert = False
+    if units in reference.unit_conversions:
+        unit_convert = True
+        var_long_name_key = df['FCST_VAR'].tolist()[0]
+        if str(var_long_name_key).upper() == 'HGT':
+            if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+                if units in ['m', 'gpm']:
+                    units = 'gpm'
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+                unit_convert = False
+            elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HGT']:
+                unit_convert = False
+        elif any(field in str(var_long_name_key).upper() for field in ['WEASD', 'SNOD', 'ASNOW']):
+            if units in ['m']:
+                units = 'm_snow'
+        if unit_convert:
+            if metric2_name is not None:
+                if (str(metric1_name).upper() in metrics_using_var_units
+                        and str(metric2_name).upper() in metrics_using_var_units):
+                    coef, const = (
+                        reference.unit_conversions[units]['formula'](
+                            None,
+                            return_terms=True
+                        )
+                    )
+            elif str(metric1_name).upper() in metrics_using_var_units:
+                coef, const = (
+                    reference.unit_conversions[units]['formula'](
+                        None,
+                        return_terms=True
+                    )
+                )
+    # Calculate desired metric
+    metric_long_names = []
+    for stat in [metric1_name, metric2_name]:
+        if stat:
+            stat_output = plot_util.calculate_stat(
+                logger, df_aggregated, str(stat).lower(), [coef, const]
+            )
+            df_aggregated[str(stat).upper()] = stat_output[0]
+            metric_long_names.append(stat_output[2])
+            if confidence_intervals:
+                ci_output = df_groups.apply(
+                    lambda x: plot_util.calculate_bootstrap_ci(
+                        logger, bs_method, x, str(stat).lower(), bs_nrep,
+                        ci_lev, bs_min_samp, [coef, const]
+                    )
+                )
+                if any(ci_output['STATUS'] == 1):
+                    logger.warning(f"Failed attempt to compute bootstrap"
+                                   + f" confidence intervals.  Sample size"
+                                   + f" for one or more groups is too small."
+                                   + f" Minimum sample size can be changed"
+                                   + f" in settings.py.")
+                    logger.warning(f"Confidence intervals will not be"
+                                   + f" plotted.")
+                    confidence_intervals = False
+                    continue
+                ci_output = ci_output.reset_index(level=2, drop=True)
+                ci_output = (
+                    ci_output
+                    .reindex(df_aggregated.index)
+                )
+                df_aggregated[str(stat).upper()+'_BLERR'] = ci_output[
+                    'CI_LOWER'
+                ].values
+                df_aggregated[str(stat).upper()+'_BUERR'] = ci_output[
+                    'CI_UPPER'
+                ].values
+
+    df_aggregated[str(metric1_name).upper()] = (
+        df_aggregated[str(metric1_name).upper()]
+    ).astype(float).tolist()
+    if metric2_name is not None:
+        df_aggregated[str(metric2_name).upper()] = (
+            df_aggregated[str(metric2_name).upper()]
+        ).astype(float).tolist()
+    df_aggregated = df_aggregated[
+        df_aggregated.index.isin(model_list, level='MODEL')
+    ]
+    pivot_metric1 = pd.pivot_table(
+        df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
+        index='ANTI_DATE_HOURS'
+    )
+    if sample_equalization:
+        pivot_counts=pd.pivot_table(
+            df_aggregated, values='COUNTS', columns='MODEL',
+            index='ANTI_DATE_HOURS'
+        )
+    pivot_metric1 = pivot_metric1.dropna() 
+    if metric2_name is not None:
+        pivot_metric2 = pd.pivot_table(
+            df_aggregated, values=str(metric2_name).upper(), columns='MODEL', 
+            index='ANTI_DATE_HOURS'
+        )
+        pivot_metric2 = pivot_metric2.dropna() 
+    if confidence_intervals:
+        pivot_ci_lower1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BLERR',
+            columns='MODEL', index='ANTI_DATE_HOURS'
+        )
+        pivot_ci_upper1 = pd.pivot_table(
+            df_aggregated, values=str(metric1_name).upper()+'_BUERR',
+            columns='MODEL', index='ANTI_DATE_HOURS'
+        )
+        if metric2_name is not None:
+            pivot_ci_lower2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BLERR',
+                columns='MODEL', index='ANTI_DATE_HOURS'
+            )
+            pivot_ci_upper2 = pd.pivot_table(
+                df_aggregated, values=str(metric2_name).upper()+'_BUERR',
+                columns='MODEL', index='ANTI_DATE_HOURS'
+            )
+
+    if (metric2_name and (pivot_metric1.empty or pivot_metric2.empty)):
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name} and/or"
+            + f" {metric2_name} stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+    elif not metric2_name and pivot_metric1.empty:
+        print_varname = df['FCST_VAR'].tolist()[0]
+        logger.warning(
+            f"Could not find (and cannot plot) {metric1_name}"
+            + f" stats for {print_varname} at any level. "
+            + f"This often happens when processed data are all NaNs, "
+            + f" which are removed.  Check for seasonal cases where critical "
+            + f" threshold is not reached. Continuing ..."
+        )
+        plt.close(num)
+        logger.info("========================================")
+        return None
+
+
+    models_renamed = []
+    count_renamed = 1
+    for requested_model in model_list:
+        if requested_model in model_colors.model_alias:
+            requested_model = (
+                model_colors.model_alias[requested_model]['settings_key']
+            )
+        if requested_model in model_settings:
+            models_renamed.append(requested_model)
+        else:
+            models_renamed.append('model'+str(count_renamed))
+            count_renamed+=1
+    models_renamed = np.array(models_renamed)
+    # Check that there are no repeated colors
+    temp_colors = [
+        model_colors.get_color_dict(name)['color'] for name in models_renamed
+    ]
+    colors_corrected=False
+    loop_count=0
+    while not colors_corrected and loop_count < 10:
+        unique, counts = np.unique(temp_colors, return_counts=True)
+        repeated_colors = [u for i, u in enumerate(unique) if counts[i] > 1]
+        if repeated_colors:
+            for c in repeated_colors:
+                models_sharing_colors = models_renamed[
+                    np.array(temp_colors)==c
+                ]
+                if np.flatnonzero(np.core.defchararray.find(
+                        models_sharing_colors, 'model')!=-1):
+                    need_to_rename = models_sharing_colors[
+                        np.flatnonzero(np.core.defchararray.find(
+                            models_sharing_colors, 'model'
+                        )!=-1)[0]
+                    ]
+                else:
+                    continue
+                models_renamed[models_renamed==need_to_rename] = (
+                    'model'+str(count_renamed)
+                )
+                count_renamed+=1
+            temp_colors = [
+                model_colors.get_color_dict(name)['color'] 
+                for name in models_renamed
+            ]
+            loop_count+=1
+        else:
+            colors_corrected = True
+    mod_setting_dicts = [
+        model_colors.get_color_dict(name) for name in models_renamed
+    ]
+
+    # Plot data
+    logger.info("Begin plotting ...")
+    incr = 1
+    if confidence_intervals:
+        indices_in_common1 = list(set.intersection(*map(
+            set, 
+            [
+                pivot_metric1.index, 
+                pivot_ci_lower1.index, 
+                pivot_ci_upper1.index
+            ]
+        )))
+        pivot_metric1 = pivot_metric1[pivot_metric1.index.isin(indices_in_common1)]
+        pivot_ci_lower1 = pivot_ci_lower1[pivot_ci_lower1.index.isin(indices_in_common1)]
+        pivot_ci_upper1 = pivot_ci_upper1[pivot_ci_upper1.index.isin(indices_in_common1)]
+        if sample_equalization:
+            pivot_counts = pivot_counts[pivot_counts.index.isin(indices_in_common1)]
+        if metric2_name is not None:
+            indices_in_common2 = list(set.intersection(*map(
+                set, 
+                [
+                    pivot_metric2.index, 
+                    pivot_ci_lower2.index, 
+                    pivot_ci_upper2.index
+                ]
+            )))
+            pivot_metric2 = pivot_metric2[pivot_metric2.index.isin(indices_in_common2)]
+            pivot_ci_lower2 = pivot_ci_lower2[pivot_ci_lower2.index.isin(indices_in_common2)]
+            pivot_ci_upper2 = pivot_ci_upper2[pivot_ci_upper2.index.isin(indices_in_common2)]
+    x_vals1 = pivot_metric1.index
+    if metric2_name is not None:
+        x_vals2 = pivot_metric2.index
+    y_min = y_min_limit
+    y_max = y_max_limit
+    if obs_thresh and '' not in obs_thresh:
+        obs_thresh_labels = np.unique(df['OBS_THRESH_VALUE'])
+        obs_thresh_argsort = np.argsort(obs_thresh_labels.astype(float))
+        requested_obs_thresh_argsort = np.argsort([
+            float(item) for item in requested_obs_thresh_value
+        ])
+        obs_thresh_labels = [obs_thresh_labels[i] for i in obs_thresh_argsort]
+        requested_obs_thresh_labels = [
+            requested_obs_thresh_value[i] for i in requested_obs_thresh_argsort
+        ]
+    if fcst_thresh and '' not in fcst_thresh:
+        fcst_thresh_labels = np.unique(df['FCST_THRESH_VALUE'])
+        fcst_thresh_argsort = np.argsort(fcst_thresh_labels.astype(float))
+        requested_fcst_thresh_argsort = np.argsort([
+            float(item) for item in requested_fcst_thresh_value
+        ])
+        fcst_thresh_labels = [fcst_thresh_labels[i] for i in fcst_thresh_argsort]
+        requested_fcst_thresh_labels = [
+            requested_fcst_thresh_value[i] for i in requested_fcst_thresh_argsort
+        ]
+    plot_reference = [False, False]
+    ref_metrics = ['OBAR']
+    if str(metric1_name).upper() in ref_metrics:
+        plot_reference[0] = True
+        pivot_reference1 = pivot_metric1
+        reference1 = pivot_reference1.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower1 = pivot_ci_lower1.mean(axis=1)
+            reference_ci_upper1 = pivot_ci_upper1.mean(axis=1)
+        if not np.any((pivot_reference1.T/reference1).T == 1.):
+            logger.warning(
+                f"{str(metric1_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[0] = False
+    if metric2_name is not None and str(metric2_name).upper() in ref_metrics:
+        plot_reference[1] = True
+        pivot_reference2 = pivot_metric2
+        reference2 = pivot_reference2.mean(axis=1)
+        if confidence_intervals:
+            reference_ci_lower2 = pivot_ci_lower2.mean(axis=1)
+            reference_ci_upper2 = pivot_ci_upper2.mean(axis=1)
+        if not np.any((pivot_reference2.T/reference2).T == 1.):
+            logger.warning(
+                f"{str(metric2_name).upper()} is requested, but the value "
+                + f"varies from model to model. "
+                + f"Will plot an individual line for each model. If a "
+                + f"single reference line is preferred, set the "
+                + f"sample_equalization toggle in ush/settings.py to 'True', "
+                + f"and check in the log file if sample equalization "
+                + f"completed successfully."
+            )
+            plot_reference[1] = False
+    if np.any(plot_reference):
+        plotted_reference = [False, False]
+        if confidence_intervals:
+            plotted_reference_CIs = [False, False]
+    f = lambda m,c,ls,lw,ms,mec: plt.plot(
+        [], [], marker=m, mec=mec, mew=2., c=c, ls=ls, lw=lw, ms=ms
+    )[0]
+    if metric2_name is not None:
+        if np.any(plot_reference):
+            ref_color_dict = model_colors.get_color_dict('obs')
+            handles = []
+            labels = []
+            line_settings = ['solid','dashed']
+            metric_names = [metric1_name, metric2_name]
+            for p, rbool in enumerate(plot_reference):
+                if rbool:
+                    handles += [
+                        f('', ref_color_dict['color'], line_settings[p], 5., 0, 'white')
+                    ]
+                else:
+                    handles += [
+                        f('', 'black', line_settings[p], 5., 0, 'white')
+                    ]
+                labels += [
+                    str(metric_names[p]).upper()
+                ]
+        else:
+            handles = [
+                f('', 'black', line_setting, 5., 0, 'white')
+                for line_setting in ['solid','dashed']
+            ]
+            labels = [
+                str(metric_name).upper()
+                for metric_name in [metric1_name, metric2_name]
+            ]
+    else:
+        handles = []
+        labels = []
+    if np.all([val==1 for val in pivot_metric1.count(axis=1)]):
+        connect_points = True
+    else:
+        connect_points = False
+    n_mods = 0
+    for m in range(len(mod_setting_dicts)):
+        if model_list[m] in model_colors.model_alias:
+            model_plot_name = (
+                model_colors.model_alias[model_list[m]]['plot_name']
+            )
+        else:
+            model_plot_name = model_list[m]
+        if str(model_list[m]) not in pivot_metric1:
+            continue
+        y_vals_metric1 = pivot_metric1[str(model_list[m])].values
+        y_vals_metric1_mean = np.nanmean(y_vals_metric1)
+        if metric2_name is not None:
+            y_vals_metric2 = pivot_metric2[str(model_list[m])].values
+            y_vals_metric2_mean = np.nanmean(y_vals_metric2)
+        if confidence_intervals:
+            y_vals_ci_lower1 = pivot_ci_lower1[
+                str(model_list[m])
+            ].values
+            y_vals_ci_upper1 = pivot_ci_upper1[
+                str(model_list[m])
+            ].values
+            if metric2_name is not None:
+                y_vals_ci_lower2 = pivot_ci_lower2[
+                    str(model_list[m])
+                ].values
+                y_vals_ci_upper2 = pivot_ci_upper2[
+                    str(model_list[m])
+                ].values
+        if not y_lim_lock:
+            if metric2_name is not None:
+                y_vals_both_metrics = np.concatenate((y_vals_metric1, y_vals_metric2))
+                if np.any(y_vals_both_metrics != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics[y_vals_both_metrics != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_both_metrics)
+                    y_vals_metric_max = np.nanmax(y_vals_both_metrics)
+            else:
+                if np.any(y_vals_metric1 != np.inf):
+                    y_vals_metric_min = np.nanmin(y_vals_metric1[y_vals_metric1 != np.inf])
+                    y_vals_metric_max = np.nanmax(y_vals_metric1[y_vals_metric1 != np.inf])
+                else:
+                    y_vals_metric_min = np.nanmin(y_vals_metric1)
+                    y_vals_metric_max = np.nanmax(y_vals_metric1)
+            if n_mods == 0:
+                y_mod_min = y_vals_metric_min
+                y_mod_max = y_vals_metric_max
+                n_mods+=1
+            else:
+                if math.isinf(y_mod_min):
+                    y_mod_min = y_vals_metric_min
+                else:
+                    y_mod_min = np.nanmin([y_mod_min, y_vals_metric_min])
+                if math.isinf(y_mod_max):
+                    y_mod_max = y_vals_metric_max
+                else:
+                    y_mod_max = np.nanmax([y_mod_max, y_vals_metric_max])
+            if (y_vals_metric_min > y_min_limit 
+                    and y_vals_metric_min <= y_mod_min):
+                y_min = y_vals_metric_min
+            if (y_vals_metric_max < y_max_limit 
+                    and y_vals_metric_max >= y_mod_max):
+                y_max = y_vals_metric_max
+        if np.abs(y_vals_metric1_mean) < 1E4:
+            metric1_mean_fmt_string = f'{y_vals_metric1_mean:.2f}'
+        else:
+            metric1_mean_fmt_string = f'{y_vals_metric1_mean:.2E}'
+        if plot_reference[0]:
+            if not plotted_reference[0]:
+                ref_color_dict = model_colors.get_color_dict('obs')
+                if connect_points:
+                    x_vals1_plot = x_vals1[~np.isnan(reference1)]
+                    y_vals1_plot = reference1[~np.isnan(reference1)]
+                else:
+                    x_vals1_plot = x_vals1
+                    y_vals1_plot = reference1
+                plt.plot(
+                    x_vals1_plot.tolist(), y_vals1_plot,
+                    marker=ref_color_dict['marker'],
+                    c=ref_color_dict['color'], mew=2., mec='white',
+                    figure=fig, ms=ref_color_dict['markersize'], ls='solid',
+                    lw=ref_color_dict['linewidth']
+                )
+                plotted_reference[0] = True
+        else:
+            if connect_points:
+                x_vals1_plot = x_vals1[~np.isnan(y_vals_metric1)]
+                y_vals1_plot = y_vals_metric1[~np.isnan(y_vals_metric1)]
+            else:
+                x_vals1_plot = x_vals1
+                y_vals1_plot = y_vals_metric1
+            plt.plot(
+                x_vals1_plot.tolist(), y_vals1_plot, 
+                marker=mod_setting_dicts[m]['marker'], 
+                c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='solid', 
+                lw=mod_setting_dicts[m]['linewidth']
+            )
+        if metric2_name is not None:
+            if np.abs(y_vals_metric2_mean) < 1E4:
+                metric2_mean_fmt_string = f'{y_vals_metric2_mean:.2f}'
+            else:
+                metric2_mean_fmt_string = f'{y_vals_metric2_mean:.2E}'
+            if plot_reference[1]:
+                if not plotted_reference[1]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    if connect_points:
+                        x_vals2_plot = x_vals2[~np.isnan(reference2)]
+                        y_vals2_plot = reference2[~np.isnan(reference2)]
+                    else:
+                        x_vals2_plot = x_vals2
+                        y_vals2_plot = reference2
+                    plt.plot(
+                        x_vals2_plot.tolist(), y_vals2_plot,
+                        marker=ref_color_dict['marker'],
+                        c=ref_color_dict['color'], mew=2., mec='white',
+                        figure=fig, ms=ref_color_dict['markersize'], ls='dashed',
+                        lw=ref_color_dict['linewidth']
+                    )
+                    plotted_reference[1] = True
+            else:
+                if connect_points:
+                    x_vals2_plot = x_vals2[~np.isnan(y_vals_metric2)]
+                    y_vals2_plot = y_vals_metric2[~np.isnan(y_vals_metric2)]
+                else:
+                    x_vals2_plot = x_vals2
+                    y_vals2_plot = y_vals_metric2
+                plt.plot(
+                    x_vals2_plot.tolist(), y_vals2_plot, 
+                    marker=mod_setting_dicts[m]['marker'], 
+                    c=mod_setting_dicts[m]['color'], mew=2., mec='white', 
+                    figure=fig, ms=mod_setting_dicts[m]['markersize'], ls='dashed', 
+                    lw=mod_setting_dicts[m]['linewidth']
+                )
+        if confidence_intervals:
+            if plot_reference[0]:
+                if not plotted_reference_CIs[0]:
+                    ref_color_dict = model_colors.get_color_dict('obs')
+                    plt.errorbar(
+                        x_vals1.tolist(), reference1,
+                        yerr=[np.abs(reference_ci_lower1), reference_ci_upper1],
+                        fmt='none', ecolor=ref_color_dict['color'],
+                        elinewidth=ref_color_dict['linewidth'],
+                        capsize=10., capthick=ref_color_dict['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+                    plotted_reference_CIs[0] = True
+            else:
+                plt.errorbar(
+                    x_vals1.tolist(), y_vals_metric1,
+                    yerr=[np.abs(y_vals_ci_lower1), y_vals_ci_upper1],
+                    fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                    elinewidth=mod_setting_dicts[m]['linewidth'],
+                    capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                    alpha=.70, zorder=0
+                )
+            if metric2_name is not None:
+                if plot_reference[1]:
+                    if not plotted_reference_CIs[1]:
+                        ref_color_dict = model_colors.get_color_dict('obs')
+                        plt.errorbar(
+                            x_vals2.tolist(), reference2,
+                            yerr=[np.abs(reference_ci_lower2), reference_ci_upper2],
+                            fmt='none', ecolor=ref_color_dict['color'],
+                            elinewidth=ref_color_dict['linewidth'],
+                            capsize=10., capthick=ref_color_dict['linewidth'],
+                            alpha=.70, zorder=0
+                        )
+                        plotted_reference_CIs[1] = True
+                else:
+                    plt.errorbar(
+                        x_vals2.tolist(), y_vals_metric2,
+                        yerr=[np.abs(y_vals_ci_lower2), y_vals_ci_upper2],
+                        fmt='none', ecolor=mod_setting_dicts[m]['color'],
+                        elinewidth=mod_setting_dicts[m]['linewidth'],
+                        capsize=10., capthick=mod_setting_dicts[m]['linewidth'],
+                        alpha=.70, zorder=0
+                    )
+        handles+=[
+            f(
+                mod_setting_dicts[m]['marker'], mod_setting_dicts[m]['color'],
+                'solid', mod_setting_dicts[m]['linewidth'], 
+                mod_setting_dicts[m]['markersize'], 'white'
+            )
+        ]
+        if display_averages:
+            if metric2_name is not None:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string},'
+                    + f'{metric2_mean_fmt_string})'
+                ]
+            else:
+                labels+=[
+                    f'{model_plot_name} ({metric1_mean_fmt_string})'
+                ]
+        else:
+            labels+=[f'{model_plot_name}']
+
+    # Zero line
+    plt.axhline(y=0, color='black', linestyle='--', linewidth=1, zorder=0) 
+    metrics_with_axline_at_1 = [
+        'FBIAS','RSD'
+    ]
+    if (str(metric1_name).upper() in metrics_with_axline_at_1
+            or str(metric2_name).upper() in metrics_with_axline_at_1):
+        plt.axhline(y=1, color='black', linestyle='--', linewidth=1, zorder=0)
+
+    # Configure axis ticks
+    xticks_min = 0
+    xticks_max = 23
+    xticks = [
+        x_val for x_val in np.arange(xticks_min, xticks_max+incr, incr)
+    ] 
+    xtick_labels = [str(xtick) for xtick in xticks]
+    show_xtick_every = len(xticks)//40+1
+    xtick_labels_with_blanks = ['' for item in xtick_labels]
+    for i, item in enumerate(xtick_labels[::int(show_xtick_every)]):
+         xtick_labels_with_blanks[int(show_xtick_every)*i] = item
+    x_buffer_size = .15
+    ax.set_xlim(
+        xticks_min-incr*x_buffer_size, xticks_max+incr*x_buffer_size
+    )
+    y_range_categories = np.array([
+        [np.power(10.,y), 2.*np.power(10.,y)] 
+        for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
+    ]).flatten()
+    round_to_nearest_categories = y_range_categories/20.
+    if math.isinf(y_min):
+        y_min = y_min_limit
+    if math.isinf(y_max):
+        y_max = y_max_limit
+    y_range = y_max-y_min
+    round_to_nearest =  round_to_nearest_categories[
+        np.digitize(y_range, y_range_categories[:-1])
+    ]
+    ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
+    ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
+    if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
+        ylim_min = float(
+            np.format_float_scientific(ylim_min, unique=False, precision=3)
+        )
+    if round_to_nearest < 1.:
+        y_precision_scale = 100/round_to_nearest
+    else:
+        y_precision_scale = 1.
+    yticks = [
+        y_val for y_val 
+        in np.arange(
+            ylim_min*y_precision_scale, 
+            ylim_max*y_precision_scale+round_to_nearest*y_precision_scale, 
+            round_to_nearest*y_precision_scale
+        )
+    ]
+    yticks=np.divide(yticks,y_precision_scale)
+    ytick_labels = [f'{ytick}' for ytick in yticks]
+    show_ytick_every = len(yticks)//10+1
+    ytick_labels_with_blanks = ['' for item in ytick_labels]
+    for i, item in enumerate(ytick_labels[::int(show_ytick_every)]):
+        ytick_labels_with_blanks[int(show_ytick_every)*i] = item
+    var_long_name_key = df['FCST_VAR'].tolist()[0]
+    if str(var_long_name_key).upper() == 'HGT':
+        if str(df['OBS_VAR'].tolist()[0]).upper() in ['CEILING']:
+            var_long_name_key = 'HGTCLDCEIL'
+        elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+            var_long_name_key = 'HPBL'
+    var_long_name = variable_translator[var_long_name_key]
+    if unit_convert:
+        if fcst_thresh and '' not in fcst_thresh:
+            fcst_thresh_labels = [float(tlab) for tlab in fcst_thresh_labels]
+            fcst_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    fcst_thresh_labels, 
+                    rounding=True
+                )
+            )
+            fcst_thresh_labels = [str(tlab) for tlab in fcst_thresh_labels]
+            requested_fcst_thresh_labels = [
+                float(tlab) for tlab in requested_fcst_thresh_labels
+            ]
+            requested_fcst_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    requested_fcst_thresh_labels,
+                    rounding=True
+                )
+            )
+            requested_fcst_thresh_labels = [
+                str(tlab) for tlab in requested_fcst_thresh_labels
+            ]
+        if obs_thresh and '' not in obs_thresh:
+            obs_thresh_labels = [float(tlab) for tlab in obs_thresh_labels]
+            obs_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    obs_thresh_labels,
+                    rounding=True
+                )
+            )
+            obs_thresh_labels = [str(tlab) for tlab in obs_thresh_labels]
+            requested_obs_thresh_labels = [
+                float(tlab) for tlab in requested_obs_thresh_labels
+            ]
+            requested_obs_thresh_labels = (
+                reference.unit_conversions[units]['formula'](
+                    requested_obs_thresh_labels,
+                    rounding=True
+                )
+            )
+            requested_obs_thresh_labels = [
+                str(tlab) for tlab in requested_obs_thresh_labels
+            ]
+        units = reference.unit_conversions[units]['convert_to']
+    if units == '-':
+        units = ''
+    if metric2_name is not None:
+        metric1_string, metric2_string = metric_long_names
+        if (str(metric1_name).upper() in metrics_using_var_units
+                and str(metric2_name).upper() in metrics_using_var_units):
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string} and {metric2_string}'
+    else:
+        metric1_string = metric_long_names[0]
+        if str(metric1_name).upper() in metrics_using_var_units:
+            if units:
+                ylabel = f'{var_long_name} ({units})'
+            else:
+                ylabel = f'{var_long_name} (unitless)'
+        else:
+            ylabel = f'{metric1_string}'
+    ax.set_ylim(ylim_min, ylim_max)
+    ax.set_ylabel(ylabel)
+    ax.set_xlabel(xlabel) 
+    ax.set_xticklabels(xtick_labels_with_blanks)
+    ax.set_yticklabels(ytick_labels_with_blanks)
+    ax.set_yticks(yticks)
+    ax.set_xticks(xticks)
+    ax.tick_params(
+        labelleft=True, labelright=False, labelbottom=True, labeltop=False
+    )
+    ax.tick_params(
+        left=False, labelleft=False, labelright=False, labelbottom=False, 
+        labeltop=False, which='minor', axis='y', pad=15
+    )
+    majyticks = [i for i, item in enumerate(ytick_labels_with_blanks) if item]
+    for mt in majyticks:
+        ax.yaxis.get_major_ticks()[mt].tick1line.set_markersize(8)
+
+    ax.legend(
+        handles, labels, framealpha=1, 
+        bbox_to_anchor=(0.5, -.15), ncol=4, frameon=True, numpoints=2, 
+        borderpad=.8, labelspacing=1.) 
+    fig.subplots_adjust(wspace=0, hspace=0)
+    ax.grid(
+        visible=True, which='major', axis='both', alpha=.5, linestyle='--', 
+        linewidth=.5, zorder=0
+    )
+
+    if sample_equalization:
+        counts = pivot_counts.mean(axis=1, skipna=True).fillna('')
+        for count, xval in zip(counts, x_vals1.tolist()):
+            if not isinstance(count, str):
+                count = str(int(count))
+            ax.annotate(
+                f'{count}', xy=(xval,1.),
+                xycoords=('data','axes fraction'), xytext=(0,12),
+                textcoords='offset points', va='top', fontsize=11,
+                color='dimgrey', ha='center'
+            )
+        ax.annotate(
+            '#SAMPLES', xy=(0.,1.), xycoords='axes fraction',
+            xytext=(-50, 21), textcoords='offset points', va='top', 
+            fontsize=11, color='dimgrey', ha='center'
+        )
+
+    # Title
+    domain = df['VX_MASK'].tolist()[0]
+    var_savename = df['FCST_VAR'].tolist()[0]
+    if 'APCP' in var_savename.upper():
+        var_savename = 'APCP'
+    elif any(field in var_savename.upper() for field in ['ASNOW','SNOD']):
+        var_savename = 'ASNOW'
+    elif str(df['OBS_VAR'].tolist()[0]).upper() in ['HPBL']:
+        var_savename = 'HPBL'
+    elif str(df['OBS_VAR'].tolist()[0]).upper() in ['MSLET','MSLMA','PRMSL']:
+        var_savename = 'MSLET'
+    if domain in list(domain_translator.keys()):
+        domain_string = domain_translator[domain]['long_name']
+        domain_save_string = domain_translator[domain]['save_name']
+    else:
+        domain_string = domain
+        domain_save_string = domain
+    date_hours_string = plot_util.get_name_for_listed_items(
+        [f'{date_hour:02d}' for date_hour in date_hours],
+        ', ', '', 'Z', 'and ', ''
+    )
+    date_start_string = date_range[0].strftime('%d %b %Y')
+    date_end_string = date_range[1].strftime('%d %b %Y')
+    if str(level).upper() in ['CEILING', 'TOTAL', 'PBL']:
+        if str(level).upper() == 'CEILING':
+            level_string = ''
+            level_savename = 'L0'
+        elif str(level).upper() == 'TOTAL':
+            level_string = 'Total '
+            level_savename = 'L0'
+        elif str(level).upper() == 'PBL':
+            level_string = ''
+            level_savename = 'L0'
+    elif str(verif_type).lower() in ['pres', 'upper_air', 'raob'] or 'P' in str(level):
+        if 'P' in str(level):
+            if str(level).upper() == 'P90-0':
+                level_string = f'Mixed-Layer '
+                level_savename = f'L90'
+            else:
+                level_num = level.replace('P', '')
+                level_string = f'{level_num} hPa '
+                level_savename = f'{level}'
+        elif str(level).upper() == 'L0':
+            level_string = f'Surface-Based '
+            level_savename = f'{level}'
+        else:
+            level_string = ''
+            level_savename = f'{level}'
+    elif str(verif_type).lower() in ['sfc', 'conus_sfc', 'polar_sfc', 'mrms', 'metar']:
+        if 'Z' in str(level):
+            if str(level).upper() == 'Z0':
+                if str(var_long_name_key).upper() in ['MLSP', 'MSLET', 'MSLMA', 'PRMSL']:
+                    level_string = ''
+                    level_savename = f'{level}'
+                else:
+                    level_string = 'Surface '
+                    level_savename = f'{level}'
+            else:
+                level_num = level.replace('Z', '')
+                if var_savename in ['TSOIL', 'SOILW']:
+                    level_string = f'{level_num}-cm '
+                    level_savename = f'{level_num}CM'
+                else:
+                    level_string = f'{level_num}-m '
+                    level_savename = f'{level}'
+        elif 'L' in str(level):
+            level_string = ''
+            level_savename = f'{level}'
+        elif 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'A{level_num.zfill(2)}'
+        else:
+            level_string = f'{level} '
+            level_savename = f'{level}'
+    elif str(verif_type).lower() in ['ccpa', 'mrms']:
+        if 'A' in str(level):
+            level_num = level.replace('A', '')
+            level_string = f'{level_num}-hour '
+            level_savename = f'A{level_num.zfill(2)}'
+        else:
+            level_string = f''
+            level_savename = f'{level}'
+    else:
+        level_string = f'{level} '
+        level_savename = f'{level}'
+    if metric2_name is not None:
+        title1 = f'{metric1_string} and {metric2_string}'
+    else:
+        title1 = f'{metric1_string}'
+    if interp_pts and '' not in interp_pts:
+        title1+=f' {interp_pts_string}'
+    fcst_thresh_on = (fcst_thresh and '' not in fcst_thresh)
+    obs_thresh_on = (obs_thresh and '' not in obs_thresh)
+    tail_dot_rgx = re.compile(r'(?:(\.)|(\.\d*?[1-9]\d*?))0+(?=\b|[^0-9])')
+    if fcst_thresh_on:
+        fcst_thresh_labels = [
+            tail_dot_rgx.sub(r'\2', lab) for lab in fcst_thresh_labels
+        ]
+        fcst_thresholds_phrase = ', '.join([
+            f'{opt}{fcst_thresh_label}' 
+            for fcst_thresh_label in fcst_thresh_labels
+        ])
+        requested_fcst_thresh_labels = [
+            tail_dot_rgx.sub(r'\2', lab) for lab in requested_fcst_thresh_labels
+        ]
+        fcst_thresholds_save_phrase = ''.join([
+            f'{opt_letter}{fcst_thresh_label}' 
+            for fcst_thresh_label in requested_fcst_thresh_labels
+        ]).replace('.','p')
+    if obs_thresh_on:
+        obs_thresh_labels = [
+            tail_dot_rgx.sub(r'\2', lab) for lab in obs_thresh_labels
+        ]
+        obs_thresholds_phrase = ', '.join([
+            f'obs{opt}{obs_thresh_label}' 
+            for obs_thresh_label in obs_thresh_labels
+        ])
+        requested_obs_thresh_labels = [
+            tail_dot_rgx.sub(r'\2', lab) for lab in requested_obs_thresh_labels
+        ]
+        obs_thresholds_save_phrase = ''.join([
+            f'obs{opt_letter}{obs_thresh_label}' 
+            for obs_thresh_label in requested_obs_thresh_labels
+        ]).replace('.','p')
+    if fcst_thresh_on:
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({fcst_thresholds_phrase}'
+                      + f' {units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({fcst_thresholds_phrase}'
+                      + f' unitless), {domain_string}')
+    elif obs_thresh_on:
+        if units:
+            title2 = (f'{level_string}{var_long_name} ({obs_thresholds_phrase}'
+                      + f' {units}), {domain_string}')
+        else:
+            title2 = (f'{level_string}{var_long_name} ({obs_thresholds_phrase}'
+                      + f' unitless), {domain_string}')
+    else:
+        if units:
+            title2 = f'{level_string}{var_long_name} ({units}), {domain_string}'
+        else:
+            title2 = f'{level_string}{var_long_name} (unitless), {domain_string}'
+    title2 += f'{valid_src}'
+    title3 = (f'{str(date_type).capitalize()} {date_hours_string} '
+              + f'{date_start_string} to {date_end_string}, {frange_string}')
+    title_center = '\n'.join([title1, title2, title3])
+    if sample_equalization:
+        title_pad=23
+    else:
+        title_pad=None
+    ax.set_title(title_center, pad=title_pad) 
+    logger.info("... Plotting complete.")
+
+    # Logos
+    if plot_logo_left:
+        if os.path.exists(path_logo_left):
+            left_logo_arr = mpimg.imread(path_logo_left)
+            left_image_box = OffsetImage(left_logo_arr, zoom=zoom_logo_left)
+            ab_left = AnnotationBbox(
+                left_image_box, xy=(0.,1.), xycoords='axes fraction',
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(0,0)
+            )
+            ax.add_artist(ab_left)
+        else:
+            logger.warning(
+                f"Left logo path ({path_logo_left}) doesn't exist. "
+                + f"Left logo will not be plotted."
+            )
+    if plot_logo_right:
+        if os.path.exists(path_logo_right):
+            right_logo_arr = mpimg.imread(path_logo_right)
+            right_image_box = OffsetImage(right_logo_arr, zoom=zoom_logo_right)
+            ab_right = AnnotationBbox(
+                right_image_box, xy=(1.,1.), xycoords='axes fraction',
+                xybox=(0, 20), boxcoords='offset points', frameon = False,
+                box_alignment=(1,0)
+            )
+            ax.add_artist(ab_right)
+        else:
+            logger.warning(
+                f"Right logo path ({path_logo_right}) doesn't exist. "
+                + f"Right logo will not be plotted."
+            )
+
+    # Saving
+    models_savename = '_'.join([str(model) for model in model_list])
+    if len(date_hours) <= 8: 
+        date_hours_savename = '_'.join([
+            f'{date_hour:02d}Z' for date_hour in date_hours
+        ])
+    else:
+        date_hours_savename = '-'.join([
+            f'{date_hour:02d}Z' 
+            for date_hour in [date_hours[0], date_hours[-1]]
+        ])
+    date_start_savename = date_range[0].strftime('%Y%m%d')
+    date_end_savename = date_range[1].strftime('%Y%m%d')
+    if str(eval_period).upper() == 'TEST':
+        time_period_savename = f'{date_start_savename}-{date_end_savename}'
+    else:
+        time_period_savename = f'{eval_period}'
+
+    plot_info = f'vhrmean'
+    save_name = (f'{str(metric1_name).lower()}')
+    if metric2_name is not None:
+        save_name+=f'_{str(metric2_name).lower()}'
+    if fcst_thresh_on:
+        save_name+=f'_{str(fcst_thresholds_save_phrase).lower()}'
+    elif obs_thresh_on:
+        save_name+=f'_{str(obs_thresholds_save_phrase).lower()}'
+    if interp_pts and '' not in interp_pts:
+        save_name+=f'_{str(interp_pts_save_string).lower()}'
+    save_name+=f'.{str(var_savename).lower()}'
+    if level_savename:
+        save_name+=f'_{str(level_savename).lower()}'
+    save_name+=f'.{str(time_period_savename).lower()}'
+    save_name+=f'.{plot_info}'
+    save_name+=f'.{str(domain_save_string).lower()}'
+    
+    if save_header:
+        save_name = f'{save_header}.'+save_name
+    save_subdir = os.path.join(
+        save_dir, f'{str(plot_group).lower()}', 
+        f'{str(time_period_savename).lower()}'
+    )
+    if not os.path.isdir(save_subdir):
+        os.makedirs(save_subdir)
+    save_path = os.path.join(save_subdir, save_name+'.png')
+    fig.savefig(save_path, dpi=dpi)
+    if restart_dir:
+        shutil.copy2(
+            save_path, 
+            os.path.join(
+                restart_dir, 
+                f'{str(plot_group).lower()}', 
+                f'{str(time_period_savename).lower()}', 
+                save_name+'.png'
+            )
+        )
+    logger.info(u"\u2713"+f" plot saved successfully as {save_path}")
+    plt.close(num)
+    logger.info('========================================')
+
+
+def main():
+
+    # Logging
+    log_metplus_dir = '/'
+    for subdir in LOG_TEMPLATE.split('/')[:-1]:
+        log_metplus_dir = os.path.join(log_metplus_dir, subdir)
+    if not os.path.isdir(log_metplus_dir):
+        os.makedirs(log_metplus_dir)
+    logger = logging.getLogger(LOG_TEMPLATE)
+    logger.setLevel(LOG_LEVEL)
+    formatter = logging.Formatter(
+        '%(asctime)s.%(msecs)03d (%(filename)s:%(lineno)d) %(levelname)s: '
+        + '%(message)s',
+        '%m/%d %H:%M:%S'
+    )
+    file_handler = logging.FileHandler(LOG_TEMPLATE, mode='a')
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger_info = f"Log file: {LOG_TEMPLATE}"
+    print(logger_info)
+    logger.info(logger_info)
+
+    if str(EVAL_PERIOD).upper() == 'TEST':
+        valid_beg = VALID_BEG
+        valid_end = VALID_END
+        init_beg = INIT_BEG
+        init_end = INIT_END
+    else:
+        valid_beg = presets.date_presets[EVAL_PERIOD]['valid_beg']
+        valid_end = presets.date_presets[EVAL_PERIOD]['valid_end']
+        init_beg = presets.date_presets[EVAL_PERIOD]['init_beg']
+        init_end = presets.date_presets[EVAL_PERIOD]['init_end']
+    if str(DATE_TYPE).upper() == 'VALID':
+        e = (f"FATAL ERROR: You requested a valid_hour_average plot with the DATE_TYPE "
+             + f"set to 'VALID'. Valid time is already used as the independent"
+             + f" variable in valid_hour_average plots. Set the DATE_TYPE to"
+             + f" 'INIT' to equalize data by initialization"
+             + f" time.  Make sure neither FCST_INIT_HOUR nor"
+             + f" FCST_VALID_HOUR is an empty list.")
+        logger.error(e)
+        raise ValueError(e)
+    elif str(DATE_TYPE).upper() == 'INIT':
+        date_beg = init_beg
+        date_end = init_end
+        date_hours = INIT_HOURS
+        anti_date_hours = VALID_HOURS
+        anti_date_type_string = 'Valid'
+        xlabel=f'{str(anti_date_type_string).capitalize()} Hour (UTC)'
+    else:
+        e = (f"FATAL ERROR: Invalid DATE_TYPE: {str(date_type).upper()}. Valid values are"
+             + f" VALID or INIT")
+        logger.error(e)
+        raise ValueError(e)
+
+    logger.debug('========================================')
+    logger.debug("Config file settings")
+    logger.debug(f"LOG_LEVEL: {LOG_LEVEL}")
+    logger.debug(f"MET_VERSION: {MET_VERSION}")
+    logger.debug(f"URL_HEADER: {URL_HEADER if URL_HEADER else 'No header'}")
+    logger.debug(f"OUTPUT_BASE_DIR: {OUTPUT_BASE_DIR}")
+    logger.debug(f"STATS_DIR: {STATS_DIR}")
+    logger.debug(f"PRUNE_DIR: {PRUNE_DIR}")
+    logger.debug(f"SAVE_DIR: {SAVE_DIR}")
+    logger.debug(f"VERIF_CASETYPE: {VERIF_CASETYPE}")
+    logger.debug(f"MODELS: {MODELS}")
+    logger.debug(f"VARIABLES: {VARIABLES}")
+    logger.debug(f"DOMAINS: {DOMAINS}")
+    logger.debug(f"INTERP: {INTERP}")
+    logger.debug(f"DATE_TYPE: {DATE_TYPE}")
+    logger.debug(
+        f"EVAL_PERIOD: {EVAL_PERIOD}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_BEG: {date_beg}"
+    )
+    logger.debug(
+        f"{DATE_TYPE}_END: {date_end}"
+    )
+    logger.debug(f"VALID_HOURS: {VALID_HOURS}")
+    logger.debug(f"INIT_HOURS: {INIT_HOURS}")
+    logger.debug(f"FCST_LEADS: {FLEADS}")
+    logger.debug(f"FCST_LEVELS: {FCST_LEVELS}")
+    logger.debug(f"OBS_LEVELS: {OBS_LEVELS}")
+    logger.debug(
+        f"FCST_THRESH: {FCST_THRESH if FCST_THRESH else 'No thresholds'}"
+    )
+    logger.debug(
+        f"OBS_THRESH: {OBS_THRESH if OBS_THRESH else 'No thresholds'}"
+    )
+    logger.debug(f"LINE_TYPE: {LINE_TYPE}")
+    logger.debug(f"METRICS: {METRICS}")
+    logger.debug(f"CONFIDENCE_INTERVALS: {CONFIDENCE_INTERVALS}")
+    logger.debug(f"INTERP_PNTS: {INTERP_PNTS if INTERP_PNTS else 'No interpolation points'}")
+
+    logger.debug('----------------------------------------')
+    logger.debug(f"Advanced settings (configurable in {SETTINGS_DIR}/settings.py)")
+    logger.debug(f"Y_MIN_LIMIT: {Y_MIN_LIMIT}")
+    logger.debug(f"Y_MAX_LIMIT: {Y_MAX_LIMIT}")
+    logger.debug(f"Y_LIM_LOCK: {Y_LIM_LOCK}")
+    logger.debug(f"X_MIN_LIMIT: Ignored for series by valid hour")
+    logger.debug(f"X_MAX_LIMIT: Ignored for series by valid hour")
+    logger.debug(f"X_LIM_LOCK: Ignored for series by valid hour")
+    logger.debug(f"Display averages? {'yes' if display_averages else 'no'}")
+    logger.debug(
+        f"Clear prune directories? {'yes' if clear_prune_dir else 'no'}"
+    )
+    logger.debug(f"Plot upper-left logo? {'yes' if plot_logo_left else 'no'}")
+    logger.debug(
+        f"Plot upper-right logo? {'yes' if plot_logo_right else 'no'}"
+    )
+    logger.debug(f"Upper-left logo path: {path_logo_left}")
+    logger.debug(f"Upper-right logo path: {path_logo_right}")
+    logger.debug(
+        f"Upper-left logo fraction of original size: {zoom_logo_left}"
+    )
+    logger.debug(
+        f"Upper-right logo fraction of original size: {zoom_logo_right}"
+    )
+    if CONFIDENCE_INTERVALS:
+        logger.debug(f"Confidence Level: {int(ci_lev*100)}%")
+        logger.debug(f"Bootstrap method: {bs_method}")
+        logger.debug(f"Bootstrap repetitions: {bs_nrep}")
+        logger.debug(
+            f"Minimum sample size for confidence intervals: {bs_min_samp}"
+        )
+    logger.debug('========================================')
+
+    date_range = (
+        datetime.strptime(date_beg, '%Y%m%d'), 
+        datetime.strptime(date_end, '%Y%m%d')+td(days=1)-td(milliseconds=1)
+    )
+    if len(METRICS) == 1:
+        metrics = (METRICS[0], None)
+    elif len(METRICS) > 1:
+        metrics = METRICS[:2]
+    else:
+        e = (f"FATAL ERROR: Received no list of metrics.  Check that, for the METRICS"
+             + f" setting, a comma-separated string of at least one metric is"
+             + f" provided")
+        logger.error(e)
+        raise ValueError(e)
+    fcst_thresh_symbol, fcst_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in FCST_THRESH])
+    )
+    obs_thresh_symbol, obs_thresh_letter = list(
+        zip(*[plot_util.format_thresh(thresh) for thresh in OBS_THRESH])
+    )
+    num=0
+    e = ''
+    if str(VERIF_CASETYPE).lower() not in list(reference.case_type.keys()):
+        e = (f"FATAL ERROR: The requested verification case/type combination is not valid:"
+             + f" {VERIF_CASETYPE}")
+    elif str(LINE_TYPE).upper() not in list(
+            reference.case_type[str(VERIF_CASETYPE).lower()].keys()):
+        e = (f"FATAL ERROR: The requested line_type is not valid for {VERIF_CASETYPE}:"
+             + f" {LINE_TYPE}")
+    else:
+        case_specs = (
+            reference.case_type
+            [str(VERIF_CASETYPE).lower()]
+            [str(LINE_TYPE).upper()]
+        )
+    if e:
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    if (str(INTERP).upper() 
+            not in case_specs['interp'].replace(' ','').split(',')):
+        e = (f"FATAL ERROR: The requested interp method is not valid for the"
+             + f" requested case type ({VERIF_CASETYPE}) and"
+             + f" line_type ({LINE_TYPE}): {INTERP}")
+        logger.error(e)
+        logger.error("Quitting ...")
+        raise ValueError(e+"\nQuitting ...")
+    for metric in metrics:
+        if metric is not None:
+            if (str(metric).lower() 
+                    not in case_specs['plot_stats_list']
+                    .replace(' ','').split(',')):
+                e = (f"FATAL ERROR: The requested metric is not valid for the"
+                     + f" requested case type ({VERIF_CASETYPE}) and"
+                     + f" line_type ({LINE_TYPE}): {metric}")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+    for requested_var in VARIABLES:
+        if requested_var in list(case_specs['var_dict'].keys()):
+            var_specs = case_specs['var_dict'][requested_var]
+        else:
+            e = (f"The requested variable is not valid for the requested case"
+                 + f" type ({VERIF_CASETYPE}) and line_type ({LINE_TYPE}):"
+                 + f" {requested_var}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+            continue
+        fcst_var_names = var_specs['fcst_var_names']
+        obs_var_names = var_specs['obs_var_names']
+        symbol_keep = []
+        letter_keep = []
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_symbol, obs_thresh_symbol])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds']
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                symbol_keep.append(True)
+            else:
+                symbol_keep.append(False)
+        for fcst_thresh, obs_thresh in list(
+                zip(*[fcst_thresh_letter, obs_thresh_letter])):
+            if (fcst_thresh in var_specs['fcst_var_thresholds']
+                    and obs_thresh in var_specs['obs_var_thresholds']):
+                letter_keep.append(True)
+            else:
+                letter_keep.append(False)
+        keep = np.add(letter_keep, symbol_keep)
+        dropped_items = np.array(FCST_THRESH)[~keep].tolist()
+        fcst_thresh = np.array(FCST_THRESH)[keep].tolist()
+        obs_thresh = np.array(OBS_THRESH)[keep].tolist()
+        if dropped_items:
+            dropped_items_string = ', '.join(dropped_items)
+            e = (f"The requested thresholds are not valid for the requested"
+                 + f" case type ({VERIF_CASETYPE}) and line_type"
+                 + f" ({LINE_TYPE}): {dropped_items_string}")
+            logger.warning(e)
+            logger.warning("Continuing ...")
+        plot_group = var_specs['plot_group']
+        if FCST_LEVELS in presets.level_presets:
+            fcst_levels = re.split(r',(?![0*])', presets.level_presets[FCST_LEVELS].replace(' ',''))
+        else:
+            fcst_levels = re.split(r',(?![0*])', FCST_LEVELS.replace(' ',''))
+        if OBS_LEVELS in presets.level_presets:
+            obs_levels = re.split(r',(?![0*])', presets.level_presets[OBS_LEVELS].replace(' ',''))
+        else:
+            obs_levels = re.split(r',(?![0*])', OBS_LEVELS.replace(' ',''))
+        for l, fcst_level in enumerate(fcst_levels):
+            if len(fcst_levels) != len(obs_levels):
+                e = ("FATAL ERROR: FCST_LEVELS and OBS_LEVELS must be lists of the same"
+                     + f" size")
+                logger.error(e)
+                logger.error("Quitting ...")
+                raise ValueError(e+"\nQuitting ...")
+            if (fcst_levels[l] not in var_specs['fcst_var_levels'] 
+                    or obs_levels[l] not in var_specs['obs_var_levels']):
+                e = (f"The requested variable/level combination is not valid: "
+                     + f"{requested_var}/{fcst_level}")
+                logger.warning(e)
+                continue
+            for domain in DOMAINS:
+                if str(domain) not in case_specs['vx_mask_list']:
+                    e = (f"The requested domain is not valid for the requested"
+                         + f" case type ({VERIF_CASETYPE}) and line_type"
+                         + f" ({LINE_TYPE}): {domain}")
+                    logger.warning(e)
+                    logger.warning("Continuing ...")
+                    continue
+                df = df_preprocessing.get_preprocessed_data(
+                    logger, STATS_DIR, PRUNE_DIR, OUTPUT_BASE_TEMPLATE, VERIF_CASE, 
+                    VERIF_TYPE, LINE_TYPE, DATE_TYPE, date_range, EVAL_PERIOD, 
+                    date_hours, FLEADS, requested_var, fcst_var_names, obs_var_names, 
+                    MODELS, domain, INTERP, INTERP_PNTS, MET_VERSION, clear_prune_dir
+                )
+                if df is None:
+                    continue
+                df_metric = df
+                plot_valid_hour_average(
+                    df_metric, logger, date_range, MODELS, num=num, 
+                    flead=FLEADS, level=fcst_level, fcst_thresh=fcst_thresh,
+                    obs_thresh=obs_thresh,
+                    metric1_name=metrics[0], metric2_name=metrics[1], 
+                    date_type=DATE_TYPE, y_min_limit=Y_MIN_LIMIT, 
+                    y_max_limit=Y_MAX_LIMIT, y_lim_lock=Y_LIM_LOCK, 
+                    xlabel=xlabel, line_type=LINE_TYPE, verif_type=VERIF_TYPE, 
+                    date_hours=date_hours, anti_date_hours=anti_date_hours, 
+                    eval_period=EVAL_PERIOD, save_dir=SAVE_DIR,
+                    restart_dir=RESTART_DIR,
+                    display_averages=display_averages, save_header=URL_HEADER, 
+                    plot_group=plot_group, 
+                    confidence_intervals=CONFIDENCE_INTERVALS, bs_nrep=bs_nrep, 
+                    interp_pts=INTERP_PNTS, bs_method=bs_method, ci_lev=ci_lev, 
+                    bs_min_samp=bs_min_samp,
+                    sample_equalization=sample_equalization,
+                    plot_logo_left=plot_logo_left,
+                    plot_logo_right=plot_logo_right,
+                    path_logo_left=path_logo_left,
+                    path_logo_right=path_logo_right,
+                    zoom_logo_left=zoom_logo_left,
+                    zoom_logo_right=zoom_logo_right
+                )
+                num+=1
+
+
+# ============ START USER CONFIGURATIONS ================
+if __name__ == "__main__":
+    print("\n=================== CHECKING CONFIG VARIABLES =====================\n")
+    LOG_METPLUS = check_LOG_METPLUS(os.environ['LOG_METPLUS'])
+    LOG_LEVEL = check_LOG_LEVEL(os.environ['LOG_LEVEL'])
+    MET_VERSION = check_MET_VERSION(os.environ['MET_VERSION'])
+    URL_HEADER = check_URL_HEADER(os.environ['URL_HEADER'])
+    VERIF_CASE = check_VERIF_CASE(os.environ['VERIF_CASE'])
+    VERIF_TYPE = check_VERIF_TYPE(os.environ['VERIF_TYPE'])
+    OUTPUT_BASE_DIR = check_OUTPUT_BASE_DIR(os.environ['OUTPUT_BASE_DIR'])
+    STATS_DIR = OUTPUT_BASE_DIR
+    PRUNE_DIR = check_PRUNE_DIR(os.environ['PRUNE_DIR'])
+    SAVE_DIR = check_SAVE_DIR(os.environ['SAVE_DIR'])
+    DATE_TYPE = check_DATE_TYPE(os.environ['DATE_TYPE'])
+    LINE_TYPE = check_LINE_TYPE(os.environ['LINE_TYPE'])
+    INTERP = check_INTERP(os.environ['INTERP'])
+    MODELS = check_MODELS(os.environ['MODELS']).replace(' ','').split(',')
+    DOMAINS = check_VX_MASK_LIST(os.environ['VX_MASK_LIST']).replace(' ','').split(',')
+
+    # valid hour (each plot will use all available valid_hours listed below)
+    VALID_HOURS = check_FCST_VALID_HOUR(os.environ['FCST_VALID_HOUR'], DATE_TYPE).replace(' ','').split(',')
+    INIT_HOURS = check_FCST_INIT_HOUR(os.environ['FCST_INIT_HOUR'], DATE_TYPE).replace(' ','').split(',')
+
+    # time period to cover (inclusive)
+    EVAL_PERIOD = check_EVAL_PERIOD(os.environ['EVAL_PERIOD'])
+    VALID_BEG = check_VALID_BEG(os.environ['VALID_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    VALID_END = check_VALID_END(os.environ['VALID_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_BEG = check_INIT_BEG(os.environ['INIT_BEG'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+    INIT_END = check_INIT_END(os.environ['INIT_END'], DATE_TYPE, EVAL_PERIOD, plot_type='time_series')
+
+    # list of variables
+    # Options: {'TMP','HGT','CAPE','RH','DPT','UGRD','VGRD','UGRD_VGRD','TCDC',
+    #           'VIS'}
+    VARIABLES = check_var_name(os.environ['var_name']).replace(' ','').split(',')
+
+    # list of lead hours
+    # Options: {list of lead hours; string, 'all'; tuple, start/stop flead; 
+    #           string, single flead}
+    FLEADS = check_FCST_LEAD(os.environ['FCST_LEAD']).replace(' ','').split(',')
+
+    # list of levels
+    FCST_LEVELS = check_FCST_LEVEL(os.environ['FCST_LEVEL'])
+    OBS_LEVELS = check_OBS_LEVEL(os.environ['OBS_LEVEL'])
+
+    FCST_THRESH = check_FCST_THRESH(os.environ['FCST_THRESH'], LINE_TYPE)
+    OBS_THRESH = check_OBS_THRESH(os.environ['OBS_THRESH'], FCST_THRESH, LINE_TYPE).replace(' ','').split(',')
+    FCST_THRESH = FCST_THRESH.replace(' ','').split(',')
+    
+    # requires two metrics to plot
+    METRICS = list(filter(None, check_STATS(os.environ['STATS']).replace(' ','').split(',')))
+
+    # set the lowest possible lower (and highest possible upper) axis limits. 
+    # E.g.: If Y_LIM_LOCK == True, use Y_MIN_LIMIT as the definitive lower 
+    # limit (ditto with Y_MAX_LIMIT)
+    # If Y_LIM_LOCK == False, then allow lower and upper limits to adjust to 
+    # data as long as limits don't overcome Y_MIN_LIMIT or Y_MAX_LIMIT 
+    Y_MIN_LIMIT = toggle.plot_settings['y_min_limit']
+    Y_MAX_LIMIT = toggle.plot_settings['y_max_limit']
+    Y_LIM_LOCK = toggle.plot_settings['y_lim_lock']
+
+
+    # configure CIs
+    CONFIDENCE_INTERVALS = check_CONFIDENCE_INTERVALS(os.environ['CONFIDENCE_INTERVALS']).replace(' ','')
+    bs_nrep = toggle.plot_settings['bs_nrep']
+    bs_method = toggle.plot_settings['bs_method']
+    ci_lev = toggle.plot_settings['ci_lev']
+    bs_min_samp = toggle.plot_settings['bs_min_samp']
+
+    # list of points used in interpolation method
+    INTERP_PNTS = check_INTERP_PTS(os.environ['INTERP_PNTS']).replace(' ','').split(',')
+
+    # At each value of the independent variable, whether or not to remove
+    # samples used to aggregate each statistic if the samples are not shared
+    # by all models.  Required to display sample sizes
+    sample_equalization = toggle.plot_settings['sample_equalization']
+
+    # Whether or not to display average values beside legend labels
+    display_averages = toggle.plot_settings['display_averages']
+
+    # Whether or not to clear the intermediate directory that stores pruned data
+    clear_prune_dir = toggle.plot_settings['clear_prune_directory']
+
+    # Information about logos
+    plot_logo_left = toggle.plot_settings['plot_logo_left']
+    plot_logo_right = toggle.plot_settings['plot_logo_right']
+    zoom_logo_left = toggle.plot_settings['zoom_logo_left']
+    zoom_logo_right = toggle.plot_settings['zoom_logo_right']
+    path_logo_left = paths.logo_left_path
+    path_logo_right = paths.logo_right_path
+
+    OUTPUT_BASE_TEMPLATE = templates.output_base_template
+
+    print("\n===================================================================\n")
+    # ============= END USER CONFIGURATIONS =================
+
+    LOG_TEMPLATE = str(LOG_TEMPLATE)
+    LOG_LEVEL = str(LOG_LEVEL)
+    MET_VERSION = float(MET_VERSION)
+    VALID_HOURS = [
+        int(valid_hour) if valid_hour else None for valid_hour in VALID_HOURS
+    ]
+    INIT_HOURS = [
+        int(init_hour) if init_hour else None for init_hour in INIT_HOURS
+    ]
+    FLEADS = [int(flead) for flead in FLEADS]
+    INTERP_PNTS = [str(pts) for pts in INTERP_PNTS]
+    VERIF_CASETYPE = str(VERIF_CASE).lower() + '_' + str(VERIF_TYPE).lower()
+    CONFIDENCE_INTERVALS = str(CONFIDENCE_INTERVALS).lower() in [
+        'true', '1', 't', 'y', 'yes'
+    ]
+    main()


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>
## Description of Changes
> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR is for adding the plotting scripts to REFS component in EVSv2. I have tested all of the plotting jobs and the
plots from my testing are displayed in the following REFS testing web-site which also can be used for this PR testing
https://www.emc.ncep.noaa.gov/users/verification/regional/cam/expr/refs/grid2grid/apcp1
All of the REFS plotting scripts are brand new and added into ecf, dev, scripts/plots/cam, ush/cam, and parm
directories. Since the plotting scripts for REFS are very similar to those of HREF, I believe that all of the issues solved for HREF have also been addressed in this PR (including resent issues like EVAL_PERIOD, nmods in the python codes).
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes
* Do you have any planned upcoming annual leave/PTO? No 
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No 
  
- [ y] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [y ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [y ] References the feature branch for `HOMEevs` are removed from the code.
- [ y] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [y ] Jobs over 15 minutes in runtime have restart capability.
- [y ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ y] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ y] Code is using METplus wrappers structure and not calling MET executables directly.
- [ y] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Following 7 "31days" jobs
jevs_plots_cam_refs_grid2obs_cape_last31days.sh
jevs_plots_cam_refs_precip_last31days.sh
jevs_plots_cam_refs_spcoutlook_last31days.sh
jevs_plots_cam_refs_grid2obs_ctc_last31days.sh
jevs_plots_cam_refs_profile_last31days.sh
jevs_plots_cam_refs_grid2obs_ecnt_last31days.sh
jevs_plots_cam_refs_snowfall_last31days.sh

and 7 "90days" jobs
jevs_plots_cam_refs_grid2obs_cape_last90days.sh
jevs_plots_cam_refs_precip_last90days.sh
jevs_plots_cam_refs_spcoutlook_last90days.sh
jevs_plots_cam_refs_grid2obs_ctc_last90days.sh
jevs_plots_cam_refs_profile_last90days.sh
jevs_plots_cam_refs_grid2obs_ecnt_last90days.sh
jevs_plots_cam_refs_snowfall_last90days.sh

plus one spatial map job
jevs_plots_cam_refs_precip_spatial.sh

Note: Since only I have historic REFS stat files, for all of the jobs, please re-point the COMIN to my personal path
export COMIN=/lfs/h2/emc/vpppg/noscrub/binbin.zhou/$NET/$evs_ver_2d

The each job has one big tar file that will be stored in the ptmp directory
