### PR TITLE
Feature/cam/change rrfs filenames

### DIFF
--- a/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.grid2obs.rrfs
+++ b/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.grid2obs.rrfs
@@ -31,13 +31,18 @@ if [ "$NEST" = "conus" ]; then
     export FHR_GROUP_LIST="SHORT FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH SBCAPE MLCAPE HPBL"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G240"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="SBCAPE MLCAPE HPBL"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m MSLP UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc TCDC VIS CEILING PTYPE"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -56,13 +61,18 @@ elif [ "$NEST" = "subreg" ]; then
     export FHR_GROUP_LIST="SHORT FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST=""
         export VHOUR_LIST="00 06 12 18"
         export GRID="G218"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc VIS CEILING"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -81,13 +91,18 @@ elif [ "$NEST" = "ak" ]; then
     export FHR_GROUP_LIST="SHORT FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH SBCAPE MLCAPE HPBL"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G091"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.ak.grib2"
+            export VAR_NAME_LIST="SBCAPE MLCAPE HPBL"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.ak.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m MSLP UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc TCDC VIS CEILING PTYPE"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -106,13 +121,18 @@ elif [ "$NEST" = "hi" ]; then
     export FHR_GROUP_LIST="SHORT FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G196"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
+            export VAR_NAME_LIST=""
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m UGRD_VGRD10m"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -131,13 +151,18 @@ elif [ "$NEST" = "pr" ]; then
     export FHR_GROUP_LIST="SHORT FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G194"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
