### PR TITLE
Modify ECMWF filename ending for future easy testing.

### DIFF
--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:45:00
-#PBS -l place=shared,select=1:ncpus=1:mem=100GB
+#PBS -l place=shared,select=1:ncpus=1:mem=125GB
 #PBS -l debug=true
 
 set -x 

--- a/ecf/scripts/prep/global_det/jevs_prep_global_det_atmos.ecf
+++ b/ecf/scripts/prep/global_det/jevs_prep_global_det_atmos.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:45:00
-#PBS -l place=shared,select=1:ncpus=1:mem=100GB
+#PBS -l place=shared,select=1:ncpus=1:mem=125GB
 #PBS -l debug=true
 
 export model=evs

--- a/jobs/JEVS_PREP_GLOBAL_DET
+++ b/jobs/JEVS_PREP_GLOBAL_DET
@@ -56,6 +56,7 @@ export SENDMAIL=${SENDMAIL:-NO}
 ####################################
 # Define COMIN/COMOUT variables
 ####################################
+export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 export COMIN=${COMIN:-$(compath.py ${envir}/com/$NET/$evs_ver)}
 export COMINcfs=${COMINcfs:-$(compath.py $envir/cfs/$cfs_ver/cfs.$INITDATE)}
 export COMINcmc=${COMINcmc:-$(compath.py $envir/cmc/$cmc_ver/cmc.$INITDATE)}

--- a/jobs/JEVS_PREP_GLOBAL_ENS
+++ b/jobs/JEVS_PREP_GLOBAL_ENS
@@ -84,6 +84,7 @@ export COMINobsproc=${COMINobsproc:-$(compath.py $envir/com/obsproc/${obsproc_ve
 export DCOMINnohrsc=${DCOMINnohrsc:-$DCOMROOT}
 export DCOMINosi_saf=${DCOMINosi_saf:-$DCOMROOT}
 export DCOMINghrsst=${DCOMINghrsst:-$DCOMROOT}
+export DCOMINecmwf=${DCOMINecmwf:-$DCOMROOT}
 
 export COMINgefs_bc=${COMINgefs_bc:-$COMINnaefs}
 export DCOMINcmce_bc=${DCOMINcmce_bc:-$DCOMIN}

--- a/jobs/JEVS_PREP_GLOBAL_ENS
+++ b/jobs/JEVS_PREP_GLOBAL_ENS
@@ -73,6 +73,7 @@ export SENDMAIL=${SENDMAIL:-NO}
 ####################################
 # Define COMIN/COMOUT variables
 ####################################
+export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 export COMIN=${COMIN:-$(compath.py ${envir}/com/${NET}/${evs_ver})}
 export COMINgefs=${COMINgefs:-$(compath.py ${envir}/com/gefs/${gefs_ver})}
 export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})}

--- a/jobs/JEVS_PREP_SUBSEASONAL
+++ b/jobs/JEVS_PREP_SUBSEASONAL
@@ -62,6 +62,7 @@ export INITDATE=${INITDATE:-$PDYm2}
 #################################################
 # Set up the INPUT and OUTPUT directories
 #################################################
+export ECMWF_FILE_EXT=${ECMWF_FILE_EXT:-1}
 export COMINgefs=${COMINgefs:-$(compath.py ${envir}/com/gefs/${gefs_ver}/gefs.$INITDATE)}
 export COMINcfs=${COMINcfs:-$(compath.py ${envir}/com/cfs/${cfs_ver}/cfs.$INITDATE)}
 export COMINgfs=${COMINgfs:-$(compath.py ${envir}/com/gfs/${gfs_ver})}

--- a/ush/global_det/global_det_atmos_prep.py
+++ b/ush/global_det/global_det_atmos_prep.py
@@ -49,7 +49,7 @@ COMPONENT = os.environ['COMPONENT']
 STEP = os.environ['STEP']
 MODELNAME = os.environ['MODELNAME'].split(' ')
 OBSNAME = os.environ['OBSNAME'].split(' ')
-ECMWF_FILE_EXT=os.environ.get('ECMWF_FILE_EXT', '1')
+ECMWF_FILE_EXT=os.environ['ECMWF_FILE_EXT']
 
 # Make COMOUT directory for dates
 output_INITDATE = COMOUT+'.'+INITDATE

--- a/ush/global_det/global_det_atmos_prep.py
+++ b/ush/global_det/global_det_atmos_prep.py
@@ -476,8 +476,10 @@ for MODEL in MODELNAME:
                                                     log_missing_file)
                     elif MODEL == 'ecmwf':
                         if fcst_hr == 0:
