### PR TITLE
Modify aigfs plot job triggers to flatten HWM

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2043,13 +2043,13 @@ suite evs_nco
             task jevs_plots_global_det_atmos_grid2grid_precip_last90days
               trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_ai_grid2obs_sfc_last90days
-              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2130 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_ai_grid2grid_pres_levs_last90days
-              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2045 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
             task jevs_plots_global_det_atmos_ai_grid2obs_pres_levs_last90days
-              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
+              trigger (:TIME >= 2100 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs == complete
             task jevs_plots_global_det_atmos_ai_grid2grid_precip_last90days
-              trigger (:TIME >= 2015 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
+              trigger (:TIME >= 2030 or :TIME < 0215) and ../../stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid == complete and ../../stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid == complete
           endfamily
           family cam
             task jevs_plots_cam_precip_last90days


### PR DESCRIPTION
## Description of Changes

This PR modifies time triggers for AIGFS plot jobs to evenly distribute node use.

Closes #975 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?

Yes, this is in support of a production upgrade to EVS v2.0.10.

* Do you have any planned upcoming annual leave/PTO?

No.

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?

Yes. Please see #975 for the time triggers that were changed.
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Testing is not required.
