### PR TITLE
Feature/cam/add severe restart

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe.sh
@@ -38,7 +38,6 @@ export evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 ############################################################
 export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
-export KEEPDATA=NO
 export VERIF_CASE=severe
 export MODELNAME=${COMPONENT}
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=64
+export nproc=8
 ############################################################
 
 export vhr=${vhr:-00}

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=8
+export nproc=1
 ############################################################
 
 export vhr=${vhr:-00}
@@ -56,6 +56,7 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
+export USE_CFP=${USE_CFP:-NO}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
@@ -1,0 +1,79 @@
+#PBS -N jevs_plots_cam_severe_nbrcnt_last31days_00
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+
+set -x
+
+cd $PBS_O_WORKDIR
+
+
+############################################################
+# Load modules
+############################################################
+
+
+export model=evs
+export NET=evs
+export COMPONENT=cam
+export STEP=plots
+export RUN=atmos
+
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+source $HOMEevs/versions/run.ver
+module reset
+module load prod_envir/${prod_envir_ver}
+
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+export evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+
+############################################################
+# For dev testing
+############################################################
+export envir=prod
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export VERIF_CASE=severe
+export MODELNAME=${COMPONENT}
+export EVAL_PERIOD=last31days
+export LINE_TYPE=nbrcnt
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
+export jobid=$job.${PBS_JOBID:-$$}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
+export nproc=64
+############################################################
+
+export vhr=${vhr:-00}
+
+export SENDMAIL=${SENDMAIL:-YES}
+export SENDCOM=${SENDCOM:-YES}
+export SENDECF=${SENDECF:-YES}
+export SENDDBN=${SENDDBN:-NO}
+export KEEPDATA=${KEEPDATA:-NO}
+
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+
+if [ -z "$MAILTO" ]; then
+
+   echo "MAILTO variable is not defined. Exiting without continuing."
+
+else
+
+   # CALL executable job script here
+   $HOMEevs/jobs/JEVS_PLOTS_CAM
+
+fi
+
+
+######################################################################
+# Purpose: This job generates severe NBRCNT verification graphics
+#          for the CAM component (deterministic and ensemble CAMs)
+#          over the last 31 days
+######################################################################
+

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l ncpus=8:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=64
+export nproc=8
 ############################################################
 
 export vhr=${vhr:-00}

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
@@ -1,0 +1,79 @@
+#PBS -N jevs_plots_cam_severe_nbrcnt_last90days_00
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+
+set -x
+
+cd $PBS_O_WORKDIR
+
+
+############################################################
+# Load modules
+############################################################
+
+
+export model=evs
+export NET=evs
+export COMPONENT=cam
+export STEP=plots
+export RUN=atmos
+
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+source $HOMEevs/versions/run.ver
+module reset
+module load prod_envir/${prod_envir_ver}
+
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+export evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+
+############################################################
+# For dev testing
+############################################################
+export envir=prod
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export VERIF_CASE=severe
+export MODELNAME=${COMPONENT}
+export EVAL_PERIOD=last90days
+export LINE_TYPE=nbrcnt
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
+export jobid=$job.${PBS_JOBID:-$$}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
+export nproc=64
+############################################################
+
+export vhr=${vhr:-00}
+
+export SENDMAIL=${SENDMAIL:-YES}
+export SENDCOM=${SENDCOM:-YES}
+export SENDECF=${SENDECF:-YES}
+export SENDDBN=${SENDDBN:-NO}
+export KEEPDATA=${KEEPDATA:-NO}
+
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+
+if [ -z "$MAILTO" ]; then
+
+   echo "MAILTO variable is not defined. Exiting without continuing."
+
+else
+
+   # CALL executable job script here
+   $HOMEevs/jobs/JEVS_PLOTS_CAM
+
+fi
+
+
+######################################################################
+# Purpose: This job generates severe NBRCNT verification graphics
+#          for the CAM component (deterministic and ensemble CAMs)
+#          over the last 90 days
+######################################################################
+

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=8
+export nproc=1
 ############################################################
 
 export vhr=${vhr:-00}
@@ -56,6 +56,7 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
+export USE_CFP=${USE_CFP:-NO}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=64
+export nproc=8
 ############################################################
 
 export vhr=${vhr:-00}

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_plots_cam_severe_00
+#PBS -N jevs_plots_cam_severe_nbrctc_last31days_00
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev
@@ -40,6 +40,8 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export VERIF_CASE=severe
 export MODELNAME=${COMPONENT}
