### PR TITLE
fix ecmwf model name typo in grid2grid config file

### DIFF
--- a/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.ai_grid2grid.pres_levs
+++ b/parm/evs_config/global_det/config.evs.prod.plots.global_det.atmos.ai_grid2grid.pres_levs
@@ -58,7 +58,7 @@ if [ $RUN_GRID2GRID_PLOTS = YES ]; then
     #    g2gp_*_fhr_min: forecast hour to start verification: HH[H]
     #    g2gp_*_fhr_max: forecast hour to end verification: HH[H]
     #    g2gp_*_fhr_inc: frequency to verify forecast hours: HH[H]
-    export g2gp_model_plot_name_list="gfs aigfs ecmmwf"
+    export g2gp_model_plot_name_list="gfs aigfs ecmwf"
     export g2gp_type_list="pres_levs"
     export g2gp_event_equalization="NO"
     export g2gp_pres_levs_truth_name_list="gfs_anl gfs_anl ecmwf_anl"


### PR DESCRIPTION

<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

fix the ecmwf name typo in grid2grid config file.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Make prtest directory
git clone https://github.com/QiShi-NOAA/EVS.git
cd EVS
git checkout feature/add_aigfs_plots
symlink the EVS_fix directory locally as "fix"

Test the following scripts:
/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_ai_grid2grid_pres_levs_last90days.sh

editing the following environment variables:
HOMEevs - set to your test EVS directory
COMOUT - set to your test output directory
export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0
