### PR TITLE
Feature/cam/refs severe f60

### DIFF
--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
@@ -70,7 +70,7 @@ fi
 
 
 ######################################################################
-# Purpose: This job preprocesses HREF member data for use in
+# Purpose: This job preprocesses REFS member data for use in
 #          CAM severe verification job
 ######################################################################
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
@@ -53,6 +53,7 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
+export SENDMAIL=${SENDMAIL:-NO}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
@@ -73,6 +73,6 @@ fi
 
 ######################################################################
 # Purpose: This job generates radar verification statistics
-#          for the HREF
+#          for the REFS
 ######################################################################
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_severe.sh
@@ -71,6 +71,6 @@ fi
 
 ######################################################################
 # Purpose: This job generates severe verification statistics
-#          for the HREF
+#          for the REFS
 ######################################################################
 

--- a/scripts/prep/cam/exevs_prep_refs_severe.sh
+++ b/scripts/prep/cam/exevs_prep_refs_severe.sh
@@ -37,7 +37,7 @@ mkdir -p ${MODEL_INPUT_DIR}
 # Define settings for 00Z REFS time-lagged members
 if [ $vhr -eq 00 ];then
 
-   nloop=1
+   nloop=2
 
    export IDATE_lag=${IDATE_lag:-`$NDATE -12 ${INITDATE}${vhr} | cut -c 1-8`}
 
@@ -61,6 +61,10 @@ if [ $vhr -eq 00 ];then
    fhr_beg1=12
    fhr_end1=36
    fhr_end1_lag6=42
+
+   fhr_beg2=36
+   fhr_end2=60
+   fhr_end2_lag6=66 # these members won't exist, but we only need 6 members
 
 # Define settings for 06Z REFS time-lagged members
 elif [ $vhr -eq 06 ]; then
@@ -159,7 +163,7 @@ fi
 # Check for forecast files to process
 ###################################################################
 k=0
-min_file_req=12
+min_file_req=6
 
 while [ $k -lt $nloop ]; do
 
@@ -267,7 +271,11 @@ i=1
    ###################################################################
 
    if [ $nfiles -ge $min_file_req ]; then
-      if [ "$nfiles" -eq "12" ]; then
+      if [ "$nfiles" -eq "6" ]; then
+         export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6"
+         export nmem="6"
+         export ens_thresh="1.0"
+      elif [ "$nfiles" -eq "12" ]; then
          export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13"
          export nmem="12"
          export ens_thresh="1.0"

--- a/scripts/stats/cam/exevs_stats_cam_severe.sh
+++ b/scripts/stats/cam/exevs_stats_cam_severe.sh
@@ -69,7 +69,7 @@ fi
 
 if [ ${MODELNAME} = refs ]; then
    fhr_min=24
-   fhr_max=54
+   fhr_max=60
    fhr_inc=6
 
 elif [ ${MODELNAME} = hrrr ]; then


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR increases REFS severe stats verification to forecast hour 60.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes; Code freeze is Apr 15 2026 and review/delivery soon after.
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/cam/refs_severe_f60
```

#### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter):
```
jevs_prep_cam_refs_severe
jevs_stats_cam_refs_severe
```
[Total: _1 prep job_; _1 stats job_]

#### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/marcel.caron/$NET/$evs_ver_2d/rm_all_href`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) where applicable, set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


#### 4) Test jobs

- `cd` into your test directory (where you want the log files to go)
- Submit **jevs_prep_cam_refs_severe** using `qsub -v vhr=12,INITDATE=20260325 ${driver}.sh` 
- Submit **jevs_stats_cam_refs_severe** using `qsub -v vhr=08,VDATE=20260325 ${driver}.sh` 


#### 5) Check jobs
- I will check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- _Note_:  **jevs_stats_cam_refs_severe** will output the following warning:
```
WARNING: process_scores() -> Forecast and observation valid times do not match (20260325_120000 != 20260316_235800) for Prob_MXUPHL25_A24_geHWT(*,*) versus LSR_PPF(*,*).
```
This is expected because the observation test data are dummy data copied from 20260316.  Using dummy data allows us to test this PR now and avoid the usual 7-day lag for severe stats jobs.

#### 6) During testing ...

- If I push changes or fixes during testing, you can usually update your branch like this:
```
git pull origin feature/cam/refs_severe_f60
```