### PR TITLE
Feature/rrfs chem release update 1

### DIFF
--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -30,7 +30,7 @@ source $HOMEevs/dev/modulefiles/cam/cam_prep.sh
 ############################################################
 ## set some variables
 #############################################################
-export KEEPDATA=YES
+export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:40:00
-#PBS -l place=shared,select=1:ncpus=1:mem=12GB
+#PBS -l place=shared,select=1:ncpus=1:mem=15GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:40:00
+#PBS -l walltime=00:20:00
 #PBS -l place=shared,select=1:ncpus=1:mem=15GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:40:00
-#PBS -l place=shared,select=1:ncpus=1:mem=10GB
+#PBS -l place=shared,select=1:ncpus=1:mem=12GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh
@@ -30,7 +30,7 @@ source $HOMEevs/dev/modulefiles/cam/cam_stats.sh
 ############################################################
 # set some variables
 ############################################################
-export KEEPDATA=YES
+export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
@@ -31,7 +31,7 @@ source $HOMEevs/dev/modulefiles/cam/cam_stats.sh
 ############################################################
 # set some variables
 ############################################################
-export KEEPDATA=YES
+export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
@@ -31,7 +31,7 @@ source $HOMEevs/dev/modulefiles/cam/cam_stats.sh
 ############################################################
 # set some variables
 ############################################################
-export KEEPDATA=YES
+export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
 

--- a/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.ecf
+++ b/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:40:00
+#PBS -l walltime=00:20:00
 #PBS -l place=shared,select=1:ncpus=1:mem=15GB
 #PBS -l debug=true
 

--- a/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.ecf
+++ b/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=shared,select=1:ncpus=1:mem=10GB
+#PBS -l place=shared,select=1:ncpus=1:mem=12GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.ecf
+++ b/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=shared,select=1:ncpus=1:mem=12GB
+#PBS -l place=shared,select=1:ncpus=1:mem=15GB
 #PBS -l debug=true
 
 export model=evs

--- a/parm/metplus_config/stats/cam/chem_grid2obs/PointStat_fcstRRFSAero_obsAERONET_AOD.conf
+++ b/parm/metplus_config/stats/cam/chem_grid2obs/PointStat_fcstRRFSAero_obsAERONET_AOD.conf
@@ -72,7 +72,7 @@ POINT_STAT_MESSAGE_TYPE =
 
 
 [filename_templates]
-FCST_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{init?fmt=%Y%m%d}/{ENV[MODELNAME]}/{ENV[mdl_cyc]}/{ENV[MODELNAME]}.t{ENV[mdl_cyc]}z.prslev.f{lead?fmt=%3H}.trim.grib2
+FCST_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{init?fmt=%Y%m%d}/{ENV[MODELNAME]}/{ENV[mdl_cyc]}/{ENV[MODELNAME]}.t{ENV[mdl_cyc]}z.evsin.f{lead?fmt=%3H}.trim.grib2
 
 OBS_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{valid?fmt=%Y%m%d}/obs/{ENV[ObsSrc]}_All_{valid?fmt=%Y%m%d}_lev15.nc
 

--- a/parm/metplus_config/stats/cam/chem_grid2obs/PointStat_fcstRRFSAero_obsAIRNOW_PM10.conf
+++ b/parm/metplus_config/stats/cam/chem_grid2obs/PointStat_fcstRRFSAero_obsAIRNOW_PM10.conf
@@ -87,7 +87,7 @@ POINT_STAT_MESSAGE_TYPE =
 
 [filename_templates]
 
-FCST_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{init?fmt=%Y%m%d}/{ENV[MODELNAME]}/{ENV[mdl_cyc]}/{ENV[MODELNAME]}.t{ENV[mdl_cyc]}z.prslev.f{lead?fmt=%3H}.trim.grib2
+FCST_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{init?fmt=%Y%m%d}/{ENV[MODELNAME]}/{ENV[mdl_cyc]}/{ENV[MODELNAME]}.t{ENV[mdl_cyc]}z.evsin.f{lead?fmt=%3H}.trim.grib2
 
 OBS_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{valid?fmt=%Y%m%d?shift=-3600}/obs/{ENV[ObsSrc]}_{ENV[HOURLY_INPUT_TYPE]}_{valid?fmt=%Y%m%d%H?shift=-3600}.nc
 

