### PR TITLE
Add aigfs grid2grid and grid2obs stats to EVS

### DIFF
--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
@@ -1,0 +1,59 @@
+#PBS -N jevs_stats_global_det_aigfs_atmos_grid2grid_00
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=01:10:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=225GB
+#PBS -l debug=true
+
+set -x
+
+cd $PBS_O_WORKDIR
+
+export model=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+
+export SENDCOM=YES
+export SENDMAIL=YES
+export KEEPDATA=NO
+export job=${PBS_JOBNAME:-jevs_stats_global_det_aigfs_atmos_grid2grid}
+export jobid=$job.${PBS_JOBID:-$$}
+export SITE=$(cat /etc/cluster_name)
+export vhr=00
+
+source $HOMEevs/versions/run.ver
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/global_det/global_det_stats.sh
+
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export machine=WCOSS2
+export USE_CFP=YES
+export nproc=128
+
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+
+export envir=prod
+export NET=evs
+export STEP=stats
+export COMPONENT=global_det
+export RUN=atmos
+export VERIF_CASE=grid2grid
+export MODELNAME=aigfs
+
+export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
+export TMPDIR=$DATAROOT
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+
+export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+# CALL executable job script here
+$HOMEevs/jobs/JEVS_STATS_GLOBAL_DET
+
+######################################################################
+# Purpose: This does the statistics work for the global deterministic
+#          atmospheric grid-to-grid component for AIGFS
+######################################################################

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh
@@ -1,0 +1,59 @@
+#PBS -N jevs_stats_global_det_aigfs_atmos_grid2obs_00
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=01:45:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=300GB
+#PBS -l debug=true
+
+set -x
+
+cd $PBS_O_WORKDIR
+
+export model=evs
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+
+export SENDCOM=YES
+export SENDMAIL=YES
+export KEEPDATA=NO
+export job=${PBS_JOBNAME:-jevs_stats_global_det_aigfs_atmos_grid2obs}
+export jobid=$job.${PBS_JOBID:-$$}
+export SITE=$(cat /etc/cluster_name)
+export vhr=00
+
+source $HOMEevs/versions/run.ver
+module reset
+module load prod_envir/${prod_envir_ver}
+source $HOMEevs/dev/modulefiles/global_det/global_det_stats.sh
+
+evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+export machine=WCOSS2
+export USE_CFP=YES
+export nproc=128
+
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+
+export envir=prod
+export NET=evs
+export STEP=stats
+export COMPONENT=global_det
+export RUN=atmos
+export VERIF_CASE=grid2obs
+export MODELNAME=aigfs
+
+export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
+export TMPDIR=$DATAROOT
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+
+export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+# CALL executable job script here
+$HOMEevs/jobs/JEVS_STATS_GLOBAL_DET
+
+######################################################################
+# Purpose: This does the statistics work for the global deterministic
+#          atmospheric grid-to-observations component for AIGFS
+######################################################################

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1688,6 +1688,10 @@ suite evs_nco
               trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_grid2grid
               trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+            task jevs_stats_global_det_aigfs_atmos_grid2obs
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+            task jevs_stats_global_det_aigfs_atmos_grid2grid
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_gfs_atmos_wmo_daily
               trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
             task jevs_stats_global_det_fnmoc_atmos_grid2obs

