### PR TITLE
Update terminal logging to DEBUG

### DIFF
--- a/parm/metplus_config/machine.conf
+++ b/parm/metplus_config/machine.conf
@@ -14,6 +14,7 @@ LOG_TIMESTAMP_TEMPLATE = %Y%m%d%H%M%S
 LOG_TIMESTAMP_USE_DATATIME = no
 LOG_MET_OUTPUT_TO_METPLUS = yes
 LOG_LEVEL = DEBUG
+LOG_LEVEL_TERMINAL = DEBUG
 LOG_MET_VERBOSITY = 2
 LOG_LINE_FORMAT = %(asctime)s.%(msecs)03d %(name)s (%(filename)s:%(lineno)d) %(levelname)s: %(message)s
 LOG_ERR_LINE_FORMAT = {LOG_LINE_FORMAT}


### PR DESCRIPTION
## Description of Changes

In trying to provide information on verification to a team at EPIC, I noticed that we don't have `LOG_LEVEL_TERMINAL`. Its default in METplus is `INFO` but we should be logging with `DEBUG` like we were before when using log files. I think this is an NCO requirement, or they have asked us to log with DEBUG before.

This sets it in machine.conf so it gets set EVS wide to all components.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    No
* Do you have any planned upcoming annual leave/PTO?
    No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    No
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

1. `git clone https://github.com/malloryprow/EVS.git`
2. `cd EVS`, `git checkout feature/terminal_log
3. `ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/`
4. `cd dev/drivers/scripts/stats/global_det`
5. In `jevs_stats_global_det_gfs_atmos_grid2obs.sh`, change..
   - `HOMEevs` to your clone
   - `COMOUT` to your desired testing location output
   - `COMIN` to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
6. `qsub -v VDATE=20260530 jevs_stats_global_det_gfs_atmos_grid2obs.sh` 