+            export VAR_NAME_LIST=""
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
         export VAR_NAME_LIST=""
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -156,13 +181,18 @@ elif [ "$NEST" = "firewx" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST="HPBL"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G240"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="HPBL"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -170,7 +200,7 @@ elif [ "$NEST" = "firewx" ]; then
         err_exit "The provided OBSNAME, $OBSNAME, is not supported for $MODELNAME"
     fi
     export GRID_POLY_LIST="${FIXevs}/masks/Bukovsky_G240_CONUS.nc"
-    export NEST_INPUT_TEMPLATE="firewx.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.1p5km.f{lead?fmt=%3H}.firewx.grib2"
+    export NEST_INPUT_TEMPLATE="firewx.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.1p5km.f{lead?fmt=%3H}.firewx.grib2"
     export MIN_IHOUR="00"
     export FHR_END_FULL="36"
     export FHR_INCR_FULL="06"
@@ -181,13 +211,18 @@ elif [ "$NEST" = "spc_otlk" ]; then
     export FHR_GROUP_LIST="SHORT FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST="SBCAPE MLCAPE"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G240"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        else
+            export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="SBCAPE MLCAPE"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST=""
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"

--- a/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.grid2obs.rrfsmem
+++ b/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.grid2obs.rrfsmem
@@ -31,13 +31,18 @@ if [ "$NEST" = "conus" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH SBCAPE MLCAPE HPBL"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G240"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="SBCAPE MLCAPE HPBL"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m MSLP UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc TCDC VIS CEILING PTYPE"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -56,13 +61,18 @@ elif [ "$NEST" = "subreg" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST=""
         export VHOUR_LIST="00 06 12 18"
         export GRID="G218"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc VIS CEILING"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -81,13 +91,18 @@ elif [ "$NEST" = "ak" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH SBCAPE MLCAPE HPBL"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G091"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.ak.grib2"
+            export VAR_NAME_LIST="SBCAPE MLCAPE HPBL"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.ak.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m MSLP UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc TCDC VIS CEILING PTYPE"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -106,13 +121,18 @@ elif [ "$NEST" = "hi" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G196"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
+            export VAR_NAME_LIST=""
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m UGRD_VGRD10m"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -131,13 +151,18 @@ elif [ "$NEST" = "pr" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
-        export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G194"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+            export VAR_NAME_LIST="HGT TMP UGRD VGRD UGRD_VGRD SPFH"
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
+            export VAR_NAME_LIST=""
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
         export VAR_NAME_LIST=""
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -156,13 +181,18 @@ elif [ "$NEST" = "firewx" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST="HPBL"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G240"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="HPBL"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST="TMP2m DPT2m RH2m UGRD10m VGRD10m UGRD_VGRD10m WIND10m GUSTsfc"
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"
@@ -170,7 +200,7 @@ elif [ "$NEST" = "firewx" ]; then
         err_exit "The provided OBSNAME, $OBSNAME, is not supported for $MODELNAME"
     fi
     export GRID_POLY_LIST="${FIXevs}/masks/Bukovsky_G240_CONUS.nc"
-    export NEST_INPUT_TEMPLATE="firewx.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.1p5km.f{lead?fmt=%3H}.firewx.grib2"
+    export NEST_INPUT_TEMPLATE="firewx.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.1p5km.f{lead?fmt=%3H}.firewx.grib2"
     export MIN_IHOUR="00"
     export FHR_END_FULL="36"
     export FHR_INCR_FULL="06"
@@ -181,13 +211,18 @@ elif [ "$NEST" = "spc_otlk" ]; then
     export FHR_GROUP_LIST="FULL"
     if [ "$OBSNAME" = "raob" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
-        export VAR_NAME_LIST="SBCAPE MLCAPE"
         export VHOUR_LIST="00 06 12 18"
         export GRID="G240"
+        if (( var_set_num == 0 )); then
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST=""
+        else
+            export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
+            export VAR_NAME_LIST="SBCAPE MLCAPE"
+        fi
     elif [ "$OBSNAME" = "metar" ]; then
         export COMINobs=${COMINobsproc}
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export VAR_NAME_LIST=""
         export VHOUR_LIST="00 03 06 09 12 15 18 21"
         export GRID="FCST"

--- a/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.precip.rrfs
+++ b/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.precip.rrfs
@@ -106,7 +106,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G240"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G240_CONUS.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_South.nc"
     elif [ "$NEST" = "ak" ]; then
         export VERIF_TYPE="mrms"
@@ -116,7 +116,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G091"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.ak.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Alaska_G091.nc"
     elif [ "$NEST" = "hi" ]; then
         export VERIF_TYPE="mrms"
@@ -126,7 +126,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G196"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Hawaii_G196.nc"
     elif [ "$NEST" = "pr" ]; then
         export VERIF_TYPE="mrms"
@@ -136,7 +136,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G194"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Puerto_Rico_G194.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"
@@ -153,7 +153,7 @@ else
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G212"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G212_CONUS.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_South.nc"
     elif [ "$NEST" = "ak" ]; then
         export VERIF_TYPE="mrms"
@@ -163,7 +163,7 @@ else
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G216"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Alaska_G216.nc"
     elif [ "$NEST" = "hi" ]; then
         export VERIF_TYPE="mrms"
@@ -173,7 +173,7 @@ else
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G196"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Hawaii_G196.nc"
     elif [ "$NEST" = "pr" ]; then
         export VERIF_TYPE="mrms"
@@ -183,7 +183,7 @@ else
         export FHR_INCR_SHORT="1"
         export MIN_IHOUR="00"
         export GRID="G194"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Puerto_Rico_G194.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"

--- a/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.precip.rrfsmem
+++ b/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.precip.rrfsmem
@@ -106,7 +106,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G240"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G240_CONUS.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_South.nc"
     elif [ "$NEST" = "ak" ]; then
         export VERIF_TYPE="mrms"
@@ -116,7 +116,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G091"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.ak.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.ak.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Alaska_G091.nc"
     elif [ "$NEST" = "hi" ]; then
         export VERIF_TYPE="mrms"
@@ -126,7 +126,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G196"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Hawaii_G196.nc"
     elif [ "$NEST" = "pr" ]; then
         export VERIF_TYPE="mrms"
@@ -136,7 +136,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G194"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Puerto_Rico_G194.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"
@@ -153,7 +153,7 @@ else
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G212"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G212_CONUS.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_South.nc"
     elif [ "$NEST" = "ak" ]; then
         export VERIF_TYPE="mrms"
@@ -163,7 +163,7 @@ else
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G216"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Alaska_G216.nc"
     elif [ "$NEST" = "hi" ]; then
         export VERIF_TYPE="mrms"
@@ -173,7 +173,7 @@ else
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G196"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.hi.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.hi.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Hawaii_G196.nc"
     elif [ "$NEST" = "pr" ]; then
         export VERIF_TYPE="mrms"
@@ -183,7 +183,7 @@ else
         export FHR_INCR_SHORT="6"
         export MIN_IHOUR="00"
         export GRID="G194"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.2p5km.f{lead?fmt=%3H}.pr.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.2p5km.f{lead?fmt=%3H}.pr.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Puerto_Rico_G194.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"

--- a/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.snowfall.rrfs
+++ b/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.snowfall.rrfs
@@ -80,7 +80,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         fi
         export MIN_IHOUR="00"
         export GRID="OBS"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G240_CONUS.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_South.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"
@@ -101,7 +101,7 @@ else
         fi
         export MIN_IHOUR="00"
         export GRID="G212"
-        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/rrfs.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G212_CONUS.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_South.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"

--- a/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.snowfall.rrfsmem
+++ b/parm/evs_config/cam/config.evs.prod.stats.cam.atmos.snowfall.rrfsmem
@@ -80,7 +80,7 @@ if [ "$BOOL_NBRHD" = True ]; then
         fi
         export MIN_IHOUR="00"
         export GRID="OBS"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G240_CONUS.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G240_CONUS_South.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"
@@ -101,7 +101,7 @@ else
         fi
         export MIN_IHOUR="00"
         export GRID="G212"
-        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.conus.grib2"
+        export MODEL_INPUT_TEMPLATE="rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${mem}/rrfs.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2"
         export MASK_POLY_LIST="${FIXevs}/masks/Bukovsky_G212_CONUS.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_East.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_West.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_Central.nc, ${FIXevs}/masks/Bukovsky_G212_CONUS_South.nc"
     else
         err_exit "The provided NEST, $NEST, is not supported for $MODELNAME"

--- a/scripts/stats/cam/exevs_stats_cam_rrfs_firewxnest_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_cam_rrfs_firewxnest_grid2obs.sh
@@ -14,7 +14,7 @@ export OBSDIR=OBS
 mkdir -p $DATA/$OBSDIR
 export modsys=rrfs
 export regionnest=firewx
-export outtyp="prslev.1p5km"
+export outtyp="2dfld.1p5km"
 
 model1=`echo $MODELNAME | tr a-z A-Z`
 export model1

--- a/scripts/stats/cam/exevs_stats_rrfs_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_rrfs_grid2obs.sh
@@ -132,11 +132,11 @@ for NEST in $NEST_LIST; do
     export NEST=$NEST
     for VERIF_TYPE in $VERIF_TYPES; do
         export VERIF_TYPE=$VERIF_TYPE
-        var_set_num=0
+        export var_set_num=0
         if [ "$VERIF_TYPE" = "raob" ]; then
-            var_set_max=2
+            var_set_max=2 # Run the loop twice
         else
-            var_set_max=1
+            var_set_max=1 # Run the loop once
         fi
         while (( var_set_num < var_set_max )); do
             source $config
@@ -178,7 +178,7 @@ for NEST in $NEST_LIST; do
                     done
                 done
             done
-            ((var_set_num++))
+            ((++var_set_num))
         done
     done 
 done

--- a/scripts/stats/cam/exevs_stats_rrfs_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_rrfs_grid2obs.sh
@@ -42,11 +42,11 @@ for NEST in $NEST_LIST; do
             # Check User's Configuration Settings
             python $USHevs/cam/cam_check_settings.py
             export err=$?; err_chk
-     
+        
             # Check Availability of Input Data
             python $USHevs/cam/cam_check_input_data.py
             export err=$?; err_chk
-     
+        
             # Create Output Directories
             python $USHevs/cam/cam_create_output_dirs.py
             export err=$?; err_chk
@@ -132,44 +132,53 @@ for NEST in $NEST_LIST; do
     export NEST=$NEST
     for VERIF_TYPE in $VERIF_TYPES; do
         export VERIF_TYPE=$VERIF_TYPE
-        source $config
-        source $USHevs/cam/cam_stats_grid2obs_filter_valid_hours_list.sh
-        for VAR_NAME in $VAR_NAME_LIST; do
-            export VAR_NAME=$VAR_NAME
-            for VHOUR in $VHOUR_LIST; do
-                export VHOUR=$VHOUR
-                # Check User's Configuration Settings
-                python $USHevs/cam/cam_check_settings.py
-                export err=$?; err_chk
-         
-                # Create Output Directories
-                python $USHevs/cam/cam_create_output_dirs.py
-                export err=$?; err_chk
-        
-                all_fhrs="" 
-                for FHR_GROUP in $FHR_GROUP_LIST; do
-                    export FHR_GROUP=$FHR_GROUP
-                    TARGET_FHR_END="FHR_END_${FHR_GROUP}"
-                    TARGET_FHR_INCR="FHR_INCR_${FHR_GROUP}"
-                    export FHR_END=${!TARGET_FHR_END}
-                    export FHR_INCR=${!TARGET_FHR_INCR}
-                    export FHR_START=$(python -c "import cam_util; print(cam_util.get_fhr_start('${VHOUR}',0,'${FHR_INCR}','${MIN_IHOUR}'))")
-                
-                    for FHR in `seq ${FHR_START} ${FHR_INCR} ${FHR_END}`; do
-                        export FHR=$(printf "%02d" $FHR)
-                        all_fhrs="$all_fhrs $FHR"
+        var_set_num=0
+        if [ "$VERIF_TYPE" = "raob" ]; then
+            var_set_max=2
+        else
+            var_set_max=1
+        fi
+        while (( var_set_num < var_set_max )); do
+            source $config
+            source $USHevs/cam/cam_stats_grid2obs_filter_valid_hours_list.sh
+            for VAR_NAME in $VAR_NAME_LIST; do
+                export VAR_NAME=$VAR_NAME
+                for VHOUR in $VHOUR_LIST; do
+                    export VHOUR=$VHOUR
+                    # Check User's Configuration Settings
+                    python $USHevs/cam/cam_check_settings.py
+                    export err=$?; err_chk
+             
+                    # Create Output Directories
+                    python $USHevs/cam/cam_create_output_dirs.py
+                    export err=$?; err_chk
+            
+                    all_fhrs="" 
+                    for FHR_GROUP in $FHR_GROUP_LIST; do
+                        export FHR_GROUP=$FHR_GROUP
+                        TARGET_FHR_END="FHR_END_${FHR_GROUP}"
+                        TARGET_FHR_INCR="FHR_INCR_${FHR_GROUP}"
+                        export FHR_END=${!TARGET_FHR_END}
+                        export FHR_INCR=${!TARGET_FHR_INCR}
+                        export FHR_START=$(python -c "import cam_util; print(cam_util.get_fhr_start('${VHOUR}',0,'${FHR_INCR}','${MIN_IHOUR}'))")
+                    
+                        for FHR in `seq ${FHR_START} ${FHR_INCR} ${FHR_END}`; do
+                            export FHR=$(printf "%02d" $FHR)
+                            all_fhrs="$all_fhrs $FHR"
+                        done
+                    done
+                    unique_fhrs=$(echo $all_fhrs | tr ' ' '\n' | sort -n | uniq)
+
+                    for FHR in $unique_fhrs; do
+                        export FHR
+                          
+                        python $USHevs/cam/cam_stats_grid2obs_create_job_script.py
+                        export err=$?; err_chk
+                        export njob=$((njob+1))
                     done
                 done
-                unique_fhrs=$(echo $all_fhrs | tr ' ' '\n' | sort -n | uniq)
-
-                for FHR in $unique_fhrs; do
-                    export FHR
-                      
-                    python $USHevs/cam/cam_stats_grid2obs_create_job_script.py
-                    export err=$?; err_chk
-                    export njob=$((njob+1))
-                done
             done
+            ((var_set_num++))
         done
     done 
 done

--- a/scripts/stats/cam/exevs_stats_rrfsmem_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_rrfsmem_grid2obs.sh
@@ -132,44 +132,53 @@ for NEST in $NEST_LIST; do
     export NEST=$NEST
     for VERIF_TYPE in $VERIF_TYPES; do
         export VERIF_TYPE=$VERIF_TYPE
-        source $config
-        source $USHevs/cam/cam_stats_grid2obs_filter_valid_hours_list.sh
-        for VAR_NAME in $VAR_NAME_LIST; do
-            export VAR_NAME=$VAR_NAME
-            for VHOUR in $VHOUR_LIST; do
-                export VHOUR=$VHOUR
-                # Check User's Configuration Settings
-                python $USHevs/cam/cam_check_settings.py
-                export err=$?; err_chk
-         
-                # Create Output Directories
-                python $USHevs/cam/cam_create_output_dirs.py
-                export err=$?; err_chk
-        
-                all_fhrs="" 
-                for FHR_GROUP in $FHR_GROUP_LIST; do
-                    export FHR_GROUP=$FHR_GROUP
-                    TARGET_FHR_END="FHR_END_${FHR_GROUP}"
-                    TARGET_FHR_INCR="FHR_INCR_${FHR_GROUP}"
-                    export FHR_END=${!TARGET_FHR_END}
-                    export FHR_INCR=${!TARGET_FHR_INCR}
-                    export FHR_START=$(python -c "import cam_util; print(cam_util.get_fhr_start('${VHOUR}',0,'${FHR_INCR}','${MIN_IHOUR}'))")
-                
-                    for FHR in `seq ${FHR_START} ${FHR_INCR} ${FHR_END}`; do
-                        export FHR=$(printf "%02d" $FHR)
-                        all_fhrs="$all_fhrs $FHR"
+        var_set_num=0
+        if [ "$VERIF_TYPE" = "raob" ]; then
+            var_set_max=2
+        else
+            var_set_max=1
+        fi
+        while (( var_set_num < var_set_max )); do
+            source $config
+            source $USHevs/cam/cam_stats_grid2obs_filter_valid_hours_list.sh
+            for VAR_NAME in $VAR_NAME_LIST; do
+                export VAR_NAME=$VAR_NAME
+                for VHOUR in $VHOUR_LIST; do
+                    export VHOUR=$VHOUR
+                    # Check User's Configuration Settings
+                    python $USHevs/cam/cam_check_settings.py
+                    export err=$?; err_chk
+             
+                    # Create Output Directories
+                    python $USHevs/cam/cam_create_output_dirs.py
+                    export err=$?; err_chk
+            
+                    all_fhrs="" 
+                    for FHR_GROUP in $FHR_GROUP_LIST; do
+                        export FHR_GROUP=$FHR_GROUP
+                        TARGET_FHR_END="FHR_END_${FHR_GROUP}"
+                        TARGET_FHR_INCR="FHR_INCR_${FHR_GROUP}"
+                        export FHR_END=${!TARGET_FHR_END}
+                        export FHR_INCR=${!TARGET_FHR_INCR}
+                        export FHR_START=$(python -c "import cam_util; print(cam_util.get_fhr_start('${VHOUR}',0,'${FHR_INCR}','${MIN_IHOUR}'))")
+                    
+                        for FHR in `seq ${FHR_START} ${FHR_INCR} ${FHR_END}`; do
+                            export FHR=$(printf "%02d" $FHR)
+                            all_fhrs="$all_fhrs $FHR"
+                        done
+                    done
+                    unique_fhrs=$(echo $all_fhrs | tr ' ' '\n' | sort -n | uniq)
+
+                    for FHR in $unique_fhrs; do
+                        export FHR
+                          
+                        python $USHevs/cam/cam_stats_grid2obs_create_job_script.py
+                        export err=$?; err_chk
+                        export njob=$((njob+1))
                     done
                 done
-                unique_fhrs=$(echo $all_fhrs | tr ' ' '\n' | sort -n | uniq)
-
-                for FHR in $unique_fhrs; do
-                    export FHR
-                      
-                    python $USHevs/cam/cam_stats_grid2obs_create_job_script.py
-                    export err=$?; err_chk
-                    export njob=$((njob+1))
-                done
             done
+            ((var_set_num++))
         done
     done 
 done

--- a/scripts/stats/cam/exevs_stats_rrfsmem_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_rrfsmem_grid2obs.sh
@@ -132,11 +132,11 @@ for NEST in $NEST_LIST; do
     export NEST=$NEST
     for VERIF_TYPE in $VERIF_TYPES; do
         export VERIF_TYPE=$VERIF_TYPE
-        var_set_num=0
+        export var_set_num=0
         if [ "$VERIF_TYPE" = "raob" ]; then
-            var_set_max=2
+            var_set_max=2 # Run loop twice
         else
-            var_set_max=1
+            var_set_max=1 # Run loop once
         fi
         while (( var_set_num < var_set_max )); do
             source $config
@@ -178,7 +178,7 @@ for NEST in $NEST_LIST; do
                     done
                 done
             done
-            ((var_set_num++))
+            ((++var_set_num))
         done
     done 
 done

--- a/ush/cam/cam_check_input_data.py
+++ b/ush/cam/cam_check_input_data.py
@@ -242,7 +242,7 @@ if proceed:
                     COMINrrfs, 
                     'firewx.{IDATE}',
                     '{IHOUR}',
-                    'rrfs.t{IHOUR}z.prslev.1p5km.f0{FHR}.firewx.grib2'
+                    'rrfs.t{IHOUR}z.2dfld.1p5km.f0{FHR}.firewx.grib2'
                 )
             ]
         else:
@@ -295,12 +295,24 @@ if proceed:
                     '{IHOUR}',
                     'rrfs.t{IHOUR}z.prslev.3km.f0{FHR}.conus.grib2'
                 ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfs.{IDATE}',
+                    '{IHOUR}',
+                    'rrfs.t{IHOUR}z.2dfld.3km.f0{FHR}.conus.grib2'
+                ))
             elif NEST == 'ak':
                 fcst_templates.append(os.path.join(
                     COMINfcst,
                     'rrfs.{IDATE}',
                     '{IHOUR}',
                     'rrfs.t{IHOUR}z.prslev.3km.f0{FHR}.ak.grib2'
+                ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfs.{IDATE}',
+                    '{IHOUR}',
+                    'rrfs.t{IHOUR}z.2dfld.3km.f0{FHR}.ak.grib2'
                 ))
             elif NEST == 'hi':
                 fcst_templates.append(os.path.join(
@@ -309,6 +321,12 @@ if proceed:
                     '{IHOUR}',
                     'rrfs.t{IHOUR}z.prslev.2p5km.f0{FHR}.hi.grib2'
                 ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfs.{IDATE}',
+                    '{IHOUR}',
+                    'rrfs.t{IHOUR}z.2dfld.2p5km.f0{FHR}.hi.grib2'
+                ))
             elif NEST == 'pr':
                 fcst_templates.append(os.path.join(
                     COMINfcst,
@@ -316,12 +334,24 @@ if proceed:
                     '{IHOUR}',
                     'rrfs.t{IHOUR}z.prslev.2p5km.f0{FHR}.pr.grib2'
                 ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfs.{IDATE}',
+                    '{IHOUR}',
+                    'rrfs.t{IHOUR}z.2dfld.2p5km.f0{FHR}.pr.grib2'
+                ))
             else:
                 fcst_templates.append(os.path.join(
                     COMINfcst,
                     'rrfs.{IDATE}',
                     '{IHOUR}',
                     'rrfs.t{IHOUR}z.prslev.3km.f0{FHR}.conus.grib2'
+                ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfs.{IDATE}',
+                    '{IHOUR}',
+                    'rrfs.t{IHOUR}z.2dfld.3km.f0{FHR}.conus.grib2'
                 ))
         elif 'rrfsmem' in MODELNAME:
             if NEST == 'conus':
