### PR TITLE
aigefs: switch name order for stats driver and ecf scripts

### DIFF
--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_hgefs_precip
-#PBS -j oe 
+#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2grid
+#PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=5:mem=25GB:prepost=true
+#PBS -l walltime=01:30:00
+#PBS -l place=vscatter,select=1:ncpus=4:mem=120GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,8 +17,8 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=hgefs
-export VERIF_CASE=precip
+export MODELNAME=aigefs
+export VERIF_CASE=grid2grid
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_gefs_grid2obs
+#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=16:mem=40GB:prepost=true
+#PBS -l place=vscatter,select=1:ncpus=16:mem=50GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,7 +17,7 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=gefs
+export MODELNAME=aigefs
 export VERIF_CASE=grid2obs
 
 module reset

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
@@ -1,9 +1,9 @@
-#PBS -N jevs_stats_aigefs_atmos_gefs_precip
+#PBS -N jevs_stats_aigefs_aigefs_atmos_precip
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:20:00
 #PBS -l place=vscatter,select=1:ncpus=5:mem=30GB:prepost=true
 #PBS -l debug=true
 
@@ -17,7 +17,7 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=gefs
+export MODELNAME=aigefs
 export VERIF_CASE=precip
 
 module reset

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_aigefs_grid2obs
+#PBS -N jevs_stats_aigefs_gefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=16:mem=50GB:prepost=true
+#PBS -l walltime=01:30:00
+#PBS -l place=vscatter,select=1:ncpus=4:mem=125GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,8 +17,8 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=aigefs
-export VERIF_CASE=grid2obs
+export MODELNAME=gefs
+export VERIF_CASE=grid2grid
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_aigefs_grid2grid
+#PBS -N jevs_stats_aigefs_gefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=01:30:00
-#PBS -l place=vscatter,select=1:ncpus=4:mem=120GB:prepost=true
+#PBS -l walltime=01:15:00
+#PBS -l place=vscatter,select=1:ncpus=16:mem=40GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,8 +17,8 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=aigefs
-export VERIF_CASE=grid2grid
+export MODELNAME=gefs
+export VERIF_CASE=grid2obs
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_hgefs_grid2grid
-#PBS -j oe
+#PBS -N jevs_stats_aigefs_gefs_atmos_precip
+#PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=4:mem=100GB:prepost=true
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=5:mem=30GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,8 +17,8 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=hgefs
-export VERIF_CASE=grid2grid
+export MODELNAME=gefs
+export VERIF_CASE=precip
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_hgefs_grid2obs
+#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=16:mem=50GB:prepost=true
+#PBS -l place=vscatter,select=1:ncpus=4:mem=100GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -18,7 +18,7 @@ export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
 export MODELNAME=hgefs
-export VERIF_CASE=grid2obs
+export VERIF_CASE=grid2grid
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_aigefs_precip
-#PBS -j oe 
+#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2obs
+#PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:20:00
-#PBS -l place=vscatter,select=1:ncpus=5:mem=30GB:prepost=true
+#PBS -l walltime=01:15:00
+#PBS -l place=vscatter,select=1:ncpus=16:mem=50GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,8 +17,8 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=aigefs
-export VERIF_CASE=precip
+export MODELNAME=hgefs
+export VERIF_CASE=grid2obs
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
@@ -32,7 +32,7 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${MODELNAME}_${RUN}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_gefs_grid2grid
-#PBS -j oe
+#PBS -N jevs_stats_aigefs_hgefs_atmos_precip
+#PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=01:30:00
-#PBS -l place=vscatter,select=1:ncpus=4:mem=125GB:prepost=true
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=5:mem=25GB:prepost=true
 #PBS -l debug=true
 
 set -x
@@ -17,8 +17,8 @@ export NET=evs
 export STEP=stats
 export COMPONENT=aigefs
 export RUN=atmos
-export MODELNAME=gefs
-export VERIF_CASE=grid2grid
+export MODELNAME=hgefs
+export VERIF_CASE=precip
 
 module reset
 module load prod_envir/${prod_envir_ver}

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -530,23 +530,23 @@ suite evs_nco
         family stats
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/stats'
           family aigefs
