### PR TITLE
Bugfix/subseasonal name error

### DIFF
--- a/ush/subseasonal/subseasonal_stats_grid2grid_create_days6_10_anomaly.py
+++ b/ush/subseasonal/subseasonal_stats_grid2grid_create_days6_10_anomaly.py
@@ -169,7 +169,7 @@ while valid_date_dt <= ENDDATE_dt and fhr <= fhr_end:
             output_file_data.close()
             input_file_data.close()
     else:
-        print("\nWARNING: "+input_file+" does not exist")
+        print("WARNING: "+input_file+" does not exist")
     valid_date_dt = valid_date_dt + datetime.timedelta(hours=int(valid_hr_inc))
     fhr+=int(valid_hr_inc)
     

--- a/ush/subseasonal/subseasonal_stats_grid2grid_create_weekly_anomaly.py
+++ b/ush/subseasonal/subseasonal_stats_grid2grid_create_weekly_anomaly.py
@@ -169,7 +169,7 @@ while valid_date_dt <= ENDDATE_dt and fhr <= fhr_end:
             output_file_data.close()
             input_file_data.close()
     else:
-        print("\nWARNING: "+input_file+" does not exist")
+        print("WARNING: "+input_file+" does not exist")
     valid_date_dt = valid_date_dt + datetime.timedelta(hours=int(valid_hr_inc))
     fhr+=int(valid_hr_inc)
     

--- a/ush/subseasonal/subseasonal_stats_grid2grid_create_weeks3_4_anomaly.py
+++ b/ush/subseasonal/subseasonal_stats_grid2grid_create_weeks3_4_anomaly.py
@@ -169,7 +169,7 @@ while valid_date_dt <= ENDDATE_dt and fhr <= fhr_end:
             output_file_data.close()
             input_file_data.close()
     else:
-        print("\nWARNING: "+input_file+" does not exist")
+        print("WARNING: "+input_file+" does not exist")
     valid_date_dt = valid_date_dt + datetime.timedelta(hours=int(valid_hr_inc))
     fhr+=int(valid_hr_inc)
     


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
While testing new ECMWF data, discovered minor bug with NameError associated with print statements in subseasonal_stats_grid2grid_create_days6_10_anomaly.py, subseasonal_stats_grid2grid_create_weekly_anomaly.py, and subseasonal_stats_grid2grid_create_weeks3_4_anomaly.py:
_File "/lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/test_new_ecmwf/EVS/ush/subseasonal/subseasonal_stats_grid2grid_create_days6_10_anomaly.py", line 172, in <module>
    print("\nWARNING: "+input_file+" does not exist")
NameError: name 'input_file' is not defined._
Minor fixes were applied to subseasonal_stats_grid2grid_create_days6_10_anomaly.py, subseasonal_stats_grid2grid_create_weekly_anomaly.py, and subseasonal_stats_grid2grid_create_weeks3_4_anomaly.py to successfully generate WARNING print statement when data is missing:
_WARNING: /lfs/h2/emc/stmp/shannon.shields/evs_test/prod/tmp/jevs_stats_subseasonal_cfs_grid2grid.256189101.cbqs01/grid2grid_stats/METplus_output/job_work_dir/reformat_data/job65/atmos.20260325/cfs/grid2grid/grid_stat_pres_lvls_GeoHeightAnom_4440000L_20260315_120000V_pairs.nc does not exist_
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No
* Do you have any planned upcoming annual leave/PTO? No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Create testing directory on WCOSS2 (prtest937)
git clone https://github.com/ShannonShields-NOAA/EVS.git
cd EVS/
git checkout bugfix/subseasonal_name_error
git branch (to confirm you are on right branch)
Link fix directory (ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix)
Go to dev/drivers/scripts/stats/subseasonal/
In jevs_stats_subseasonal_cfs_grid2grid.sh and jevs_stats_subseasonal_gefs_grid2grid.sh, edit the following:
HOMEevs to your test directory path
export KEEPDATA=YES
Set COMOUT to where you want the stats files
Set COMIN=/lfs/h2/emc/vpppg/noscrub/mallory.row/verification/global/test_new_ecmwf/evs/v2.0/prep/subseasonal/
OR copy the data directories above to another path
**NOTE**: Make sure to cd atmos.20260316 and remove the following directories:
rm -r cfs
rm -r gefs
rm -r gfs
rm -r ghrsst_ospo
rm -r osi_saf
rm -r prepbufr_nam
rm -r umd
cd  ecmwf/
rm ecmwf.2026031612.anl
The above steps replicate how the NameError was first noticed.
Then run **qsub jevs_stats_subseasonal_cfs_grid2grid.sh** and **qsub jevs_stats_subseasonal_gefs_grid2grid.sh**