--- a/ecf/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.ecf
@@ -1,0 +1,67 @@
+#PBS -N evs_stats_global_det_aigfs_atmos_grid2grid
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=01:10:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=225GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x
+export COMPONENT=global_det
+export STEP=stats
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export nproc=128
+export USE_CFP=YES
+export NET=evs
+export RUN=atmos
+export VERIF_CASE=grid2grid
+export MODELNAME=aigfs
+export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_STATS_GLOBAL_DET
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.ecf
@@ -1,0 +1,67 @@
+#PBS -N evs_stats_global_det_aigfs_atmos_grid2obs
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=01:45:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=300GB
+#PBS -l debug=true
+
+export model=evs
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x
+export COMPONENT=global_det
+export STEP=stats
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export nproc=128
+export USE_CFP=YES
+export NET=evs
+export RUN=atmos
+export VERIF_CASE=grid2obs
+export MODELNAME=aigfs
+export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_STATS_GLOBAL_DET
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/parm/evs_config/global_det/config.evs.prod.stats.global_det.atmos.grid2grid.aigfs
+++ b/parm/evs_config/global_det/config.evs.prod.stats.global_det.atmos.grid2grid.aigfs
@@ -1,0 +1,96 @@
+#!/bin/bash
+##---------------------------------------------------------------------------
+##---------------------------------------------------------------------------
+## NCEP EMC Verification System (EVS) - AIGFS Atmospheric
+##
+## CONTRIBUTORS: Mallory Row, mallory.row@noaa.gov, NOAA/NWS/NCEP/EMC-VPPPGB
+##               Qi Shi, qi.shi@noaa.gov
+## PURPOSE: Set up configurations to run EVS AIGFS Atmospheric standalone
+##---------------------------------------------------------------------------
+##--------------------------------------------------------------------------
+
+set -x
+
+echo "BEGIN: $(basename ${BASH_SOURCE[0]})"
+
+#####################################################
+# WHAT METPLUS USE CASES TO RUN FOR AIGFS ATMOSPHERIC
+#####################################################
+## SET TO "YES" or "NO"
+## EDIT SECTIONS BELOW FOR VERIFICATION TYPES REQUESTED
+export RUN_GRID2GRID_STATS="YES"
+export RUN_GRID2GRID_PLOTS="NO"
+export RUN_GRID2OBS_STATS="NO"
+export RUN_GRID2OBS_PLOTS="NO"
+
+####################################################
+# GENERAL SETTINGS APPLIED TO ALL USE CASES
+####################################################
+## INPUT DATA SETTINGS
+#model_list:             model names
+#model_evs_data_dir_list:    directory path to model .stat files
+#model_file_format_list: file format of model files
+export model_list="$MODELNAME"
+export model_evs_data_dir_list="$COMOUTfinal"
+export model_file_format_list="$COMIN/prep/$COMPONENT/${RUN}.{init?fmt=%Y%m%d}/${MODELNAME}/${MODELNAME}.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+
+## OUTPUT DATA SETTINGS
+#OUTPUTROOT: base output directory
+export OUTPUTROOT="$DATAROOT"
+## DATE SETTINGS
+#start_date:       verification start date, format YYYYMMDD
+#end_date:         verification end date, format YYYYMMDD
+export start_date=$VDATE
+export end_date=$VDATE
+####################################################
+# SETTINGS FOR SPECIFIC USE CASES
+####################################################
+if [ $RUN_GRID2GRID_STATS = YES ]; then
+    #g2gs_type_list: list type of verifications to run for grid-to-grid: pres_levs, precip_accum24hr,
+    #                                                                    precip_accum3hr, snow, sst, sea_ice
+    #                                                                    means
+    #    pres_levs:        compare variables on pressure levels to model's own analysis
+    #    precip_accum24hr: compare to CCPA 24 hour accumulation
+    #    precip_accum3hr:  compare to CCPA 3 hour accumulation
+    #    snow:             compare to NOHRSC
+    #    sst:              compare to GHRSST Median
+    #    sea_ice:          compare to OSI-SAF
+    #g2gs_pres_levs_truth_name_list: list of reference name for truth files
+    #g2gs_pres_levs_truth_format_list: list of truth file format(s)
+    #g2gs_precip_accum*_file_format_list: list of precip file format(s)
+    #g2gs_precip_accum*_file_accum_list: list of precip accumulations in file: hours (HH) or continuous
+    #g2gs_precip_accum*_var_list: list of the precip variable name to use
+    #g2gs_*_init_hr_list: list of cycles/initialization hours to be included in verification: HH
+    #g2gs_*_valid_hr_list: list of valid hours to be included in verification: HH
+    #For defining forecast hours:
+    #    g2gs*_fhr_list: list of forecast hours: HH[H]
+    #OR 
+    #    g2gs_*_fhr_min: forecast hour to start verification: HH[H]
+    #    g2gs_*_fhr_max: forecast hour to end verification: HH[H]
+    #    g2gs_*_fhr_inc: frequency to verify forecast hours: HH[H]
+    export g2gs_type_list="means pres_levs precip_accum24hr"
+    export g2gs_means_init_hr_list="00 06 12 18"
+    export g2gs_means_valid_hr_list="00 06 12 18"
+    export g2gs_means_fhr_min=24
+    export g2gs_means_fhr_max=384
+    export g2gs_means_fhr_inc=24
+    export g2gs_precip_accum24hr_file_format_list="$COMIN/prep/$COMPONENT/${RUN}.{init?fmt=%Y%m%d}/${MODELNAME}/${MODELNAME}.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+    export g2gs_precip_accum24hr_file_accum_list="6"
+    export g2gs_precip_accum24hr_var_list="APCP"
+    export g2gs_precip_accum24hr_init_hr_list="12"
+    export g2gs_precip_accum24hr_fhr_min=24
+    export g2gs_precip_accum24hr_fhr_max=384
+    export g2gs_precip_accum24hr_fhr_inc=24
+    export g2gs_pres_levs_truth_name_list="gfs_anl"
+    export g2gs_pres_levs_truth_format_list="$COMINgfs/gfs.{valid?fmt=%Y%m%d}/{valid?fmt=%2H}/atmos/gfs.t{valid?fmt=%2H}z.pgrb2.0p25.anl"
+    export g2gs_pres_levs_init_hr_list="00 06 12 18"
+    export g2gs_pres_levs_valid_hr_list="00 06 12 18"
+    export g2gs_pres_levs_fhr_min=6
+    export g2gs_pres_levs_fhr_max=384
+    export g2gs_pres_levs_fhr_inc=6
+    export g2gs_mv_database_name="mv_evs_global_det_atmos_grid2grid_stats_$MODELNAME"
+    export g2gs_mv_database_group="$USER"
+    export g2gs_mv_database_desc="Grid-to-grid METplus data for $MODELNAME"
+fi
+
+echo "END: $(basename ${BASH_SOURCE[0]})"