--- a/parm/metplus_config/stats/cam/chem_grid2obs/PointStat_fcstRRFSAero_obsAIRNOW_PM25.conf
+++ b/parm/metplus_config/stats/cam/chem_grid2obs/PointStat_fcstRRFSAero_obsAIRNOW_PM25.conf
@@ -86,7 +86,7 @@ POINT_STAT_MESSAGE_TYPE =
 
 [filename_templates]
 
-FCST_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{init?fmt=%Y%m%d}/{ENV[MODELNAME]}/{ENV[mdl_cyc]}/{ENV[MODELNAME]}.t{ENV[mdl_cyc]}z.prslev.f{lead?fmt=%3H}.trim.grib2
+FCST_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{init?fmt=%Y%m%d}/{ENV[MODELNAME]}/{ENV[mdl_cyc]}/{ENV[MODELNAME]}.t{ENV[mdl_cyc]}z.evsin.f{lead?fmt=%3H}.trim.grib2
 
 OBS_POINT_STAT_INPUT_TEMPLATE = {ENV[RUN]}.{valid?fmt=%Y%m%d?shift=-3600}/obs/{ENV[ObsSrc]}_{ENV[HOURLY_INPUT_TYPE]}_{valid?fmt=%Y%m%d%H?shift=-3600}.nc
 

--- a/scripts/prep/cam/exevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/scripts/prep/cam/exevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -203,7 +203,7 @@ for mdl_cyc in "${cyc_opt[@]}"; do
   
         # --- RESTART Logic ---
         if [ "${check_restart}" == "YES" ]; then
-            checkfile_pattern="${MODELNAME}.t${mdl_cyc}z.2dfld.f*.trim.grib2"
+            checkfile_pattern="${MODELNAME}.t${mdl_cyc}z.evsin.f*.trim.grib2"
             mdl_file_count=$(find "${prep_rrfs}" -name "${checkfile_pattern}" | wc -l)
             
             if [ ${mdl_file_count} -eq ${max_hour} ]; then

--- a/scripts/prep/cam/exevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/scripts/prep/cam/exevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -203,13 +203,13 @@ for mdl_cyc in "${cyc_opt[@]}"; do
   
         # --- RESTART Logic ---
         if [ "${check_restart}" == "YES" ]; then
-            checkfile_pattern="${MODELNAME}.t${mdl_cyc}z.prslev.f*.trim.grib2"
+            checkfile_pattern="${MODELNAME}.t${mdl_cyc}z.2dfld.f*.trim.grib2"
             mdl_file_count=$(find "${prep_rrfs}" -name "${checkfile_pattern}" | wc -l)
             
             if [ ${mdl_file_count} -eq ${max_hour} ]; then
                 # Check if the last file is healthy
                 fhr3_last=$(printf %3.3d ${max_hour})
-                last_file="${prep_rrfs}/${MODELNAME}.t${mdl_cyc}z.prslev.f${fhr3_last}.trim.grib2"
+                last_file="${prep_rrfs}/${MODELNAME}.t${mdl_cyc}z.evsin.f${fhr3_last}.trim.grib2"
                 if wgrib2 -V "${last_file}" > /dev/null 2>&1; then
                     echo "DEBUG :: Cycle ${mdl_cyc} complete. Skipping."
                     continue 
@@ -221,8 +221,8 @@ for mdl_cyc in "${cyc_opt[@]}"; do
         # --- Extraction Loop ---
         while [ ${hour_now} -le ${max_hour} ]; do
             fhr3=$(printf %3.3d ${hour_now})