-            task jevs_stats_aigefs_atmos_aigefs_grid2grid
+            task jevs_stats_aigefs_aigefs_atmos_grid2grid
               trigger :TIME >= 0830 and :TIME < 1430 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_aigefs_grid2obs
+            task jevs_stats_aigefs_aigefs_atmos_grid2obs
               trigger :TIME >= 0945 and :TIME < 1600 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_aigefs_precip
+            task jevs_stats_aigefs_aigefs_atmos_precip
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_gefs_grid2grid
+            task jevs_stats_aigefs_gefs_atmos_grid2grid
               trigger :TIME >= 0930 and :TIME < 1530 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_gefs_grid2obs
+            task jevs_stats_aigefs_gefs_atmos_grid2obs
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_gefs_precip
+            task jevs_stats_aigefs_gefs_atmos_precip
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_hgefs_grid2grid
+            task jevs_stats_aigefs_hgefs_atmos_grid2grid
               trigger :TIME >= 0900 and :TIME < 1500 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_hgefs_grid2obs
+            task jevs_stats_aigefs_hgefs_atmos_grid2obs
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
-            task jevs_stats_aigefs_atmos_hgefs_precip
+            task jevs_stats_aigefs_hgefs_atmos_precip
               trigger :TIME >= 1000 and :TIME < 1600 and ../../../../00/evs/prep/aigefs/jevs_prep_aigefs_atmos == complete
           endfamily
           family global_ens
@@ -1472,17 +1472,17 @@ suite evs_nco
           edit ECF_FILES '%PACKAGEHOME%/ecf/scripts/plots'
           family aigefs
             task jevs_plots_aigefs_atmos_aigefs_profile2_last90days
-              trigger :TIME >= 1600 and :TIME < 2200 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_aigefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_gefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_hgefs_grid2obs == complete
+              trigger :TIME >= 1600 and :TIME < 2200 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs == complete
             task jevs_plots_aigefs_atmos_aigefs_profile1_last90days
-              trigger :TIME >= 1700 and :TIME < 2300 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_aigefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_gefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_hgefs_grid2obs == complete
+              trigger :TIME >= 1700 and :TIME < 2300 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs == complete
             task jevs_plots_aigefs_atmos_aigefs_precip_last90days
-              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_aigefs_precip == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_gefs_precip == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_hgefs_precip == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip == complete
             task jevs_plots_aigefs_atmos_aigefs_grid2obs_last90days
-              trigger :TIME >= 1415 and :TIME < 2015 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_aigefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_gefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_hgefs_grid2obs == complete
+              trigger :TIME >= 1415 and :TIME < 2015 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs == complete
             task jevs_plots_aigefs_atmos_aigefs_grid2obs_separate_last90days
-              trigger :TIME >= 1415 and :TIME < 2015 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_aigefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_gefs_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_hgefs_grid2obs == complete
+              trigger :TIME >= 1415 and :TIME < 2015 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs == complete
             task jevs_plots_aigefs_atmos_aigefs_grid2grid_last90days
-              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_aigefs_grid2grid == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_gefs_grid2grid == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_atmos_hgefs_grid2grid == complete
+              trigger :TIME >= 1400 and :TIME < 2000 and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid == complete and ../../../../06/evs/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid == complete
           endfamily
           family global_ens
             task jevs_plots_global_ens_atmos_naefs_precip_last90days

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.ecf
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_hgefs_grid2grid
+#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=4:mem=100GB:prepost=true
+#PBS -l walltime=01:30:00
+#PBS -l place=vscatter,select=1:ncpus=4:mem=120GB:prepost=true
 #PBS -l debug=true
 
 export model=evs
@@ -47,7 +47,7 @@ export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=grid2grid
-export MODELNAME=hgefs
+export MODELNAME=aigefs
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.ecf
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_gefs_grid2obs
+#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=16:mem=40GB:prepost=true
+#PBS -l place=vscatter,select=1:ncpus=16:mem=50GB:prepost=true
 #PBS -l debug=true
 
 export model=evs