--- a/parm/evs_config/global_det/config.evs.prod.stats.global_det.atmos.grid2obs.aigfs
+++ b/parm/evs_config/global_det/config.evs.prod.stats.global_det.atmos.grid2obs.aigfs
@@ -1,0 +1,78 @@
+#!/bin/bash
+##---------------------------------------------------------------------------
+##---------------------------------------------------------------------------
+## NCEP EMC Verification System (EVS) - AIGFS Atmospheric
+##
+## CONTRIBUTORS: Mallory Row, mallory.row@noaa.gov, NOAA/NWS/NCEP/EMC-VPPPGB
+##               Qi Shi, qi.shi@noaa.gov
+## PURPOSE: Set up configurations to run EVS AIGFS Atmospheric standalone
+##---------------------------------------------------------------------------
+##--------------------------------------------------------------------------
+
+set -x
+
+echo "BEGIN: $(basename ${BASH_SOURCE[0]})"
+
+#####################################################
+# WHAT METPLUS USE CASES TO RUN FOR AIGFS ATMOSPHERIC
+#####################################################
+## SET TO "YES" or "NO"
+## EDIT SECTIONS BELOW FOR VERIFICATION TYPES REQUESTED
+export RUN_GRID2GRID_STATS="NO"
+export RUN_GRID2GRID_PLOTS="NO"
+export RUN_GRID2OBS_STATS="YES"
+export RUN_GRID2OBS_PLOTS="NO"
+
+####################################################
+# GENERAL SETTINGS APPLIED TO ALL USE CASES
+####################################################
+## INPUT DATA SETTINGS
+#model_list:             model names
+#model_evs_data_dir_list:    directory path to model .stat files
+#model_file_format_list: file format of model files
+export model_list="$MODELNAME"
+export model_evs_data_dir_list="$COMOUTfinal"
+export model_file_format_list="$COMIN/prep/$COMPONENT/${RUN}.{init?fmt=%Y%m%d}/${MODELNAME}/${MODELNAME}.t{init?fmt=%H}z.f{lead?fmt=%3H}"
+
+## OUTPUT DATA SETTINGS
+#OUTPUTROOT: base output directory
+export OUTPUTROOT="$DATAROOT"
+## DATE SETTINGS
+#start_date:       verification start date, format YYYYMMDD
+#end_date:         verification end date, format YYYYMMDD
+export start_date=$VDATE
+export end_date=$VDATE
+####################################################
+# SETTINGS FOR SPECIFIC USE CASES
+####################################################
+
+if [ $RUN_GRID2OBS_STATS = YES ]; then
+    #g2os_type_list: list type of verifications to run for grid-to-obs: pres_levs, ptype, sfc
+    #    pres_levs:  compare variables on pressure levels to GDAS prepbufr obs
+    #    ptype:      compare precip-type variables to NAM/RAP prepbufr obs
+    #    sfc:        compare surface variables to GDAS and NAM/RAP prepbufr obs
+    #g2os_*_init_hr_list: list of cycles/initialization hours to be included in verification: HH
+    #g2os_*_valid_hr_list: list of valid hours to be included in verification: HH
+    #For defining forecast hours:
+    #    g2os*_fhr_list: list of forecast hours: HH[H]
+    #OR 
+    #    g2os_*_fhr_min: forecast hour to start verification: HH[H]
+    #    g2os_*_fhr_max: forecast hour to end verification: HH[H]
+    #    g2os_*_fhr_inc: frequency to verify forecast hours: at HH[H]
+    export g2os_type_list="pres_levs sfc"
+    export g2os_pres_levs_init_hr_list="00 06 12 18"
+    export g2os_pres_levs_valid_hr_list="00 06 12 18"
+    export g2os_pres_levs_fhr_min=6
+    export g2os_pres_levs_fhr_max=384
+    export g2os_pres_levs_fhr_inc=6
+    export g2os_sfc_init_hr_list="00 06 12 18"
+    export g2os_sfc_valid_hr_list="00 06 12 18"
+    export g2os_sfc_fhr_min=6
+    export g2os_sfc_fhr_max=384
+    export g2os_sfc_fhr_inc=6
+    export g2os_mv_database_name="mv_evs_global_det_atmos_grid2obs_stats_$MODELNAME"
+    export g2os_mv_database_group="$USER"
+    export g2os_mv_database_desc="Grid-to-obs METplus data for $MODELNAME"
+fi
+
+echo "END: $(basename ${BASH_SOURCE[0]})"

