### PR TITLE
Removing HGEFS version number (not used in EVS)

### DIFF
--- a/jobs/JEVS_PREP_AIGEFS
+++ b/jobs/JEVS_PREP_AIGEFS
@@ -70,7 +70,6 @@ export COMIN=${COMIN:-$(compath.py ${envir}/com/${NET}/${evs_ver})}
 export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})}
 export COMINgefs=${COMINgefs:-$(compath.py ${envir}/com/gefs/${gefs_ver})}
 export COMINaigefs=${COMINaigefs:-$(compath.py ${envir}/com/aigefs/${aigefs_ver})}
-export COMINhgefs=${COMINhgefs:-$(compath.py ${envir}/com/hgefs/${hgefs_ver})}
 export DCOMIN=${DCOMIN:-${DCOMROOT}}
 export COMINccpa=${COMINccpa:-$(compath.py $envir/com/ccpa/${ccpa_ver})}
 export COMINobsproc=${COMINobsproc:-$(compath.py $envir/com/obsproc/${obsproc_ver})}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -50,7 +50,6 @@ export fnmoc_ver=v1.1
 export gefs_ver=v12.3
 export gfs_ver=v16.3
 export glwu_ver=v2.0
-export hgefs_ver=v1.0
 export hiresw_ver=v8.1
 export hourly_ver=v0.0
 export href_ver=v3.1


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

Gwen told us in the [EVS v2.0.9 Release Notes](https://docs.google.com/document/d/10wODGNTUk_Urv257G-FuaxZXHSZNIipPiN-z3E_w-Q4/edit?usp=sharing) that `/lfs/h1/ops/prod/com/hgefs/${hgefs_ver}/` files are not used in EVS. Instead, individual GEFS and AIGEFS members are gathered and combined to make HGEFS in EVS (HGEFS = GEFS + AIGEFS). This is very much like how NAEFS is used in ops EVS (NAEFS = GEFS + CMC).

Since `${hgefs_ver}` only appears in EVS twice ([see here](https://github.com/search?q=repo%3ANOAA-EMC%2FEVS%20hgefs_ver&type=code)) and because `COMINhgefs` is exported in the prep J-job and then never used ([see here](https://github.com/search?q=repo%3ANOAA-EMC%2FEVS+COMINhgefs&type=code)), I am removing the `${hgefs_ver}` and `COMINhgefs` from EVS in accordance with the NCO standard of not calling a model you don't use in operational code. 

Since `COMINhgefs` only appeared in the aigefs prep J-job, I think we just need to test the AIGEFS prep job (jevs_prep_aigefs_atmos.sh) to make sure prep files are still produced correctly. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes, ASAP (needed for EVS v2.0.9 code delivery on 4/8/26)

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Please test `jevs_prep_aigefs_atmos.sh` using the most recent date with aigefs prep data in the **emc.vpppg parallel**. If the prep output is the same as the prep output in the emc.vpppg parallel, then removing to two lines of code was transparent to the EVS v2.0.9 code delivery and NCO standards have been met.