@@ -47,7 +47,7 @@ export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=grid2obs
-export MODELNAME=gefs
+export MODELNAME=aigefs
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.ecf
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_aigefs_grid2grid
+#PBS -N jevs_stats_aigefs_aigefs_atmos_precip
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:30:00
-#PBS -l place=vscatter,select=1:ncpus=4:mem=120GB:prepost=true
+#PBS -l walltime=00:20:00
+#PBS -l place=vscatter,select=1:ncpus=5:mem=30GB:prepost=true
 #PBS -l debug=true
 
 export model=evs
@@ -46,7 +46,7 @@ fi
 export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
-export VERIF_CASE=grid2grid
+export VERIF_CASE=precip
 export MODELNAME=aigefs
 
 ############################################################

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_atmos_gefs_grid2grid
+#PBS -N jevs_stats_aigefs_gefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.ecf
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_hgefs_precip
+#PBS -N jevs_stats_aigefs_gefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=5:mem=25GB:prepost=true
+#PBS -l walltime=01:15:00
+#PBS -l place=vscatter,select=1:ncpus=16:mem=40GB:prepost=true
 #PBS -l debug=true
 
 export model=evs
@@ -46,8 +46,8 @@ fi
 export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
-export VERIF_CASE=precip
-export MODELNAME=hgefs
+export VERIF_CASE=grid2obs
+export MODELNAME=gefs
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.ecf
@@ -1,9 +1,9 @@
-#PBS -N jevs_stats_aigefs_atmos_aigefs_precip
+#PBS -N jevs_stats_aigefs_gefs_atmos_precip
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:20:00
+#PBS -l walltime=00:15:00
 #PBS -l place=vscatter,select=1:ncpus=5:mem=30GB:prepost=true
 #PBS -l debug=true
 
@@ -47,7 +47,7 @@ export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
 export VERIF_CASE=precip
-export MODELNAME=aigefs
+export MODELNAME=gefs
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.ecf
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_gefs_precip
+#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
-#PBS -l place=vscatter,select=1:ncpus=5:mem=30GB:prepost=true
+#PBS -l walltime=01:15:00
+#PBS -l place=vscatter,select=1:ncpus=4:mem=100GB:prepost=true
 #PBS -l debug=true
 
 export model=evs
@@ -46,8 +46,8 @@ fi
 export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
-export VERIF_CASE=precip
-export MODELNAME=gefs
+export VERIF_CASE=grid2grid
+export MODELNAME=hgefs
 
 ############################################################
 # Execute j-job

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_atmos_hgefs_grid2obs
+#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.ecf
@@ -1,10 +1,10 @@
-#PBS -N jevs_stats_aigefs_atmos_aigefs_grid2obs
+#PBS -N jevs_stats_aigefs_hgefs_atmos_precip
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:15:00
-#PBS -l place=vscatter,select=1:ncpus=16:mem=50GB:prepost=true
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter,select=1:ncpus=5:mem=25GB:prepost=true
 #PBS -l debug=true
 
 export model=evs
@@ -46,8 +46,8 @@ fi
 export OMP_NUM_THREADS=1
 export NET=evs
 export RUN=atmos
-export VERIF_CASE=grid2obs
-export MODELNAME=aigefs
+export VERIF_CASE=precip
+export MODELNAME=hgefs
 
 ############################################################
 # Execute j-job


### PR DESCRIPTION
## Description of Changes
This PR switches name order for stats driver and ecf scripts per code managers' request.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? Out of office on most Fridays.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/Lichuan.Chen/${NET}/$evs_ver_2d
COMOUT - set to your test output directory
KEEPDATA - set to YES

(2) Run the atmos stats job
Run the following job in dev/drivers/scripts/stats/aigefs for any VDATE:
qsub jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
qsub jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
qsub jevs_stats_aigefs_aigefs_atmos_precip.sh
qsub jevs_stats_aigefs_gefs_atmos_grid2grid.sh
qsub jevs_stats_aigefs_gefs_atmos_grid2obs.sh
qsub jevs_stats_aigefs_gefs_atmos_precip.sh
qsub jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
qsub jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
qsub jevs_stats_aigefs_hgefs_atmos_precip.sh

After the jobs completed, log files should be free of errors or warnings, and the output directories under evs/v2.0/stats/aigefs should be the same as those under /lfs/h2/emc/vpppg/noscrub/Lichuan.Chen/evs/v2.0/stats/aigefs.