### PR TITLE
Move dbnet_alert into g2op_type_list loop

### DIFF
--- a/scripts/plots/aqm/exevs_plots_aqm_grid2obs.sh
+++ b/scripts/plots/aqm/exevs_plots_aqm_grid2obs.sh
@@ -187,11 +187,11 @@ if [ "${SENDCOM}" == "YES" ]; then
                 cp -v ${large_tar_file} ${COMOUT}/.
             fi
         fi
+        if [ "${SENDDBN}" == "YES" ]; then
+            ${DBNROOT}/bin/dbn_alert MODEL EVS_RZDM ${job} ${COMOUT}/${tar_file_combine}
+        fi
     done
     cd ${DATA}
 fi
 
-if [ "${SENDDBN}" == "YES" ]; then
-    ${DBNROOT}/bin/dbn_alert MODEL EVS_RZDM ${job} ${COMOUT}/${tar_file_combine}
-fi
 exit


### PR DESCRIPTION
## Description of Changes

This PR fixes a bug where the following files were not being alerted:
- `com/evs/v2.0/plots/aqm/atmos.<VDATE>/evs.plots.aqm.atmos.grid2obs_ozmax8.last90days.v<VDATE>.tar`
- `com/evs/v2.0/plots/aqm/atmos.<VDATE>/evs.plots.aqm.atmos.grid2obs_ozone.last31days.v<VDATE>.tar`

This change moves the call to `dbnet_alert` into the loop over `g2op_type_list`.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, this is a bugfix for EVS v2.0 in production during its 30-day IT test. I do not anticipate needing to restart the 30-day test for this change, but I will need to upgrade EVS to v2.0.6.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Please find the output and dbnet_alert logs on **Cactus** at `/lfs/h1/nco/idsb/noscrub/russell.manser/projects/evs/dbnet_alerts/`
- `evs_plots_aqm_atmos_grid2obs_daily_last90days.o96473241`
- `evs_plots_aqm_atmos_grid2obs_hourly_last31days.o96473240`
- `atmos.20260218/dbnlogs/evs_plots_aqm_atmos_grid2obs_daily_last90days.20260218.dbnlog`
- `atmos.20260218/dbnlogs/evs_plots_aqm_atmos_grid2obs_hourly_last31days.20260218.dbnlog`