### PR TITLE
Fix ops global_det failure (checks for missing NOHRSC in ush script)

### DIFF
--- a/ush/global_det/global_det_atmos_plots_nohrsc_spatial_map.py
+++ b/ush/global_det/global_det_atmos_plots_nohrsc_spatial_map.py
@@ -104,16 +104,20 @@ class NOHRSCSpatialMap:
             stderr=subprocess.DEVNULL
         )
         if check_wgrib2.returncode == 0:
-            self.logger.info(f"Converting {nohrsc_grib2_file} GRIB2 file to "
-                             +f"{nohrsc_netcdf_file} netCDF file")
-            run_convert = subprocess.run(
-                ['wgrib2', nohrsc_grib2_file, '-netcdf',
-                 nohrsc_netcdf_file]
-            )
-            if run_convert.returncode != 0:
-                self.logger.error("Could not convert {nohrsc_grib2_file} "
-                                  +'to netCDF using wgrib2')
-                sys.exit(1)
+            if os.path.exists(nohrsc_grib2_file):
+                self.logger.info(f"Converting {nohrsc_grib2_file} GRIB2 file to "
+                                 +f"{nohrsc_netcdf_file} netCDF file")
+                run_convert = subprocess.run(
+                    ['wgrib2', nohrsc_grib2_file, '-netcdf',
+                     nohrsc_netcdf_file]
+                )
+                if run_convert.returncode != 0:
+                    self.logger.error(f"Could not convert {nohrsc_grib2_file} "
+                                      +'to netCDF using wgrib2')
+                    sys.exit(0)
+            else:
+                self.logger.debug(f"{nohrsc_grib2_file} does not exist")
+                sys.exit(0)
         else:
             self.logger.error("wgrib2 executable not in PATH")
             sys.exit(1)


### PR DESCRIPTION
## Description of Changes

There was an ops failure in plots/global_det/jevs_plots_global_det_atmos_grid2grid_snow_last90days.sh on Saturday 5/2/26. Mallory, Marcel, and Alicia worked for 2 hours to test an ush/ script fix that was then delivered to NCO. This PR applies that ush/ script fix to the develop branch. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? ASAP
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? NO
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS
git checkout feature/nohrsc_fix
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix
cd sorc/
./build.sh
cd ../dev/drivers/scripts/plots/global_det/

vi jevs_plots_global_det_atmos_grid2grid_snow_last90days.sh
**Change the following**:
HOMEevs to the directory that you are currently in (e.g., add pr679test/ into path)
COMIN from $USER to emc.vpppg (tells job to use emc.vpppg parallel stats as input)
Change COMOUT if you need to.
KEEPDATA to YES 

qsub -v VDATE_END=20260501 jevs_plots_global_det_atmos_grid2grid_snow_last90days.sh

Check the resulting log file for FATAL errors and see if plots were created. Compare to emc.vpppg parallel, where we already ran the fix. 