### PR TITLE
Bugfix/EVSv2-RTOFS_yticks

### DIFF
--- a/ush/rtofs/lead_average.py
+++ b/ush/rtofs/lead_average.py
@@ -778,9 +778,12 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
 
         ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
         ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
-
-        # If the range is extremely small (nearly a flat line), add a fixed buffer
-        yticks = np.arange(ylim_min, ylim_max + round_to_nearest, round_to_nearest)
+    y_span = ylim_max - ylim_min
+    if y_span == 0: y_span = 1.0 # Prevent math error if data is perfectly flat
+    
+    ylim_min -= (y_span * 0.1)
+    ylim_max += (y_span * 0.1)    
+    # If the range is extremely small (nearly a flat line), add a fixed buffer
 
     if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
         ylim_min = float(

--- a/ush/rtofs/lead_average.py
+++ b/ush/rtofs/lead_average.py
@@ -761,14 +761,26 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         ylim_min = (np.floor(y_min/round_to_nearest)*round_to_nearest)- 0.5 * margin
         ylim_max = (np.ceil(y_max/round_to_nearest)*round_to_nearest)+ 0.5 * margin
     else:
-        round_to_nearest_categories = y_range_categories/0.2
-        y_range = y_max-y_min
-        round_to_nearest =  round_to_nearest_categories[
-        np.digitize(y_range, y_range_categories[:-1])
+        # If the range is very small, don't let the interval get too tiny
+        y_range = y_max - y_min
+
+        # We use a larger divisor (e.g., 5 or 10) instead of 0.2
+        # to ensure fewer, more readable ticks
+        round_to_nearest_categories = y_range_categories / 5.0
+
+        round_to_nearest = round_to_nearest_categories[
+            np.digitize(y_range, y_range_categories[:-1])
         ]
-        ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest 
+
+        # Safety check: Force a minimum step size if the math produces 0
+        if round_to_nearest < 0.01:
+            round_to_nearest = 0.05
+
+        ylim_min = np.floor(y_min/round_to_nearest)*round_to_nearest
         ylim_max = np.ceil(y_max/round_to_nearest)*round_to_nearest
 
+        # If the range is extremely small (nearly a flat line), add a fixed buffer
+        yticks = np.arange(ylim_min, ylim_max + round_to_nearest, round_to_nearest)
 
     if len(str(ylim_min)) > 5 and np.abs(ylim_min) < 1.:
         ylim_min = float(
@@ -781,7 +793,8 @@ def plot_lead_average(df: pd.DataFrame, logger: logging.Logger,
         yticks = np.arange(-1, 1.1, 0.1)
     else:
         yticks = np.arange(ylim_min, ylim_max+round_to_nearest, round_to_nearest)
-    
+        if len(yticks) > 8:
+            yticks = np.linspace(ylim_min, ylim_max, 5)
     var_long_name_key = df['FCST_VAR'].tolist()[0]
     if str(var_long_name_key).upper() == 'HGT':
         if str(df['OBS_VAR'].tolist()[0]).upper() == 'CEILING':


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR addresses issues with the y-axis visualization in lead_average.py for EVSv2-RTOFS **Argo** plots. It was noticed recently that the automated scaling logic resulted in overlapping/unreadable tick labels when the data range (margin) was too small. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 No.
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
To test this PR, please follow these steps:

1- Clone my fork in your local and checkout branch `feature/EVSv2-RTOFS_yticks`.
2- Set your `$HOMEevs` to point to your local test directory.
3- `mkdir` fix in your `$HOMEevs` and Soft link the fix directory: 
`ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/`
4- For all **plots** driver scripts:
- In `$COMIN`, replace the `${USER}` with `emc.vpppg`.
- `$KEEPDATA` set to YES
- `$SENDMAIL` set to NO
- Run the **plots** driver scripts for the current `VDATE` for all plots driver scripts using `qsub` command: 
`qsub $HOMEevs/dev/drivers/scripts/plots/rtofs/*`