+                            replace_end = f"1{ECMWF_FILE_EXT}"
+                            replace_index = -1 * len(replace_end)
                             input_fcst_file = (
-                                input_fcst_file[:-3]+'1'+f'{ECMWF_FILE_EXT}'
+                                f"{input_fcst_file[:replace_index]}{replace_end}"
                             )
                         gda_util.prep_prod_ecmwf_file(input_fcst_file,
                                                       tmp_fcst_file,

--- a/ush/global_det/global_det_atmos_prep.py
+++ b/ush/global_det/global_det_atmos_prep.py
@@ -49,6 +49,7 @@ COMPONENT = os.environ['COMPONENT']
 STEP = os.environ['STEP']
 MODELNAME = os.environ['MODELNAME'].split(' ')
 OBSNAME = os.environ['OBSNAME'].split(' ')
+ECMWF_FILE_EXT=os.environ.get('ECMWF_FILE_EXT', '1')
 
 # Make COMOUT directory for dates
 output_INITDATE = COMOUT+'.'+INITDATE
@@ -329,13 +330,13 @@ global_det_model_dict = {
             'fcst_hrs': range(24, 72+12, 12)},
     'ecmwf': {'input_fcst_file_format': os.path.join(DCOMINecmwf,
                                                      'U1D{init?fmt=%m%d%H}00'
-                                                     +'{valid?fmt=%m%d%H}001'),
+                                                     +'{valid?fmt=%m%d%H}00'+f'{ECMWF_FILE_EXT}'),
               'input_anl_file_format': os.path.join(DCOMINecmwf,
                                                     'U1D{init?fmt=%m%d%H}00'
-                                                    +'{init?fmt=%m%d%H}011'),
+                                                    +'{init?fmt=%m%d%H}01'+f'{ECMWF_FILE_EXT}'),
               'input_precip_file_format': os.path.join(DCOMINecmwf_precip,
                                                        'UWD{init?fmt=%Y%m%d%H%M}'
-                                                       +'{valid?fmt=%m%d%H%M}1'),
+                                                       +'{valid?fmt=%m%d%H%M}'+f'{ECMWF_FILE_EXT}'),
               'inithours': ['00', '12'],
               'fcst_hrs': range(0, 240+6, 6)},
     'fnmoc': {'input_fcst_file_format': os.path.join(DCOMINfnmoc,

--- a/ush/global_det/global_det_atmos_prep.py
+++ b/ush/global_det/global_det_atmos_prep.py
@@ -476,7 +476,9 @@ for MODEL in MODELNAME:
                                                     log_missing_file)
                     elif MODEL == 'ecmwf':
                         if fcst_hr == 0:
-                            input_fcst_file = input_fcst_file[:-2]+'11'
+                            input_fcst_file = (
+                                input_fcst_file[:-3]+'1'+f'{ECMWF_FILE_EXT}'
+                            )
                         gda_util.prep_prod_ecmwf_file(input_fcst_file,
                                                       tmp_fcst_file,
                                                       CDATE_dt,

--- a/ush/global_ens/evs_process_atmos_ecme.sh
+++ b/ush/global_ens/evs_process_atmos_ecme.sh
@@ -91,7 +91,7 @@ while [ ${hourix} -lt 31 ]; do
   vmdh=` echo ${vymdh} | cut -c5-10`
   vhour=`${NHOUR} ${vymdh} ${ymdh}`
   if [ ${hourix} = 0 ] ; then
-    DCD=${DCOMIN}/$yyyymmdd/wgrbbul/ecmwf/DCD${imdh}00${vmdh}001
+    DCD=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/DCD${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
     if [ -s $DCD ] ; then
       >$WORKtask/ecmanl.t${ihour}z.grid3.f000.grib1
       chmod 640 $WORKtask/ecmanl.t${ihour}z.grid3.f000.grib1
@@ -122,7 +122,7 @@ while [ ${hourix} -lt 31 ]; do
   #*************************************************************
   # Retrieve required fields from ECME member files E1E in DCOM
   #*************************************************************
-  E1E=${DCOMIN}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}001
+  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
   if [ ! -s $E1E ]; then
     echo "WARNING: $E1E is not available"
     if [ $SENDMAIL = YES ]; then
@@ -172,7 +172,7 @@ while [ ${hourix} -lt 31 ]; do
   vymdh=`${NDATE} ${hourinc} ${ymdh}`
   vmdh=` echo ${vymdh} | cut -c5-10`
   vhour=`${NHOUR} ${vymdh} ${ymdh}`
-  E1E=${DCOMIN}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}001
+  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
   if [ -s $E1E ]; then
     >E1E_apcp.${hourinc}
     chmod 640 E1E_apcp.${hourinc}
@@ -241,7 +241,7 @@ while [ ${hourix} -lt 31 ]; do
   vymdh=`${NDATE} ${hourinc} ${ymdh}`
   vmdh=` echo ${vymdh} | cut -c5-10`
   vhour=`${NHOUR} ${vymdh} ${ymdh}`
-  E1E=${DCOMIN}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}001
+  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
   if [ -s $E1E ]; then
     >E1E_vertical.${hourinc}
     chmod 640 E1E_vertical.${hourinc}

