### PR TITLE
Resolve Bugzilla 1686

### DIFF
--- a/sorc/evs_g2g_adjustCMC.fd/evs_g2g_adjustCMC.f
+++ b/sorc/evs_g2g_adjustCMC.fd/evs_g2g_adjustCMC.f
@@ -16,8 +16,8 @@ C            NAEFS member files
 C         3. The NAEFS verification will use GFS anaylysis as validation
 C            data
 C            
-C    Last update: 12/5/2023, Binbin Zhou  Lynker@?NCEP/EMC
-C                    Remove goto statements required by NCO
+C    Last update: 4/21/2026, Mallory Row
+C                    Fix errors occuring with debug flags
        
 CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
       use grib_mod
@@ -156,7 +156,7 @@ C  raw data
        kpd11_cmce(12)=0
        kpd10_gefs(12)=103
        kpd10_cmce(12)=103
-  
+
        read_gfs=1
        read_gefs=1
        read_cmc=1
@@ -177,11 +177,11 @@ C  raw data
 
        !write(*,*) 'jf=',jf
 
-       allocate(gfsa(10,jf)) 
-       allocate(cmca(10,jf))
-       allocate(gefs(10,jf))
-       allocate(cmce(10,jf)) 
-       allocate(cmce_adj(10,jf)) 
+       allocate(gfsa(12,jf))
+       allocate(cmca(12,jf))
+       allocate(gefs(12,jf))
+       allocate(cmce(12,jf))
+       allocate(cmce_adj(12,jf))
  
         !Open gefs and cmce member files to read
         open(1, file=gefs_file_list, status='old')
@@ -198,8 +198,8 @@ C  raw data
           jpd2=kpd2(i)
           
 
-          gfld_gfsanl%fld=0.0
-          gfld_cmcanl%fld=0.0
+          ! gfld_gfsanl%fld=0.0
+          ! gfld_cmcanl%fld=0.0
 
 
           jpd12=kpd12_gefs(i)
@@ -279,8 +279,8 @@ C  raw data
           jpd2=kpd2(i)
 
 
-          gfld_gefs%fld=0.0
-          gfld_cmce%fld=0.0
+          ! gfld_gefs%fld=0.0
+          ! gfld_cmce%fld=0.0
 
           jpd12=kpd12_gefs(i)
           jpd11=kpd11_gefs(i)


### PR DESCRIPTION
## Description of Changes

This resolves Bugzilla 1686: exec/evs_g2g_adjustCMC.x fails with debug options. Some information from NCO below:

> During IT testing, exec/evs_g2g_adjustCMC.x fails when compiled with debug options.
> forrtl: severe (408): fort: (7): Attempt to use pointer FLD when it is not associated with a target

These changes were suggested by Gemini and @BinbinZhou-NOAA confirmed the allocations was a bug. The change results in differences in the stat files due to a bug being fixed.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No
* Do you have any planned upcoming annual leave/PTO?
No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

1. `git clone https://github.com/malloryprow/EVS.git`
2. `cd EVS`, `git checkout bugzilla_1686`
3. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`
4. `cd sorc`
5. `export BUILD_DEBUG=YES; ./build.sh 2>&1 | tee build.debug.$(date +%Y%m%d_%H%M).log`
6. Run `dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh`
    - Set `HOMEevs` to the clone's location
    - Set `KEEPDATA` to `YES`
    - Set `COMIN` to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
    - Set `COMOUT` to some testing location