--- a/ush/global_det/global_det_atmos_stats_grid2grid_create_job_scripts.py
+++ b/ush/global_det/global_det_atmos_stats_grid2grid_create_job_scripts.py
@@ -1001,11 +1001,21 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                                 and job_env_dict['MODEL'] == 'jma':
                             write_job_cmds = False
                     elif JOB_GROUP == 'generate_stats':
+                        #remove variable that AIGFS do not have
+                        if verif_type == 'means'\
+                                and job_env_dict['MODEL'] == 'aigfs'\
+                                and verif_type_job \
+                                in ['CAPESfcBased',\
+                                    'CloudWater','GeoHeightTropopause','PBLHeight',\
+                                    'PrecipWater','PresSfc','PresTropopause', 'RelHum2m',\
+                                    'SnowWaterEqv','SpefHum2m','TempTropopause','TempSoilTopLayer',\
+                                    'TotalOzone','VolSoilMoistTopLayer']:
+                            write_job_cmds = False
                         # Models below do not have Ozone Mixing Ratio
                         if verif_type == 'pres_levs' \
                                 and job_env_dict['MODEL'] \
                                 in ['cmc', 'cmc_regional', 'dwd', 'ecmwf',
-                                    'fnmoc', 'jma', 'metfra', 'ukmet'] \
+                                    'fnmoc', 'jma', 'metfra', 'ukmet','aigfs'] \
                                 and verif_type_job == 'Ozone':
                             write_job_cmds = False
                         # IMD does not have Ozone Mixing Ratio at 925mb

