### PR TITLE
EVS-RTOFS headline score plots date

### DIFF
--- a/ush/rtofs/settings.py
+++ b/ush/rtofs/settings.py
@@ -99,9 +99,9 @@ class Presets():
         self.date_presets = {
             'last90days': {
                 'valid_beg': (datetime.now()-td(days=90)).strftime('%Y%m%d'),
-                'valid_end': (datetime.now()-td(days=1)).strftime('%Y%m%d'),
+                'valid_end': (datetime.now()-td(days=3)).strftime('%Y%m%d'),
                 'init_beg': (datetime.now()-td(days=90)).strftime('%Y%m%d'),
-                'init_end': (datetime.now()-td(days=1)).strftime('%Y%m%d')
+                'init_end': (datetime.now()-td(days=3)).strftime('%Y%m%d')
             },
             'last60days': {
                 'valid_beg': (datetime.now()-td(days=60)).strftime('%Y%m%d'),


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR resolves an issue with the date displayed on EVS-RTOFS headline score plots. The underlying scripts have been updated to ensure that both the date at the top of the headline score plots and the final date shown in the plots correctly reflect the last date for which data is available.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Environment Setup
Clone the fork and check out the relevant feature branch:
`git clone https://github.com/SamiraArdani-NOAA/EVS.git`
cd EVS
git checkout `feature/EVS-RTOFS_headline_date`

Configure your test environment:
Set $HOMEevs to your local test directory.
Link the necessary fix files:
`mkdir -p $HOMEevs/fix`
`ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/`

Test implementation:
Run only **headline plots** driver script:
In `$COMIN`, replace the `${USER}` with `emc.vpppg`.
`Set export KEEPDATA=YES`
`Set export SENDMAIL=NO`
Submit the job using `qsub` command:  
`qsub $HOMEevs/dev/drivers/scripts/plots/rtofs/jevs_plots_rtofs_headline_grid2grid_last90days.sh` 
