### PR TITLE
Add jason3 and prepbufr_gdas obs types

### DIFF
--- a/ecf/scripts/prep/global_det/jevs_prep_global_det_wave.ecf
+++ b/ecf/scripts/prep/global_det/jevs_prep_global_det_wave.ecf
@@ -50,7 +50,7 @@ fi
 export NET=evs
 export RUN=wave
 export MODELNAME="gfs"
-export OBSNAME="ndbc"
+export OBSNAME="ndbc jason3 prepbufr_gdas"
 
 ############################################################
 # Execute j-job


### PR DESCRIPTION
## Description of Changes

This PR adds `jason3` and `prepbufr_gdas` observation types in `ecf/scripts/prep/global_det/jevs_prep_global_det_wave.ecf`.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes. This change is already active in EVS v2.0.5 evaluation in production.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Run `ecf/scripts/prep/global_det/jevs_prep_global_det_wave.ecf` to confirm that the following subdirectories and data within them are being produced.

`prep/global_det/wave.<PDY>/jason3/jason3.20260211.nc`
`prep/global_det/wave.<PDY>/prepbufr_gdas/gdas.SFCSHP.<PDY>00.nc`
`prep/global_det/wave.<PDY>/prepbufr_gdas/gdas.SFCSHP.<PDY>06.nc`
`prep/global_det/wave.<PDY>/prepbufr_gdas/gdas.SFCSHP.<PDY>12.nc`
`prep/global_det/wave.<PDY>/prepbufr_gdas/gdas.SFCSHP.<PDY>18.nc`