--- a/ush/global_det/global_det_atmos_stats_grid2grid_create_job_scripts.py
+++ b/ush/global_det/global_det_atmos_stats_grid2grid_create_job_scripts.py
@@ -1001,7 +1001,7 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                                 and job_env_dict['MODEL'] == 'jma':
                             write_job_cmds = False
                     elif JOB_GROUP == 'generate_stats':
-                        #remove variable that AIGFS do not have
+                        #remove variable that AIGFS does not have
                         if verif_type == 'means'\
                                 and job_env_dict['MODEL'] == 'aigfs'\
                                 and verif_type_job \
@@ -1015,7 +1015,7 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                         if verif_type == 'pres_levs' \
                                 and job_env_dict['MODEL'] \
                                 in ['cmc', 'cmc_regional', 'dwd', 'ecmwf',
-                                    'fnmoc', 'jma', 'metfra', 'ukmet','aigfs'] \
+                                    'fnmoc', 'jma', 'metfra', 'ukmet', 'aigfs'] \
                                 and verif_type_job == 'Ozone':
                             write_job_cmds = False
                         # IMD does not have Ozone Mixing Ratio at 925mb

--- a/ush/global_det/global_det_atmos_stats_grid2obs_create_job_scripts.py
+++ b/ush/global_det/global_det_atmos_stats_grid2obs_create_job_scripts.py
@@ -905,14 +905,22 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                                                               'fnmoc', 'imd',
                                                               'jma', 'ukmet']:
                             write_job_cmds = False
-                        # JMA does not have Relative Humidity
+                        # JMA and AIGFS does not have Relative Humidity
                         if job_env_dict['VERIF_TYPE'] == 'pres_levs' \
                                 and verif_type_job == 'RelHum' \
-                                and job_env_dict['MODEL'] == 'jma':
+                                and job_env_dict['MODEL'] in ['jma', 'aigfs']:
                             write_job_cmds = False
-                        # CMC and FNMOC do not have variables at all levels
+                        #AIGFS does not have all sfc variables
+                        if job_env_dict['VERIF_TYPE'] == 'sfc' \
+                                and verif_type_job in [\
+                                'CAPEMixedLayer', 'CAPESfcBased', 'Ceiling',\
+                                'Dewpoint2m', 'RelHum2m', 'TotCloudCover',\
+                                'Visibility', 'WindGust','PBLHeight']\
+                                and job_env_dict['MODEL'] == 'aigfs':
+                            write_job_cmds = False
+                        # CMC, FNMOC and AIGFS do not have variables at all levels
                         if job_env_dict['VERIF_TYPE'] == 'pres_levs' \
