### PR TITLE
Update downstream code due to GCAFSv1 encoding changes

### DIFF
--- a/parm/metplus_config/stats/global_chem/atmos_grid2obs/PointStat_fcstGCAFS_obsAERONET.conf
+++ b/parm/metplus_config/stats/global_chem/atmos_grid2obs/PointStat_fcstGCAFS_obsAERONET.conf
@@ -48,12 +48,12 @@ POINT_STAT_DESC = G004
 ## For `GRIB2_ipdtmpl_index = [ idx1, idx2,... ]; GRIB2_ipdtmpl_val = [ val1, val2,... ];`
 ##   with ${DEGRIB2} in `module grib_util`; `${DEGRIB2} grib2_file`
 ##   read PRODUCT TEMPLATE #.##; index order starts from 0.
-##   For example, index 2 is 62000 and index 10 is 550 from the line
+##   For example, index 2 is 62000 and index 10 is 545 from the line
 ##   PRODUCT TEMPLATE 4. 48: ( PARAMETER = AOTK     0 20 102 )
-##       20 102 62000 0 6 20 0 0 7 9 550 9 550 2 0 96 0 0 1 120 10 0 0 255 0 0
+##       20 102 62000 0 6 20 0 0 7 9 545 9 565 2 0 97 0 0 1 117 10 0 0 255 0 0
 FCST_VAR1_NAME = AOTK
 FCST_VAR1_LEVELS = L0
-FCST_VAR1_OPTIONS = GRIB2_ipdtmpl_index = [ 2, 10 ]; GRIB2_ipdtmpl_val = [ 62000, 550 ]
+FCST_VAR1_OPTIONS = GRIB2_ipdtmpl_index = [ 2, 10 ]; GRIB2_ipdtmpl_val = [ 62000, 545 ]
 
 OBS_VAR1_NAME = AOD
 OBS_VAR1_LEVELS = Z550

--- a/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
+++ b/scripts/prep/global_chem/exevs_prep_global_chem_atmos_grid2obs.sh
@@ -153,7 +153,7 @@ done
 match_aod_1=":AOTK:"
 match_aod_2="aerosol=Total Aerosol"
 match_aod_3="aerosol_size <2e-05"
-match_aod_4="aerosol_wavelength >=5.5e-07,<=5.5e-07"
+match_aod_4="aerosol_wavelength >=5.45e-07,<=5.65e-07"
 match_pm25_1="PMTF"
 match_pm25_2="aerosol=Total Aerosol"
 match_pm25_3="aerosol_size <2.5e-06"


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

The GCAFSv1 developer changed the grib2 encoding for the Aerosol Optical Thickness (AOTK) at 550nm, which is utilized for EVSv2.0 verification.

The corresponding GRIB2 messages for AOTK are:
02/22: 20:10960483:vt=2026022621:entire atmosphere:117 hour fcst:AOTK Aerosol Optical Thickness [Numeric]:aerosol=Total Aerosol:aerosol_size <2e-05:aerosol_wavelength **>=5.5e-07,<=5.5e-07**
02/23: 20:10319700:vt=2026022721:entire atmosphere:117 hour fcst:AOTK Aerosol Optical Thickness [Numeric]:aerosol=Total Aerosol:aerosol_size <2e-05:aerosol_wavelength >**=5.45e-07,<=5.65e-07**

Consequently, the criteria for trimming the full grib2 output and for data matching in MetPlus must be updated to align with these changes


## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES, 03/11/2026

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 NO
 
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

(1) Prep test

run ~/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh

with changes;

add 
export COMINgcafs=/lfs/h2/emc/ptmp/li.pan/newtest/COMROOT/dogtest

Adjust HOMEevs for PR test
Adjust COMOUT for PR test

Run today's prep (default to 2026/03/01)

(2) Stats test
Run 
jevs_stats_global_chem_atmos_grid2obs_aeronetsh
jevs_stats_global_chem_atmos_grid2obs_airnow.sh

in ~/dev/drivers/scripts/stats/global_chem

with changes; (need at least 6 days of prep for 120 fcst hours)

export COMIN=/lfs/h2/emc/physics/noscrub/ho-chun.huang/evs/gcafsr1_v2.0

Adjust HOMEevs for PR test
Adjust COMOUT for PR test

Run today's stats (default to 2026/03/01)

submit vhr=00, 03, 06, 09, 12, 15, 18 at the same time. After previous "vhr"s were done, submit vhr=21.