+export EVAL_PERIOD=last31days
+export LINE_TYPE=nbrctc
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
@@ -48,8 +50,6 @@ export nproc=64
 ############################################################
 
 export vhr=${vhr:-00}
-export EVAL_PERIOD=${EVAL_PERIOD:-last31days}
-export LINE_TYPE=${LINE_TYPE:-nbrctc}
 
 export SENDMAIL=${SENDMAIL:-YES}
 export SENDCOM=${SENDCOM:-YES}
@@ -72,7 +72,8 @@ fi
 
 
 ######################################################################
-# Purpose: This job generates severe verification graphics
+# Purpose: This job generates severe NBRCTC verification graphics
 #          for the CAM component (deterministic and ensemble CAMs)
+#          over the last 31 days
 ######################################################################
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=8
+export nproc=1
 ############################################################
 
 export vhr=${vhr:-00}
@@ -56,6 +56,7 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
+export USE_CFP=${USE_CFP:-NO}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=64
+export nproc=8
 ############################################################
 
 export vhr=${vhr:-00}

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
@@ -1,0 +1,79 @@
+#PBS -N jevs_plots_cam_severe_nbrctc_last90days_00
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q dev
+#PBS -A VERF-DEV
+#PBS -l walltime=00:15:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=64:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+
+set -x
+
+cd $PBS_O_WORKDIR
+
+
+############################################################
+# Load modules
+############################################################
+
+
+export model=evs
+export NET=evs
+export COMPONENT=cam
+export STEP=plots
+export RUN=atmos
+
+export HOMEevs=/lfs/h2/emc/vpppg/noscrub/$USER/EVS
+source $HOMEevs/versions/run.ver
+module reset
+module load prod_envir/${prod_envir_ver}
+
+source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
+export evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
+
+
+############################################################
+# For dev testing
+############################################################
+export envir=prod
+export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
+export VERIF_CASE=severe
+export MODELNAME=${COMPONENT}
+export EVAL_PERIOD=last90days
+export LINE_TYPE=nbrctc
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
+export jobid=$job.${PBS_JOBID:-$$}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
+export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
+export nproc=64
+############################################################
+
+export vhr=${vhr:-00}
+
+export SENDMAIL=${SENDMAIL:-YES}
+export SENDCOM=${SENDCOM:-YES}
+export SENDECF=${SENDECF:-YES}
+export SENDDBN=${SENDDBN:-NO}
+export KEEPDATA=${KEEPDATA:-NO}
+
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+
+if [ -z "$MAILTO" ]; then
+
+   echo "MAILTO variable is not defined. Exiting without continuing."
+
+else
+
+   # CALL executable job script here
+   $HOMEevs/jobs/JEVS_PLOTS_CAM
+
+fi
+
+
+######################################################################
+# Purpose: This job generates severe NBRCTC verification graphics
+#          for the CAM component (deterministic and ensemble CAMs)
+#          over the last 90 days
+######################################################################
+

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 
@@ -46,7 +46,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_${LINE_TYPE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/ptmp/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export nproc=8
+export nproc=1
 ############################################################
 
 export vhr=${vhr:-00}
@@ -56,6 +56,7 @@ export SENDCOM=${SENDCOM:-YES}
 export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
+export USE_CFP=${USE_CFP:-NO}
 
 export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
 

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2463,6 +2463,12 @@ suite evs_nco
             task jevs_plots_cam_grid2obs_last90days
               trigger (:TIME >= 2100 or :TIME < 0300) and ../../stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_rrfs_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_1 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_2 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_3 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_4 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_5 == complete
               edit VHR '21'
+            task jevs_plots_cam_severe_nbrctc_last90days
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../stats/cam/jevs_stats_cam_hrrr_severe == complete and ../../stats/cam/jevs_stats_cam_rrfs_severe == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_1 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_2 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_3 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_4 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_5 == complete
+              edit VHR '21'
+            task jevs_plots_cam_severe_nbrcnt_last90days
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../stats/cam/jevs_stats_cam_hrrr_severe == complete and ../../stats/cam/jevs_stats_cam_rrfs_severe == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_1 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_2 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_3 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_4 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_severe_mem_5 == complete
+              edit VHR '21'
             task jevs_plots_cam_headline
               trigger (:TIME >= 2100 or :TIME < 0300) and ../../stats/cam/jevs_stats_cam_hrrr_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_rrfs_grid2obs_vhr_21 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_1 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_2 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_3 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_4 == complete and ../../stats/cam/jevs_stats_cam_rrfsmem_grid2obs_vhr_21_mem_5 == complete
               edit VHR '21'

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 export model=evs 
@@ -50,8 +50,8 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export USE_CFP=YES
-export nproc=8
+export USE_CFP=NO
+export nproc=1
 export NET="evs"
 export RUN="atmos"
 export VERIF_CASE="severe"

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_severe_nbrcnt_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export USE_CFP=YES
+export nproc=8
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="severe"
+export MODELNAME=${COMPONENT}
+export LINE_TYPE="nbrcnt"
+export EVAL_PERIOD="last31days"
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 export model=evs 
@@ -50,8 +50,8 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export USE_CFP=YES
-export nproc=8
+export USE_CFP=NO
+export nproc=1
 export NET="evs"
 export RUN="atmos"
 export VERIF_CASE="severe"

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_severe_nbrcnt_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export USE_CFP=YES
+export nproc=8
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="severe"
+export MODELNAME=${COMPONENT}
+export LINE_TYPE="nbrcnt"
+export EVAL_PERIOD="last90days"
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 export model=evs 
@@ -50,8 +50,8 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export USE_CFP=YES
-export nproc=8
+export USE_CFP=NO
+export nproc=1
 export NET="evs"
 export RUN="atmos"
 export VERIF_CASE="severe"

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_severe_nbrctc_last31days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export USE_CFP=YES
+export nproc=8
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="severe"
+export MODELNAME=${COMPONENT}
+export LINE_TYPE="nbrctc"
+export EVAL_PERIOD="last31days"
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:15:00
-#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l select=1:ncpus=1:ompthreads=1:mem=800MB
 #PBS -l debug=true
 
 export model=evs 
@@ -50,8 +50,8 @@ if [ -n "%VHR:%" ]; then
 else
   export vhr=00
 fi
-export USE_CFP=YES
-export nproc=8
+export USE_CFP=NO
+export nproc=1
 export NET="evs"
 export RUN="atmos"
 export VERIF_CASE="severe"

--- a/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.ecf
@@ -1,0 +1,74 @@
+#PBS -N evs_plots_cam_severe_nbrctc_last90days
+#PBS -j oe
+#PBS -S /bin/bash
+#PBS -q %QUEUE%
+#PBS -A %PROJ%-%PROJENVIR%
+#PBS -l walltime=00:15:00
+#PBS -l select=1:ncpus=8:ompthreads=1:mem=800MB
+#PBS -l debug=true
+
+export model=evs 
+%include <head.h>
+%include <envir-p1.h>
+
+############################################################
+# Load modules
+############################################################
+set -x 
+export COMPONENT=cam
+export STEP=plots
+
+module load PrgEnv-intel/${PrgEnvintel_ver}
+module load intel/${intel_ver}
+module load ve/evs/${ve_evs_ver}
+module load cray-mpich/${craympich_ver}
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
+module load libjpeg/${libjpeg_ver}
+module load libpng/${libpng_ver}
+module load zlib/${zlib_ver}
+module load jasper/${jasper_ver}
+module load udunits/${udunits_ver}
+module load gsl/${gsl_ver}
+module load netcdf/${netcdf_ver}
+module load nco/${nco_ver}
+module load cdo/${cdo_ver}
+module load grib_util/${grib_util_ver}
+module load wgrib2/${wgrib2_ver}
+module load proj/${proj_ver}
+module load geos/${geos_ver}
+module load imagemagick/${imagemagick_ver}
+module load met/${met_ver}
+module load metplus/${metplus_ver}
+module list
+   
+############################################################
+# Specify environment variables
+############################################################
+if [ -n "%VHR:%" ]; then
+  export vhr=${vhr:-%VHR:%}
+else
+  export vhr=00
+fi
+export USE_CFP=YES
+export nproc=8
+export NET="evs"
+export RUN="atmos"
+export VERIF_CASE="severe"
+export MODELNAME=${COMPONENT}
+export LINE_TYPE="nbrctc"
+export EVAL_PERIOD="last90days"
+
+############################################################
+# Execute j-job
+############################################################
+$HOMEevs/jobs/JEVS_PLOTS_CAM
+if [ $? -ne 0 ]; then
+   ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
+   ecflow_client --abort
+   exit
+fi
+
+%include <tail.h>
+%manual
+%end

--- a/scripts/plots/cam/exevs_plots_cam_severe.sh
+++ b/scripts/plots/cam/exevs_plots_cam_severe.sh
@@ -186,8 +186,6 @@ chmod 775 $DATA/poescript
 export MP_PGMMODEL=mpmd
 export MP_CMDFILE=${DATA}/poescript
 
-export USE_CFP=NO
-
 if [ "$USE_CFP" = "YES" ]; then
 
    echo "running cfp"

--- a/scripts/plots/cam/exevs_plots_cam_severe.sh
+++ b/scripts/plots/cam/exevs_plots_cam_severe.sh
@@ -48,6 +48,9 @@ export STAT_OUTPUT_BASE_TEMPLATE="{MODEL}.{valid?fmt=%Y%m%d}/${NET}.stats.{MODEL
 export OUTPUT_DIR=${DATA}/out/${VERIF_CASE}/${eval_period}
 export IMG_HEADER=${NET}.${COMPONENT}
 
+export RESTART_DIR="${COMOUTplots}/${VERIF_CASE}/restart"
+export COMPLETED_JOBS_DIR="completed_jobs_${LINE_TYPE}_${EVAL_PERIOD}"
+
 export LOG_LEVEL="DEBUG"
 
 export PYTHONDONTWRITEBYTECODE=1
@@ -69,6 +72,9 @@ export MET_VERSION="${MET_VERSION%.}"
 mkdir -p ${PRUNE_DIR}
 mkdir -p ${STAT_OUTPUT_BASE_DIR}
 mkdir -p ${OUTPUT_DIR}
+mkdir -p ${RESTART_DIR}
+mkdir -p ${RESTART_DIR}/${COMPLETED_JOBS_DIR}
+mkdir -p ${RESTART_DIR}/${VERIF_CASE}/${EVAL_PERIOD}
 mkdir -p ${DATA}/out/logs # main log output dir
 
 
@@ -98,6 +104,14 @@ for model in ${model_list}; do
       n=$((n+1))
    done
 done
+
+
+############################################################
+# Check For Restart Files
+############################################################
+
+python ${USHevs}/cam/cam_production_restart.py
+export err=$?; err_chk
 
 
 ############################################################
@@ -150,6 +164,7 @@ for PLOT_TYPE in ${PLOT_TYPES}; do
 	
             echo "${USHevs}/${COMPONENT}/evs_cam_plots_severe.sh $PLOT_TYPE $DOMAIN $LINE_TYPE $FCST_INIT_HOUR $FCST_LEAD $njob" >> $DATA/poescript
             mkdir -p ${DATA}/out/workdirs/job${njob}/logs
+            mkdir -p ${DATA}/out/workdirs/job${njob}/${COMPLETED_JOBS_DIR}
             njob=$((njob+1))
 
 

--- a/ush/cam/cam_production_restart.py
+++ b/ush/cam/cam_production_restart.py
@@ -57,7 +57,10 @@ elif STEP == 'plots':
     COMOUTplots = os.environ['COMOUTplots']
     RESTART_DIR = os.environ['RESTART_DIR']
     COMPLETED_JOBS_DIR = os.environ['COMPLETED_JOBS_DIR']
-    working_dir = os.path.join(DATA, VERIF_CASE, 'out')
+    if VERIF_CASE in ['radar','severe']:
+        working_dir = os.path.join(DATA, 'out')
+    else:
+        working_dir = os.path.join(DATA, VERIF_CASE, 'out')
     completed_jobs_dir = os.path.join(
         RESTART_DIR, 
         COMPLETED_JOBS_DIR

--- a/ush/cam/cam_util.py
+++ b/ush/cam/cam_util.py
@@ -358,7 +358,10 @@ def mark_job_completed(restart_dir, data_dir, verif_case,
         raise ValueError(e)
 
     restart_out = Path(restart_dir) / completed_jobs_dirname
-    data_out = Path(data_dir) / verif_case
+    if verif_case in ['radar', 'severe']:
+        data_out = Path(data_dir)
+    else:
+        data_out = Path(data_dir) / verif_case
     if job_type:
         restart_out = restart_out / job_type
         data_out = data_out / 'METplus_output' / 'workdirs' / job_type / job_name / completed_jobs_dirname / job_type

--- a/ush/cam/evs_cam_plots_severe.sh
+++ b/ush/cam/evs_cam_plots_severe.sh
@@ -62,82 +62,87 @@ fi
 # Run python scripts for the specified plot type 
 ###################################################################
 
-if [ $PLOT_TYPE = performance_diagram ]; then
+if [[ -f "${RESTART_DIR}/${COMPLETED_JOBS_DIR}/${job_name}" ]]; then
+   echo "NOTE: Jobs were restarted and job${njob} has already completed. Continuing."
 
-   export STATS="sratio,pod,csi"
-   python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-   export err=$?; err_chk
+else
+    if [ $PLOT_TYPE = performance_diagram ]; then
 
-elif [ $PLOT_TYPE = threshold_average ]; then
+       export STATS="sratio,pod,csi"
+       python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+       export err=$?; err_chk
 
-   if [ $LINE_TYPE = nbrcnt ]; then
+    elif [ $PLOT_TYPE = threshold_average ]; then
 
-      export STATS="fss"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+       if [ $LINE_TYPE = nbrcnt ]; then
 
-   elif [ $LINE_TYPE = nbrctc ]; then
+          export STATS="fss"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-      export STATS="csi"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+       elif [ $LINE_TYPE = nbrctc ]; then
 
-      export STATS="fbias"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+          export STATS="csi"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-   elif [ $LINE_TYPE = pstd ]; then
+          export STATS="fbias"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-      export STATS="bss_smpl"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+       elif [ $LINE_TYPE = pstd ]; then
 
-      export STATS="bs"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+          export STATS="bss_smpl"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-   fi
+          export STATS="bs"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-elif [ $PLOT_TYPE = lead_average ]; then
+       fi
 
-   if [ $LINE_TYPE = pstd ]; then
+    elif [ $PLOT_TYPE = lead_average ]; then
 
-      export STATS="bss_smpl"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+       if [ $LINE_TYPE = pstd ]; then
 
-      export STATS="bs"
-      python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-      export err=$?; err_chk
+          export STATS="bss_smpl"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-   else
+          export STATS="bs"
+          python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+          export err=$?; err_chk
 
-      for FCST_THRESH in ${FCST_THRESHs}; do
+       else
 
-         OBS_THRESH=${FCST_THRESH}
+          for FCST_THRESH in ${FCST_THRESHs}; do
 
-         if [ $LINE_TYPE = nbrcnt ]; then
+             OBS_THRESH=${FCST_THRESH}
 
-            export STATS="fss"
-            python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-            export err=$?; err_chk
+             if [ $LINE_TYPE = nbrcnt ]; then
 
-         elif [ $LINE_TYPE = nbrctc ]; then
+                export STATS="fss"
+                python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+                export err=$?; err_chk
 
-            export STATS="csi"
-            python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-            export err=$?; err_chk
+             elif [ $LINE_TYPE = nbrctc ]; then
 
-            export STATS="fbias"
-            python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
-            export err=$?; err_chk
-         fi
+                export STATS="csi"
+                python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+                export err=$?; err_chk
 
-      done
-   
-   fi
+                export STATS="fbias"
+                python ${USHevs}/${COMPONENT}/${PLOT_TYPE}.py
+                export err=$?; err_chk
+             fi
+
+          done
+       
+       fi
+
+    fi
+    python -c "import sys; sys.path.insert(0, '${USHevs}/${COMPONENT}'); import cam_util; cam_util.mark_job_completed('${RESTART_DIR}', '${DATA}', '${VERIF_CASE}', '${COMPLETED_JOBS_DIR}', '${job_name}')"
 
 fi
-
-
 exit


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR adds a restart capability to the cam severe plots job, which makes this job compliant with NCO's implementation standards.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes;  we'd like to move the severe plots job from dev to ops with this PR, and the code freeze date is set for April 15.
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No, but these are new jobs.  These jobs can run at any time but I have them set up for vhr=21.

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/cam/add_severe_restart
```

#### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter):
```
jevs_plots_cam_severe_nbrctc_last90days
jevs_plots_cam_severe_nbrcnt_last90days
```
[Total: _2 plots jobs_]

#### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/marcel.caron/$NET/$evs_ver_2d/realtime`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


#### 4) Test jobs

- `cd` into your test directory (where you want the log files to go)
- Submit each driver using `qsub -v vhr=21 ${driver}.sh`

We can discuss whether or not we want to test anything else.

#### 5) Check jobs
- I will check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
_NOTE:_ There are no RRFS member severe data in the test stats directory, therefore we may need to increase the walltimes and memory limits of each job once we have an archive of RRFS Member statistics to test with.  Of the seven members plotted in these jobs, the test stats directory currently includes HRRR and RRFS.

#### 6) During testing ...

- If I push changes or fixes during testing, you can usually update your branch like this:
```
git pull origin feature/cam/add_severe_restart
```