### PR TITLE
Fix stats/global_det triggers on prep job

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -1689,45 +1689,45 @@ suite evs_nco
           endfamily
           family global_det
             task jevs_stats_global_det_ukmet_atmos_grid2obs
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_ukmet_atmos_grid2grid
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_metfra_atmos_grid2grid
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_jma_atmos_grid2obs
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_jma_atmos_grid2grid
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_gfs_atmos_grid2obs
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_gfs_atmos_grid2grid
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_aigfs_atmos_grid2obs
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_aigfs_atmos_grid2grid
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_gfs_atmos_wmo_daily
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_fnmoc_atmos_grid2obs
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_fnmoc_atmos_grid2grid
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_ecmwf_atmos_grid2obs
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_ecmwf_atmos_grid2grid
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_dwd_atmos_grid2grid
-              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1930 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_cmc_regional_atmos_grid2grid
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_cmc_atmos_grid2obs
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_cmc_atmos_grid2grid
-              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1915 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_cfs_atmos_grid2obs
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
             task jevs_stats_global_det_cfs_atmos_grid2grid
-              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_global_det_atmos_prep == complete
+              trigger (:TIME >= 1855 or :TIME < 0055) and ../../prep/global_det/jevs_prep_global_det_atmos == complete
           endfamily
           family cam
             task jevs_stats_cam_nam_firewxnest_grid2obs_vhr_18


### PR DESCRIPTION
## Description of Changes

This PR fixes triggers on `18/evs/v2.0/stats/global_det` tasks.

`../../prep/global_det/jevs_global_det_atmos_prep` --> `../../prep/global_det/jevs_prep_global_det_atmos`

Closes #965 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

This is in support of the code delivery provided to NCO for evs.v2.0.9/evs.v2.0.10.

* Do you have any planned upcoming annual leave/PTO?

Yes, but I do not anticipate those dates affecting this PR. I can provide the dates by email if needed.

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No.
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

```shell
$ module load intel/19.1.3.304
$ module load python/3.8.6
$ module load ecflow
$ python -c 'import ecflow; ecflow.Defs("ecf/defs/evs-nco.def")' 2>&1 | tee ecflow_defs.log
```

The above test produces broken triggers unrelated to this change, but the triggers for `18/evs/v2.0/stats/global_det` have been fixed.