### PR TITLE
Increase requested walltime to 50 mins

### DIFF
--- a/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days.sh
+++ b/dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:40:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=325GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days.ecf
+++ b/ecf/scripts/plots/global_det/jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:40:00
+#PBS -l walltime=00:50:00
 #PBS -l place=vscatter:exclhost,select=5:ncpus=128:ompthreads=1:mem=325GB
 #PBS -l debug=true
 


### PR DESCRIPTION
## Description of Changes

This PR increases the requested walltime for `jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days` from 40 to 50 mins.

Closes #974.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, this is in support of a production upgrade to evs.v2.0.10.

* Do you have any planned upcoming annual leave/PTO?

Yes, see previous email threads please.

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

No.
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Run `dev/drivers/scripts/plots/global_det/jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days.sh` and confirm that the job completes within the walltime. Observed run times in para have ranged 37-38.5 minutes.