-            mdl_full_grib2="${MODELNAME}.t${mdl_cyc}z.prslev.3km.f${fhr3}.na.grib2"
-            mdl_trim_grib2="${MODELNAME}.t${mdl_cyc}z.prslev.f${fhr3}.trim.grib2"
+            mdl_full_grib2="${MODELNAME}.t${mdl_cyc}z.2dfld.3km.f${fhr3}.na.grib2"
+            mdl_trim_grib2="${MODELNAME}.t${mdl_cyc}z.evsin.f${fhr3}.trim.grib2"
             
             check_full_file="${com_rrfs_mdl}/${mdl_full_grib2}"
             check_trim_file="${com_rrfs_mdl}/${mdl_trim_grib2}"

--- a/scripts/stats/cam/exevs_stats_cam_rrfs_chem_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_cam_rrfs_chem_grid2obs.sh
@@ -117,7 +117,7 @@ for ObsType in ${grid2obs_list}; do
         aday=`echo ${adate} |cut -c1-8`
         acyc=`echo ${adate} |cut -c9-10`
         if [ "${acyc}" == "${mdl_cyc}" ]; then
-          fcst_file=${EVSINrrfs}/${RUN}.${aday}/${MODELNAME}/${acyc}/${MODELNAME}.t${acyc}z.prslev.f${filehr}.trim.grib2
+          fcst_file=${EVSINrrfs}/${RUN}.${aday}/${MODELNAME}/${acyc}/${MODELNAME}.t${acyc}z.evsin.f${filehr}.trim.grib2
           if [ -s ${fcst_file} ]; then
             if [ "${check_restart}" == "YES" ]; then
               point_stat_file="${COMOUTsmall}/point_stat_${OutputId}_${fhr}0000L_${VDATE}_${vhr}0000V.stat"


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

The input source GRIB2 files were updated from containing "prslev" to "2dfld" in their filenames. This change was implemented following a revision to the RRFS GRIB2 output on 15Z, April 16, 2026.

Additionally, the filename for the trimmed GRIB2 files has been updated from including "prslev" to "evsin" to prevent disruption from future naming changes.

The following procedures are for the implementation of the parallel execution of emc.vpppg:

- Prep Output Transfer: The prep output files should be copied from the user's directory to the shared emc.vpppg directory.

Source: /lfs/h2/emc/vpppg/noscrub/ho-chun.huang/evs/rrfs_v2.0/prep/cam/chem.*
Destination: /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/prep/cam

- Stats Output Transfer: The transfer of stats output files is required, with the specific action dependent on the directory structure of Marcel's RRFS/REFS output:

Case 1: Absence of the rrfs.yyyymmdd directory
Source: /lfs/h2/emc/vpppg/noscrub/ho-chun.huang/evs/rrfs_v2.0/stats/cam/rrfs.*
Destination: /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/stats/cam

Case 2: Presence of the rrfs.yyyymmdd directory
Source: /lfs/h2/emc/vpppg/noscrub/ho-chun.huang/evs/rrfs_v2.0/stats/cam/rrfs.yyyymmdd/*
Destination: /lfs/h2/emc/vpppg/noscrub/emc.vpppg/evs/v2.0/stats/cam/rrfs.yyyymmdd


> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES.  06/17/2026

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
NO

  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Please download the branch and update the HOMEevs to reflect the correct PR code directory.

(1) Prep

Execute the script: ~/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh.

Ensure the following environment variable is set: export COMINrrfs=/lfs/h1/ops/para/com/rrfs/v1.0.

Configure COMIN and COMOUT to point to the designated PR test directory.

Run the script for the current date, default to PDYm3.

(2) Stats

In the statistics directory: ~/dev/drivers/scripts/stats/cam/.

Execute the statistics scripts:
jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh

Point the input prep output to the my personal prep directory by setting the following environment variable:
export COMIN=/lfs/h2/emc/vpppg/noscrub/ho-chun.huang/evs/rrfs_v2.0.

Configure COMOUT to point to the designated PR test directory.
export COMOUT=${COMIN}/stats/cam

Please run vhr=00, 01, 02,....22 at the same time, when the previous jobs finished, then submit vhr=23.

Run the scripts for the current date, default to PDYm3.