-                                and job_env_dict['MODEL'] in ['cmc', 'fnmoc']:
+                                and job_env_dict['MODEL'] in ['cmc', 'fnmoc','aigfs']:
                             if job_env_dict['MODEL'] == 'cmc':
                                 mod_rm_level_list = [
                                     'P400', 'P300', 'P200', 'P150', 'P100',
@@ -931,6 +939,10 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                                     mod_rm_level_list.append('P200')
                                     mod_rm_level_list.append('P150')
                                     mod_rm_level_list.append('P100')
+                            elif job_env_dict['MODEL'] == 'aigfs':
+                                mod_rm_level_list = [
+                                    'P20', 'P10', 'P5', 'P1'
+                                ]
                             for dtype in ['fcst', 'obs']:
                                 dtype_level_list = (
                                     job_env_dict[f"var1_{dtype}_levels"]\

--- a/ush/global_det/global_det_atmos_stats_grid2obs_create_job_scripts.py
+++ b/ush/global_det/global_det_atmos_stats_grid2obs_create_job_scripts.py
@@ -905,7 +905,7 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                                                               'fnmoc', 'imd',
                                                               'jma', 'ukmet']:
                             write_job_cmds = False
-                        # JMA and AIGFS does not have Relative Humidity
+                        # JMA and AIGFS do not have Relative Humidity
                         if job_env_dict['VERIF_TYPE'] == 'pres_levs' \
                                 and verif_type_job == 'RelHum' \
                                 and job_env_dict['MODEL'] in ['jma', 'aigfs']:

--- a/ush/global_det/global_det_atmos_stats_grid2obs_create_job_scripts.py
+++ b/ush/global_det/global_det_atmos_stats_grid2obs_create_job_scripts.py
@@ -920,7 +920,7 @@ if JOB_GROUP in ['reformat_data', 'assemble_data', 'generate_stats']:
                             write_job_cmds = False
                         # CMC, FNMOC and AIGFS do not have variables at all levels
                         if job_env_dict['VERIF_TYPE'] == 'pres_levs' \
-                                and job_env_dict['MODEL'] in ['cmc', 'fnmoc','aigfs']:
+                                and job_env_dict['MODEL'] in ['cmc', 'fnmoc', 'aigfs']:
                             if job_env_dict['MODEL'] == 'cmc':
                                 mod_rm_level_list = [
                                     'P400', 'P300', 'P200', 'P150', 'P100',

--- a/ush/global_det/global_det_atmos_util.py
+++ b/ush/global_det/global_det_atmos_util.py
@@ -1422,9 +1422,10 @@ def get_model_file(valid_time_dt, init_time_dt, forecast_hour,
         elif 'qpf_verif/METFRA' in source_file:
             prep_prod_metfra_file(source_file, dest_file, init_time_dt,
                                   forecast_hour, 'precip', log_missing_file)
-        elif '.precip.' in dest_file and 'com/gfs' in source_file \
+        elif '.precip.' in dest_file \
+                and any(x in source_file for x in ['com/gfs', '/aigfs']) \
                 and int(forecast_hour) in [3,6]:
-            ### Need to prepare special files for GFS precip for
+            ### Need to prepare special files for GFS and AIGFS precip
             ### for f003 and f006 as APCP variables in the files
             ### are the same and throw WARNING from MET
             if check_file_exists_size(source_file):


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

AIGFS grid2grid and grid2obs stats generation is added to the EVS v2.0 global-det component.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes, end of the month
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? NO
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Make prtest directory
git clone https://github.com/QiShi-NOAA/EVS.git
cd EVS
git checkout feature/add_aigfs_stats
symlink the EVS_fix directory locally as "fix"

Test prep step:
In dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_**grid2grid**.sh script, editing the following environment variables:
HOMEevs - set to your test EVS directory
COMOUT - set to your test output directory
export COMIN=/lfs/h2/emc/vpppg/noscrub/qi.shi/EVS_dev_qi/evs/v2.0
**qsub** jevs_stats_global_det_aigfs_atmos_grid2grid.sh 

In dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_**grid2obs**.sh script, editing the following environment variables:
HOMEevs - set to your test EVS directory
COMOUT - set to your test output directory
export COMIN=/lfs/h2/emc/vpppg/noscrub/qi.shi/EVS_dev_qi/evs/v2.0
**qsub** jevs_stats_global_det_aigfs_atmos_grid2obs.sh 



