### PR TITLE
Add rrfs members to graphics

### DIFF
--- a/ush/cam/cam_plots_snowfall_graphx_defs.py
+++ b/ush/cam/cam_plots_snowfall_graphx_defs.py
@@ -22,7 +22,7 @@ graphics = {
     'cam':{
         'snowfall':{
             'nohrsc':{
-                'fcst_group1, rrfs, hrrr':{
+                'fcst_group1, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5, hrrr':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -130,7 +130,7 @@ graphics = {
                         }
                     },
                 },
-                'fcst_group2, rrfs':{
+                'fcst_group2, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -238,7 +238,7 @@ graphics = {
                         }
                     },
                 },
-                'init_group1, fcst_group1, var_group1, rrfs, hrrr':{
+                'init_group1, fcst_group1, var_group1, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5, hrrr':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -346,7 +346,7 @@ graphics = {
                         }
                     },
                 },
-                'init_group1, fcst_group1, var_group2, rrfs, hrrr':{
+                'init_group1, fcst_group1, var_group2, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5, hrrr':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -454,7 +454,7 @@ graphics = {
                         }
                     },
                 },
-                'init_group1, fcst_group2, var_group1, rrfs':{
+                'init_group1, fcst_group2, var_group1, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -562,7 +562,7 @@ graphics = {
                         }
                     },
                 },
-                'init_group2, fcst_group1, var_group1, rrfs, hrrr':{
+                'init_group2, fcst_group1, var_group1, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5, hrrr':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -670,7 +670,7 @@ graphics = {
                         }
                     },
                 },
-                'init_group2, fcst_group1, var_group2, rrfs, hrrr':{
+                'init_group2, fcst_group1, var_group2, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5, hrrr':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',
@@ -739,7 +739,7 @@ graphics = {
                         }
                     },
                 },
-                'init_group2, fcst_group2, var_group1, rrfs':{
+                'init_group2, fcst_group2, var_group1, rrfs, rrfsmem1, rrfsmem2, rrfsmem3, rrfsmem4, rrfsmem5':{
                     'threshold_average':{
                         'DATE_TYPE':'INIT',
                         'VALID_BEG':'',


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR adds RRFS Members to snowfall graphics jobs in EVS.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes.  Code freeze for RRFS and REFS PRs is Apr 15 2026 and review/delivery soon after.
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/cam/add_rrfsmem_snowfall_plots
```

#### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter):
```
jevs_plots_cam_snowfall_last90days
```
[Total: _1 plots job_]

#### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/marcel.caron/$NET/$evs_ver_2d/add_rrfsmem_snowfall_stats`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


#### 4) Test jobs

- `cd` into your test directory (where you want the log files to go)
- Submit the driver using `qsub -v vhr=00 ${driver}.sh`

#### 5) Check jobs
- I will check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
_Note_: This job outputs many warnings, even in the cool season.  Warnings normally indicate a lack of samples at the given threshold.  In this case, many of these warnings are due to the lack of test samples to begin with; I have generated about five days of statistics for testing, which is not typical in ops.

#### 6) During testing ...

- If I push changes or fixes during testing, you can usually update your branch like this:
```
git pull origin feature/cam/add_rrfsmem_snowfall_plots
```