### PR TITLE
Updated the COMIN and COMOUT path.

### DIFF
--- a/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last31days.sh
@@ -47,8 +47,8 @@ export KEEPDATA=${KEEPDATA:-NO}
 ## developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export OUTPUTROOT=/lfs/h2/emc/ptmp/$USER
-export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
-export COMOUT=${OUTPUTROOT}/${NET}/${evs_ver_2d}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}_devonly/${evs_ver_2d}
+export COMOUT=${OUTPUTROOT}/${NET}_devonly/${evs_ver_2d}
 export EVAL_PERIOD="last31days"
 
 export run_mpi='yes'

--- a/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last90days.sh
+++ b/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last90days.sh
@@ -47,8 +47,8 @@ export KEEPDATA=${KEEPDATA:-NO}
 ## developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export OUTPUTROOT=/lfs/h2/emc/ptmp/$USER
-export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
-export COMOUT=${OUTPUTROOT}/${NET}/${evs_ver_2d}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}_devonly/${evs_ver_2d}
+export COMOUT=${OUTPUTROOT}/${NET}_devonly/${evs_ver_2d}
 export EVAL_PERIOD="last90days"
 
 export run_mpi='yes'

--- a/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh
+++ b/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh
@@ -54,8 +54,8 @@ export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov'
 # developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export OUTPUTROOT=/lfs/h2/emc/vpppg/noscrub/$USER
-export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
-export COMOUT=${OUTPUTROOT}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}_devonly/${evs_ver_2d}
+export COMOUT=${OUTPUTROOT}/${NET}_devonly/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}
 
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}

--- a/dev/drivers/scripts/stats/nwps/jevs_stats_nwps_wave_grid2obs.sh
+++ b/dev/drivers/scripts/stats/nwps/jevs_stats_nwps_wave_grid2obs.sh
@@ -52,8 +52,8 @@ export KEEPDATA=${KEEPDATA:-NO}
 ### developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export OUTPUTROOT="/lfs/h2/emc/vpppg/noscrub/$USER"
-export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
-export COMOUT=${OUTPUTROOT}/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}_devonly/${evs_ver_2d}
+export COMOUT=${OUTPUTROOT}/${NET}_devonly/${evs_ver_2d}/${STEP}/${COMPONENT}
  
 export run_mpi='yes'
 export gather='yes'


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This is just a small PR to update the `COMIN` and `COMOUT` path to store the data into the devonly in emc.vpppg for EVS-NWPS. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
plots step takes longer than 15 min but restart capability is not required for components in dev.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- Environment Setup
clone https://github.com/SamiraArdani-NOAA/EVS.git
checkout branch `feature/EVS-NWPS_move_net` and set your `HOMEevs` to point to your local repository.
`ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/`
In all driver scripts, Update the `COMIN` so that it points to the parallel outputs in `emc.vpppg`:
`export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}_devonly/${evs_ver_2d}`
`KEEPDATA` set to `YES`
`SENDMAIL` set to `NO`
2- Execute the renamed J-jobs:

Prep: `qsub $HOMEevs/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh`

Stats: `qsub $HOMEevs/dev/drivers/scripts/stats/nwps/jevs_stats_nwps_wave_grid2obs.sh`

plots: `qsub $HOMEevs/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last31days.sh`

plots: `qsub $HOMEevs/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last90days.sh`