### PR TITLE
Fix read logic for SPC OTLK dbfs

### DIFF
--- a/ush/cam/evs_prep_spc_otlk.py
+++ b/ush/cam/evs_prep_spc_otlk.py
@@ -106,12 +106,12 @@ for DAY in range(1,4):
                         NAME = cutil.run_shell_command([
                                'gis_dump_dbf', 
                                os.path.join(OTLK_DIR,f'{SHP_FILE}.dbf'),
-                               '|', 'sed', '-n', f"'\^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
+                               '|', 'sed', '-n', f"'/^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
                                '|', 'grep', '-m1', "'LABEL'" # Get the label line from Record #REC
                                '|', 'cut', '-d\'"\'', '-f2'], # Get the label value 
                                capture_output=True)
                         NAME = NAME.replace('\n','')
-                        regexp="^[^:. ()]*$"
+                        regexp="^[^:. ()]+$"
                         if not re.match(regexp, NAME):
                             print(f'NOTE: Record name ({NAME}) '
                                   + f'indicates no outlooks for Day {DAY} '

--- a/ush/cam/evs_prep_spc_otlk.py
+++ b/ush/cam/evs_prep_spc_otlk.py
@@ -106,9 +106,9 @@ for DAY in range(1,4):
                         NAME = cutil.run_shell_command([
                                'gis_dump_dbf', 
                                os.path.join(OTLK_DIR,f'{SHP_FILE}.dbf'),
-                               '|', 'egrep', '-A', '5', f'"^Record {REC}"',
-                               '|', 'tail','-1',
-                               '|', 'cut', '-d\'"\'', '-f2'],
+                               '|', 'sed', '-n', f"'\^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
+                               '|', 'grep', '-m1', "'LABEL'" # Get the label line from Record #REC
+                               '|', 'cut', '-d\'"\'', '-f2'], # Get the label value 
                                capture_output=True)
                         NAME = NAME.replace('\n','')
                         regexp="^[^:. ()]*$"

--- a/ush/mesoscale/evs_prep_spc_otlk.py
+++ b/ush/mesoscale/evs_prep_spc_otlk.py
@@ -106,9 +106,9 @@ for DAY in range(1,4):
                         NAME = cutil.run_shell_command([
                                'gis_dump_dbf', 
                                os.path.join(OTLK_DIR,f'{SHP_FILE}.dbf'),
-                               '|', 'egrep', '-A', '5', f'"^Record {REC}"',
-                               '|', 'tail','-1',
-                               '|', 'cut', '-d\'"\'', '-f2'],
+                               '|', 'sed', '-n', f"'\^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
+                               '|', 'grep', '-m1', "'LABEL'" # Get the label line from Record #REC
+                               '|', 'cut', '-d\'"\'', '-f2'], # Get the label value
                                capture_output=True)
                         NAME = NAME.replace('\n','')
                         regexp="^[^:. ()]*$"

--- a/ush/mesoscale/evs_prep_spc_otlk.py
+++ b/ush/mesoscale/evs_prep_spc_otlk.py
@@ -106,12 +106,12 @@ for DAY in range(1,4):
                         NAME = cutil.run_shell_command([
                                'gis_dump_dbf', 
                                os.path.join(OTLK_DIR,f'{SHP_FILE}.dbf'),
-                               '|', 'sed', '-n', f"'\^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
+                               '|', 'sed', '-n', f"'/^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
                                '|', 'grep', '-m1', "'LABEL'" # Get the label line from Record #REC
                                '|', 'cut', '-d\'"\'', '-f2'], # Get the label value
                                capture_output=True)
                         NAME = NAME.replace('\n','')
-                        regexp="^[^:. ()]*$"
+                        regexp="^[^:. ()]+$"
                         if not re.match(regexp, NAME):
                             print(f'NOTE: Record name ({NAME}) '
                                   + f'indicates no outlooks for Day {DAY} '


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

- _Issue:_ SPC Outlook dbf files have been changed, which breaks the way EVS/cam and /mesoscale read them.  The result is that EVS is unable to produce SPC Outlook masks.  _Fix:_ Change dbf read logic to explicitly select the needed label value from dbf.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, it affects ops EVS.
* Do you have any planned upcoming annual leave/PTO?

Yes, March 10-13 
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/read_spc_otlk_dbf
```

#### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter):
```
jevs_prep_cam_severe
jevs_prep_mesoscale_grid2obs
```
[Total: _2 prep jobs_]

#### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver} 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

#### 4) Test jobs

- `cd` into your test directory (where you want the log files to go)
- Submit the job's driver script using `qsub -v vhr=07 $driver` on the command line

#### 5) Check jobs
- I will check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- We should confirm that SPC Outlook files are generated in COMOUT

#### 6) During testing ...

- If I push changes or fixes during testing, you can usually update your branch like this:
```
git pull origin bugfix/read_spc_otlk_dbf
```