--- a/ush/global_ens/evs_process_atmos_ecme.sh
+++ b/ush/global_ens/evs_process_atmos_ecme.sh
@@ -91,7 +91,7 @@ while [ ${hourix} -lt 31 ]; do
   vmdh=` echo ${vymdh} | cut -c5-10`
   vhour=`${NHOUR} ${vymdh} ${ymdh}`
   if [ ${hourix} = 0 ] ; then
-    DCD=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/DCD${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
+    DCD=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/DCD${imdh}00${vmdh}00${ECMWF_FILE_EXT}
     if [ -s $DCD ] ; then
       >$WORKtask/ecmanl.t${ihour}z.grid3.f000.grib1
       chmod 640 $WORKtask/ecmanl.t${ihour}z.grid3.f000.grib1
@@ -122,7 +122,7 @@ while [ ${hourix} -lt 31 ]; do
   #*************************************************************
   # Retrieve required fields from ECME member files E1E in DCOM
   #*************************************************************
-  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
+  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT}
   if [ ! -s $E1E ]; then
     echo "WARNING: $E1E is not available"
     if [ $SENDMAIL = YES ]; then
@@ -172,7 +172,7 @@ while [ ${hourix} -lt 31 ]; do
   vymdh=`${NDATE} ${hourinc} ${ymdh}`
   vmdh=` echo ${vymdh} | cut -c5-10`
   vhour=`${NHOUR} ${vymdh} ${ymdh}`
-  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
+  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT}
   if [ -s $E1E ]; then
     >E1E_apcp.${hourinc}
     chmod 640 E1E_apcp.${hourinc}
@@ -241,7 +241,7 @@ while [ ${hourix} -lt 31 ]; do
   vymdh=`${NDATE} ${hourinc} ${ymdh}`
   vmdh=` echo ${vymdh} | cut -c5-10`
   vhour=`${NHOUR} ${vymdh} ${ymdh}`
-  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT:-1}
+  E1E=${DCOMINecmwf}/$yyyymmdd/wgrbbul/ecmwf/E1E${imdh}00${vmdh}00${ECMWF_FILE_EXT}
   if [ -s $E1E ]; then
     >E1E_vertical.${hourinc}
     chmod 640 E1E_vertical.${hourinc}

--- a/ush/subseasonal/subseasonal_prep_obs.py
+++ b/ush/subseasonal/subseasonal_prep_obs.py
@@ -36,6 +36,7 @@ RUN = os.environ['RUN']
 COMPONENT = os.environ['COMPONENT']
 STEP = os.environ['STEP']
 OBSNAME = os.environ['OBSNAME'].split(' ')
+ECMWF_FILE_EXT = os.environ.get('ECMWF_FILE_EXT', '1')
 
 # Make COMOUT directory for dates
 COMOUT_INITDATE = COMOUT+'.'+INITDATE
@@ -63,7 +64,7 @@ subseasonal_obs_dict = {
                                                'wgrbbul',
                                                'ecmwf',
                                                'DCD{init?fmt=%m%d%H}00'
-                                               +'{init?fmt=%m%d%H}001'),
+                                               +'{init?fmt=%m%d%H}00'+f'{ECMWF_FILE_EXT}'),
                       'arch_file_format': os.path.join(COMOUT_INITDATE,                                                              'ecmwf',
                                                        'ecmwf.'
                                                        +'{init?fmt=%Y%m%d%H}'

--- a/ush/subseasonal/subseasonal_prep_obs.py
+++ b/ush/subseasonal/subseasonal_prep_obs.py
@@ -36,7 +36,7 @@ RUN = os.environ['RUN']
 COMPONENT = os.environ['COMPONENT']
 STEP = os.environ['STEP']
 OBSNAME = os.environ['OBSNAME'].split(' ')
-ECMWF_FILE_EXT = os.environ.get('ECMWF_FILE_EXT', '1')
+ECMWF_FILE_EXT = os.environ['ECMWF_FILE_EXT']
 
 # Make COMOUT directory for dates
 COMOUT_INITDATE = COMOUT+'.'+INITDATE


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Modify ECMWF filename default ending 1 to $ECMWF_FILE_EXT for future easy testing (testing data always have different ending number other than 1).

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? 
   I'd like the change to put in before/on the date ECMWF implement 50r1 upgrade May 12th.
* Do you have any planned upcoming annual leave/PTO?
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [xx= ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Run with ECMWF test data
