### PR TITLE
Remove j prefix from PBS job name

### DIFF
--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2grid
+#PBS -N evs_stats_aigefs_aigefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2obs
+#PBS -N evs_stats_aigefs_aigefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_aigefs_atmos_precip
+#PBS -N evs_stats_aigefs_aigefs_atmos_precip
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_gefs_atmos_grid2grid
+#PBS -N evs_stats_aigefs_gefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_gefs_atmos_grid2obs
+#PBS -N evs_stats_aigefs_gefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_gefs_atmos_precip
+#PBS -N evs_stats_aigefs_gefs_atmos_precip
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2grid
+#PBS -N evs_stats_aigefs_hgefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2obs
+#PBS -N evs_stats_aigefs_hgefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q dev

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_hgefs_atmos_precip
+#PBS -N evs_stats_aigefs_hgefs_atmos_precip
 #PBS -j oe 
 #PBS -S /bin/bash
 #PBS -q dev

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2grid
+#PBS -N evs_stats_aigefs_aigefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_aigefs_atmos_grid2obs
+#PBS -N evs_stats_aigefs_aigefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_aigefs_atmos_precip
+#PBS -N evs_stats_aigefs_aigefs_atmos_precip
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_gefs_atmos_grid2grid
+#PBS -N evs_stats_aigefs_gefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_gefs_atmos_grid2obs
+#PBS -N evs_stats_aigefs_gefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_gefs_atmos_precip
+#PBS -N evs_stats_aigefs_gefs_atmos_precip
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2grid
+#PBS -N evs_stats_aigefs_hgefs_atmos_grid2grid
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_hgefs_atmos_grid2obs
+#PBS -N evs_stats_aigefs_hgefs_atmos_grid2obs
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%

--- a/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.ecf
+++ b/ecf/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.ecf
@@ -1,4 +1,4 @@
-#PBS -N jevs_stats_aigefs_hgefs_atmos_precip
+#PBS -N evs_stats_aigefs_hgefs_atmos_precip
 #PBS -j oe
 #PBS -S /bin/bash
 #PBS -q %QUEUE%


### PR DESCRIPTION
## Description of Changes

This PR removes the `j` prefix from PBS job names in `ecf/scripts/stats/aigefs/evs_stats_aigefs_*` and `dev/drivers` equivalents.

Closes #971.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, this is in support of a production upgrade to EVS v2.0.10.
 
* Do you have any planned upcoming annual leave/PTO?

Yes. I have shared my PTO dates by email.
 
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No. 
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Run `ecf/scripts/stats/aigefs/evs_stats_aigefs_*` and check that their output file names begin with `evs_` instead of `jevs_`.
