### PR TITLE
Add copy of runhistory file for history/safekeeping

### DIFF
--- a/dev/runhistory/parm/models/evs
+++ b/dev/runhistory/parm/models/evs
@@ -1,0 +1,13 @@
+whichpdys       PDYm8
+runjobs         jrunhistory_daily
+storetypes      perm
+dir             $(compath.py evs/evs_ver)
+files           ./stats/{aigefs,analyses,aqm,cam,global_chem,global_det,global_ens,mesoscale,rtofs,subseasonal,wafs}/*.%thepdy%/evs.stats.*.v%thepdy%.stat
+tarmod          .stats
+dotransfer
+#
+whichpdys       PDYm5
+storetypes      5yr
+files           ./plots/{aqm,cam,global_chem,global_det,mesoscale,rtofs}/headline.%thepdy%/evs.plots.*headline.v%thepdy%.tar
+tarmod          .plots
+dotransfer


### PR DESCRIPTION
## Description of Changes

This adds a copy of the EVS runhistory file (needed by NCO) to the repo so we can have a history of the file and a copy on GitHub for safekeeping. It is currently set up to match the develop branch and not ops (includes aigefs and remove nfcens); edited from /lfs/h1/ops/prod/packages/runhistory.v2.5.42/parm/models/evs.


I'm open to putting the file in a different spot or giving it a different name.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
      No

* Do you have any planned upcoming annual leave/PTO?
    Yes, Thursday 5/28 and Friday 5/29
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    N/A
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> No testing needed.
