### PR TITLE
moves the aigfs lines under the global_det family a

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2054,16 +2054,14 @@ suite evs_nco
               trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_grid2grid_precip_last90days
               trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid == complete
-          endfamily
-          family aigfs
             task jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_ai_grid2grid_pres_levs_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_ai_grid2obs_pres_levs_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_ai_grid2grid_precip_last90days
-              trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
           endfamily
           family cam
             task jevs_plots_cam_precip_last90days

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2055,13 +2055,13 @@ suite evs_nco
             task jevs_plots_global_det_atmos_grid2grid_precip_last90days
               trigger (:TIME >= 1945 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days
-              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_ai_grid2grid_pres_levs_last90days
-              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_ai_grid2obs_pres_levs_last90days
-              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_ai_grid2grid_precip_last90days
-              trigger (:TIME >= 2015 or :TIME < 0145) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
           endfamily
           family cam
             task jevs_plots_cam_precip_last90days


### PR DESCRIPTION


<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

- moves the aigfs lines under the global_det family
- updates the AIGFS plots times to 2015Z

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?Yes
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? NO
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

