### PR TITLE
Nco patch v2.0.5

### DIFF
--- a/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
+++ b/ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf
@@ -51,7 +51,6 @@ fi
 export nproc=128
 export USE_CFP=YES
 
-export envir=prod
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=grid2obs

--- a/jobs/JEVS_PREP_AQM
+++ b/jobs/JEVS_PREP_AQM
@@ -37,8 +37,6 @@ export cycle=${cycle:-t${vhr}z}
 setpdy.sh
 . ./PDY
 
-export envir=${envir:-prod}
-
 export NET=${NET:-evs}
 export STEP=${STEP:-prep}
 export COMPONENT=${COMPONENT:-aqm}

--- a/jobs/JEVS_PREP_GLOBAL_CHEM
+++ b/jobs/JEVS_PREP_GLOBAL_CHEM
@@ -30,10 +30,6 @@ export DATA=${DATA:-${DATAROOT:?}/${jobid:?}}
 mkdir -p ${DATA}
 cd ${DATA}
 
-export envir=${envir:-prod}
-
-echo ${COMPATH}
-
 export NET=${NET:-evs}
 export STEP=${STEP:-prep}
 export COMPONENT=${COMPONENT:-global_chem}

--- a/jobs/JEVS_STATS_AQM
+++ b/jobs/JEVS_STATS_AQM
@@ -36,8 +36,6 @@ export cycle=${cycle:-t${vhr}z}
 setpdy.sh
 . ./PDY
 
-export envir=${envir:-prod}
-
 # Define COMIN/COMOUT variables:
 
 echo ${COMPATH}

--- a/jobs/JEVS_STATS_GLOBAL_CHEM
+++ b/jobs/JEVS_STATS_GLOBAL_CHEM
@@ -34,8 +34,6 @@ cd $DATA
 setpdy.sh
 . ./PDY
 
-export envir=${envir:-prod}
-
 # Define COMIN/COMOUT variables:
 
 echo ${COMPATH}

--- a/scripts/stats/global_det/exevs_stats_global_det_atmos_grid2grid.sh
+++ b/scripts/stats/global_det/exevs_stats_global_det_atmos_grid2grid.sh
@@ -10,6 +10,7 @@
 set -x
 
 export VERIF_CASE_STEP_abbrev="g2gs"
+export MET_PYTHON_EXE=$( which python )
 
 echo "RUN MODE:$evs_run_mode"
 

--- a/ush/global_ens/ush_gens_plot_py/df_preprocessing.py
+++ b/ush/global_ens/ush_gens_plot_py/df_preprocessing.py
@@ -133,7 +133,7 @@ def create_df(logger, stats_dir, pruned_data_dir, line_type, date_range,
             ))
             df_tmp = pd.read_csv(
                 fpath, delim_whitespace=True, header=None, skiprows=1,
-                names=df_colnames, dtype=str
+                names=df_colnames, dtype=str, on_bad_lines='warn'
             )
             i = -1*len(df_line_type_colnames)
             for col_name in df_colnames[i:]:

--- a/ush/mesoscale/ush_sref_plot_py/lead_average.py
+++ b/ush/mesoscale/ush_sref_plot_py/lead_average.py
@@ -896,6 +896,10 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         for y in [-5,-4,-3,-2,-1,0,1,2,3,4,5]
     ]).flatten()
     round_to_nearest_categories = y_range_categories/20.
+    if math.isinf(y_min):
+        y_min = y_min_limit
+    if math.isinf(y_max):
+        y_max = y_max_limit
     y_range = y_max-y_min
     round_to_nearest =  round_to_nearest_categories[
         np.digitize(y_range, y_range_categories[:-1])


### PR DESCRIPTION
## Description of Changes

There were some failures over the weekend in EVS v2.0.5 in **para** as a result of changes applied in #898. This PR applies fixes for those changes and adds one additional fix.

This PR makes the following changes:

- Remove export envir from following scripts:
  - `ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf`
  - `jobs/JEVS_PREP_AQM`
  - `jobs/JEVS_PREP_GLOBAL_CHEM`
  - `jobs/JEVS_STATS_AQM`
  - `jobs/JEVS_STATS_GLOBAL_CHEM`
- Add `on_bad_lines=’warn’` to `ush/global_ens/ush_gens_plot_py/df_preprocessing.py`
- Add `export MET_PYTHON_EXE=$( which python )` to `scripts/stats/global_det/exevs_stats_global_det_atmos_grid2grid.sh`
- Apply fix from #904 

Using `export envir=` was causing jobs to not find data in para and sometimes resulting in failures. In operations this variable is set in `head.h` in the job card and should not be modified.

I applied the fix to `ush/global_ens/ush_gens_plot_py/df_preprocessing.py` following similar change to SREF files.

Exporting `MET_PYTHON_EXE` appears to be necessary, but hard-coded paths are against production standards, so I replaced with `which python`.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes. Please review this PR for inclusion in EVS v2.0.5 evaluation.

* Do you have any planned upcoming annual leave/PTO?

N/A

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  
N/A

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

The following jobs have been run to test the changes listed above. Please find corresponding output files on Cactus at `/lfs/h1/nco/idsb/noscrub/russell.manser/projects/evs/para_failures/evs.v2.0.5`

- Remove export envir
  - Job: ecf/scripts/plots/global_chem/jevs_plots_global_chem_atmos_grid2obs_airnow_last90days.ecf: envir/evs_plots_global_chem_atmos_grid2obs_airnow_last90days.o94420615
  - Job: ecf/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2obs.ecf: evs_prep_aqm_atmos_grid2obs.o94433305
  - Job: ecf/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2grid.ecf: evs_prep_aqm_atmos_grid2grid.o94433306
  - Job: ecf/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2obs_vhr_00.ecf: evs_stats_aqm_atmos_grid2obs_vhr_00.o94433669
  - Job: ecf/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.ecf: evs_prep_global_chem_atmos_grid2obs.o94433774
  - Job: ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow_vhr_00.ecf: evs_stats_global_chem_atmos_grid2obs_airnow_vhr_00.o94434090
  - Job: ecf/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00.ecf: evs_stats_global_chem_atmos_grid2obs_aeronet_vhr_00.o94434091
- Add on_bad_lines=’warn’ to ush/global_ens/ush_gens_plot_py/df_preprocessing.py
  - Job: ecf/scripts/plots/global_ens/jevs_plots_global_ens_atmos_gefs_profile3_last90days.ecf
  - Output: evs_plots_global_ens_atmos_gefs_profile3_last90days.warn_bad_lines
- Add export MET_PYTHON_EXE=$( which python )
  - Job: ecf/scripts/stats/global_det/evs_stats_global_det_gfs_atmos_grid2grid.ecf
  - Output: evs_stats_global_det_gfs_atmos_grid2grid.MET_PYTHON_EXE
- Apply fix from https://github.com/NOAA-EMC/EVS/pull/904