### PR TITLE
fixing the "correlation coefficient" plots

### DIFF
--- a/ush/nwps/lead_average.py
+++ b/ush/nwps/lead_average.py
@@ -304,6 +304,15 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
     df_aggregated = df_aggregated[
         df_aggregated.index.isin(model_list, level='MODEL')
     ]
+    for stat in [metric1_name, metric2_name]:
+        if stat and str(stat).upper() in ['CORR', 'PCOR']:
+            stat_col = str(stat).upper()
+            if stat_col in df_aggregated.columns:
+                # Log that we are cleaning lead averages
+                logger.info(f"Cleaning {stat_col} spikes (>1 or <-1) before averaging by lead.")
+
+                # Replace invalid values with NaN so they don't skew the mean
+                df_aggregated.loc[(df_aggregated[stat_col] > 1.0) | (df_aggregated[stat_col] < -1.0), stat_col] = np.nan
     pivot_metric1 = pd.pivot_table(
         df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
         index='LEAD_HOURS'

--- a/ush/nwps/time_series.py
+++ b/ush/nwps/time_series.py
@@ -322,8 +322,6 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
 
                 # Option A: Replace with NaN (Recommended for Time Series to keep gaps)
                 df_aggregated.loc[(df_aggregated[stat_col] > 1.0) | (df_aggregated[stat_col] < -1.0), stat_col] = np.nan
-
-                    
     pivot_metric1 = pd.pivot_table(
         df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
         index=str(date_type).upper()

--- a/ush/nwps/time_series.py
+++ b/ush/nwps/time_series.py
@@ -314,6 +314,16 @@ def plot_time_series(df: pd.DataFrame, logger: logging.Logger,
     df_aggregated = df_aggregated[
         df_aggregated.index.isin(model_list, level='MODEL')
     ]
+    for stat in [metric1_name, metric2_name]:
+        if stat and str(stat).upper() in ['CORR', 'PCOR']:
+            stat_col = str(stat).upper()
+            if stat_col in df_aggregated.columns:
+                logger.info(f"Applying range check for {stat_col} to remove values outside [-1, 1]")
+
+                # Option A: Replace with NaN (Recommended for Time Series to keep gaps)
+                df_aggregated.loc[(df_aggregated[stat_col] > 1.0) | (df_aggregated[stat_col] < -1.0), stat_col] = np.nan
+
+                    
     pivot_metric1 = pd.pivot_table(
         df_aggregated, values=str(metric1_name).upper(), columns='MODEL', 
         index=str(date_type).upper()


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR implements a range-check filter for correlation metrics (CORR, PCOR) within the plotting scripts for NWPS component of EVS. It addresses an issue where the Pearson Correlation Coefficient occasionally exceeds the physical/mathematical bounds of [-1, 1].
In specific verification scenarios—particularly those involving wave variables with low spatial variance or small sample sizes—the denominator in the correlation calculation (the product of standard deviations) can approach or equal zero. This leads to numerical instability, resulting in "spikes" or overflow values (e.g., r > 1.0) in the METplus .stat output.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
Please test this PR after 1530z to make sure the .stat for the test `VDATE` run is available.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability. 
The plots jobs takes more than 15 min but since the NWPS component is in dev the restart capability is not necessary for now.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs. 
There are expected WARNINGs due to missing data.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- Environment Setup
- clone https://github.com/SamiraArdani-NOAA/EVS.git
- checkout branch `feature/EVS-NWPS_correlation_coeff` and set your $HOMEevs to point to your local repository.
- `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/`
- In all driver scripts, Update the $COMIN so that it points to the parallel outputs in `emc.vpppg`:
  $KEEPDATA set to YES
  $SENDMAIL set to NO

2- Execute the plots jobs (Testing only plots jobs would be enough) :

`qsub $HOMEevs/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last31days.sh`
`qsub $HOMEevs/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last90days.sh`

3- the updated images will be shown in my test webpage [here](https://www.emc.ncep.noaa.gov/users/verification/ocean_lake/nwps/test/grid2obs/swh/) after successful testing.