@@ -332,6 +362,13 @@ if proceed:
                     f'm00{mem}',
                     'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'prslev.3km.f0{FHR}.conus.grib2'
                 ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfsens.{IDATE}',
+                    '{IHOUR}',
+                    f'm00{mem}',
+                    'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'2dfld.3km.f0{FHR}.conus.grib2'
+                ))
             elif NEST == 'ak':
                 fcst_templates.append(os.path.join(
                     COMINfcst,
@@ -339,6 +376,13 @@ if proceed:
                     '{IHOUR}',
                     f'm00{mem}',
                     'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'prslev.3km.f0{FHR}.ak.grib2'
+                ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfsens.{IDATE}',
+                    '{IHOUR}',
+                    f'm00{mem}',
+                    'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'2dfld.3km.f0{FHR}.ak.grib2'
                 ))
             elif NEST == 'hi':
                 fcst_templates.append(os.path.join(
@@ -348,6 +392,13 @@ if proceed:
                     f'm00{mem}',
                     'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'prslev.2p5km.f0{FHR}.hi.grib2'
                 ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfsens.{IDATE}',
+                    '{IHOUR}',
+                    f'm00{mem}',
+                    'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'2dfld.2p5km.f0{FHR}.hi.grib2'
+                ))
             elif NEST == 'pr':
                 fcst_templates.append(os.path.join(
                     COMINfcst,
@@ -356,6 +407,13 @@ if proceed:
                     f'm00{mem}',
                     'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'prslev.2p5km.f0{FHR}.pr.grib2'
                 ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfsens.{IDATE}',
+                    '{IHOUR}',
+                    f'm00{mem}',
+                    'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'2dfld.2p5km.f0{FHR}.pr.grib2'
+                ))
             else:
                 fcst_templates.append(os.path.join(
                     COMINfcst,
@@ -363,6 +421,13 @@ if proceed:
                     '{IHOUR}',
                     f'm00{mem}',
                     'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'prslev.3km.f0{FHR}.conus.grib2'
+                ))
+                fcst_templates.append(os.path.join(
+                    COMINfcst,
+                    'rrfsens.{IDATE}',
+                    '{IHOUR}',
+                    f'm00{mem}',
+                    'rrfs.t{IHOUR}z.'+f'm00{mem}.'+'2dfld.3km.f0{FHR}.conus.grib2'
                 ))
         else:
             print(f"The provided MODELNAME ({MODELNAME}) is not recognized."

--- a/ush/cam/evs_cam_stats_radar.sh
+++ b/ush/cam/evs_cam_stats_radar.sh
@@ -98,7 +98,7 @@ elif [ ${MODELNAME} = rrfs ]; then
    fhr_inc=1
 
    export MODEL_INPUT_DIR=${COMINrrfs}
-   export MODEL_INPUT_TEMPLATE=${modsys}.{init?fmt=%Y%m%d}/{init?fmt=%H}/${modsys}.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.${DOM}.grib2
+   export MODEL_INPUT_TEMPLATE=${modsys}.{init?fmt=%Y%m%d}/{init?fmt=%H}/${modsys}.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.${DOM}.grib2
 
 elif [[ "${MODELNAME}" = *"rrfsmem"* ]]; then
 
@@ -107,7 +107,7 @@ elif [[ "${MODELNAME}" = *"rrfsmem"* ]]; then
    fhr_inc=1
 
    export MODEL_INPUT_DIR=${COMINrrfs}
-   export MODEL_INPUT_TEMPLATE=${modsys}ens.{init?fmt=%Y%m%d}/{init?fmt=%H}/m00${mem}/${modsys}.t{init?fmt=%2H}z.m00${mem}.prslev.3km.f{lead?fmt=%3H}.${DOM}.grib2
+   export MODEL_INPUT_TEMPLATE=${modsys}ens.{init?fmt=%Y%m%d}/{init?fmt=%H}/m00${mem}/${modsys}.t{init?fmt=%2H}z.m00${mem}.2dfld.3km.f{lead?fmt=%3H}.${DOM}.grib2
 
 fi
 
@@ -152,7 +152,7 @@ while [ $fhr -le $fhr_max ]; do
       else
          ihr_avail="00 06 12 18"
       fi
-      export fcst_file=${modsys}.${IDATE}/${INIT_HR}/${modsys}.t${INIT_HR}z.prslev.3km.f$(printf "%03d" $fhr).${DOM}.grib2
+      export fcst_file=${modsys}.${IDATE}/${INIT_HR}/${modsys}.t${INIT_HR}z.2dfld.3km.f$(printf "%03d" $fhr).${DOM}.grib2
    
    elif [ ${MODELNAME} = refs ]; then
       ihr_avail="00 06 12 18"
@@ -160,7 +160,7 @@ while [ $fhr -le $fhr_max ]; do
    
    elif [[ "${MODELNAME}" = *"rrfsmem"* ]]; then
       ihr_avail="00 06 12 18"
-      export fcst_file=${modsys}ens.${IDATE}/${INIT_HR}/m00${mem}/${modsys}.t${INIT_HR}z.m00${mem}.prslev.3km.f$(printf "%03d" $fhr).${DOM}.grib2
+      export fcst_file=${modsys}ens.${IDATE}/${INIT_HR}/m00${mem}/${modsys}.t${INIT_HR}z.m00${mem}.2dfld.3km.f$(printf "%03d" $fhr).${DOM}.grib2
    
    fi
 

--- a/ush/cam/evs_rrfs_severe_prep.sh
+++ b/ush/cam/evs_rrfs_severe_prep.sh
@@ -18,9 +18,9 @@ export JOBNUM=$2
 export MODEL_INPUT_DIR=${COMINrrfs}
 
 if [ $MEMNUM = ctl ]; then
-   export MODEL_INPUT_TEMPLATE=rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/${MODELNAME}.t{init?fmt=%2H}z.prslev.3km.f{lead?fmt=%3H}.conus.grib2
+   export MODEL_INPUT_TEMPLATE=rrfs.{init?fmt=%Y%m%d}/{init?fmt=%2H}/${MODELNAME}.t{init?fmt=%2H}z.2dfld.3km.f{lead?fmt=%3H}.conus.grib2
 else
-   export MODEL_INPUT_TEMPLATE=rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${MEMNUM}/rrfs.t{init?fmt=%2H}z.m00${MEMNUM}.prslev.3km.f{lead?fmt=%3H}.conus.grib2
+   export MODEL_INPUT_TEMPLATE=rrfsens.{init?fmt=%Y%m%d}/{init?fmt=%2H}/m00${MEMNUM}/rrfs.t{init?fmt=%2H}z.m00${MEMNUM}.2dfld.3km.f{lead?fmt=%3H}.conus.grib2
 fi
 
 
@@ -60,9 +60,9 @@ i=1
    while [ $i -le $min_file_req ]; do
 
       if [ $MEMNUM = ctl ]; then
-         export fcst_file=rrfs.${INITDATE}/${vhr}/${MODELNAME}.t${vhr}z.prslev.3km.f$(printf "%03d" $fhr).conus.grib2
+         export fcst_file=rrfs.${INITDATE}/${vhr}/${MODELNAME}.t${vhr}z.2dfld.3km.f$(printf "%03d" $fhr).conus.grib2
       else
-         export fcst_file=rrfsens.${INITDATE}/${vhr}/m00${MEMNUM}/rrfs.t${vhr}z.m00${MEMNUM}.prslev.3km.f$(printf "%03d" $fhr).conus.grib2
+         export fcst_file=rrfsens.${INITDATE}/${vhr}/m00${MEMNUM}/rrfs.t${vhr}z.m00${MEMNUM}.2dfld.3km.f$(printf "%03d" $fhr).conus.grib2
       fi
 
       if [ -s ${MODEL_INPUT_DIR}/$fcst_file ]; then


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR ...
- changes RRFS, RRFS member, and RRFS FireWx Nest forecasts to the new "2dfld" files for surface-based fields
- adds logic to handle verification for fields now located in the 2dfld files but still verified against RAOBs (along with upper-air verification)

These adjustments are needed to handle the RRFS changes described [here](https://github.com/NOAA-EMC/rrfs-workflow/pull/1421).

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, code freeze date for initial RRFS work is currently set for **June 17**.  The changes in this PR are also needed before we can start running an emc.vpppg parallel for the affected jobs
* Do you have any planned upcoming annual leave/PTO?

No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No

- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

#### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/cam/change_rrfs_filenames
```

#### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter):
```
jevs_prep_cam_rrfs_severe
jevs_prep_cam_rrfsmem_severe
```
```
jevs_stats_cam_rrfs_grid2obs
jevs_stats_cam_rrfsmem_grid2obs
jevs_stats_cam_rrfs_firewxnest_grid2obs
```
```
jevs_stats_cam_rrfs_precip
jevs_stats_cam_rrfsmem_precip
```
```
jevs_stats_cam_rrfs_snowfall
jevs_stats_cam_rrfsmem_snowfall
```
```
jevs_stats_cam_rrfs_radar
jevs_stats_cam_rrfsmem_radar
```
[Total: _2 prep jobs; 9 stats jobs_]

#### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMINrrfs** - add and set to `/lfs/h1/ops/para/com/rrfs/${rrfs_ver}`
**COMINobsproc** - (_grid2obs only_) add and set to `/lfs/h1/ops/para/com/obsproc/${obsproc_ver}`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


#### 4) Test jobs

- `cd` into your test directory (where you want the log files to go)
- Submit all **precip** drivers using `qsub -v vhr=19 ${driver}.sh`
- Submit all other drivers using `qsub -v vhr=12 ${driver}.sh` 
- _Note 1:_ **precip** and **grid2obs** jobs take the longest to run
- _Note 2:_  **rrfsmem** jobs will automatically use `mem=1`

We can discuss whether or not we want to test anything else.

#### 5) Check jobs
- I will check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

#### 6) During testing ...

- If I push changes or fixes during testing, you can usually update your branch like this:
```
git pull origin feature/cam/change_rrfs_filenames
```