### PR TITLE
Add prep/mesoscale directories to transfer list

### DIFF
--- a/parm/transfer/transfer_evs_prep.list
+++ b/parm/transfer/transfer_evs_prep.list
@@ -41,6 +41,9 @@ _COMROOT_/evs/_SHORTVER_/prep/
 + /global_chem/
 + /global_chem/*._PDYm4_/***
 + /global_chem/*._PDYm3_/***
++ /mesoscale/
++ /mesoscale/*._PDYm2_/***
++ /mesoscale/*._PDYm1_/***
 + /nfcens/
 + /nfcens/wave._PDYm2_/***
 + /nfcens/wave._PDYm1_/***


### PR DESCRIPTION
## Description of Changes
- [x] Closes #922 

This PR adds `prep/mesoscale` COM directories to `parm/transfer/transfer_evs_prep.list`.

After this PR is approved, please create a release branch and tag for evs.v2.0.8. A code delivery is not required for this update.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, please review and merge this PR for inclusion in EVS v2.0 in evaulation mode.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

This change has been tested on the operational system (**Dogwood**) in the parallel production environment. You can find the output log for the corresponding transfer job on **Cactus** at

`/lfs/h1/nco/idsb/noscrub/russell.manser/projects/evs/transfer/output/transfer_evs_prep_1400.o100995666`

You can also check that files were transferred correctly by inspecting the following directory on **Cactus**:

`/lfs/h1/ops/para/com/evs/v2.0/prep/mesoscale/`

where you should see the following:

```
drwxrwsr-x 3 ops.para para 4096 Mar  4 07:00 atmos.20260303
drwxrwsr-x 3 ops.para para 4096 Mar  5 07:00 atmos.20260304
drwxrwsr-x 3 ops.para para 4096 Mar 12 07:00 atmos.20260311
drwxrwsr-x 3 ops.para para 4096 Mar 13 07:00 atmos.20260312
```