### PR TITLE
skip metplus for missing files (refs prep severe)

### DIFF
--- a/scripts/prep/cam/exevs_prep_refs_severe.sh
+++ b/scripts/prep/cam/exevs_prep_refs_severe.sh
@@ -163,7 +163,6 @@ fi
 # Check for forecast files to process
 ###################################################################
 k=0
-min_file_req=6
 
 while [ $k -lt $nloop ]; do
 
@@ -269,25 +268,29 @@ i=1
    ###################################################################
    # Run METplus if all forecast files exist or exit gracefully
    ###################################################################
-
+    
+   if [ "$fhr_end" -gt 54 ]; then
+      export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6"
+      export nmem="6"
+      export min_file_req=6
+      export ens_thresh="1.0"
+   elif [ "$fhr_end" -gt 48 ]; then
+      export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13"
+      export nmem="12"
+      export min_file_req=12
+      export ens_thresh="1.0"
+   elif [ "$fhr_end" -gt 42 ]; then
+      export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem7, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13"
+      export nmem="13"
+      export min_file_req=12
+      export ens_thresh="0.92"
+   else
+      export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem7, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13, $mem14"
+      export nmem="14"
+      export min_file_req=12
+      export ens_thresh="0.85"
+   fi
    if [ $nfiles -ge $min_file_req ]; then
-      if [ "$nfiles" -eq "6" ]; then
-         export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6"
-         export nmem="6"
-         export ens_thresh="1.0"
-      elif [ "$nfiles" -eq "12" ]; then
-         export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13"
-         export nmem="12"
-         export ens_thresh="1.0"
-      elif [ "$nfiles" -eq "13" ]; then
-         export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem7, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13"
-         export nmem="13"
-         export ens_thresh="0.92"
-      else
-         export mems="$mem1, $mem2, $mem3, $mem4, $mem5, $mem6, $mem7, $mem8, $mem9, $mem10, $mem11, $mem12, $mem13, $mem14"
-         export nmem="14"
-         export ens_thresh="0.85"
-      fi
       echo "Found $nfiles forecast files. Generating ${MODELNAME} SSPF for ${vhr}Z ${INITDATE} cycle at F${fhr_end}"
       ${METPLUS_PATH}/ush/run_metplus.py -c $PARMevs/metplus_config/machine.conf $PARMevs/metplus_config/${STEP}/${COMPONENT}/${VERIF_CASE}/GenEnsProd_fcstREFS_MXUPHL_SurrogateSevere.conf
       export err=$?; err_chk


### PR DESCRIPTION
## Description of Changes

This PR fixes logic to skip METplus when needed forecasts are unavailable.  It supports #986 and responds to a failed test there.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, 6/22
* Do you have any planned upcoming annual leave/PTO?
    * Yes, 6/18 and 6/19 is a federal holiday
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/refs/skip_metplus_severe
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_prep_cam_refs_severe    vhr=00,06,12,18 # submit after hrrr,, rrfsmem, and rrfs severe are finished
```

[Total: _1 prep job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/mallory.row/verification/EVS_PRs/pr986/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

### 4) Test jobs
`cd` into your test directory (where you want the log files to go)

- Submit using `qsub -v vhr=00 ${driver}.sh` 

We can discuss whether or not we want to test anything else.

### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- _NOTE:_ There should be one warning about too few files at F036 and that METplus will not run (since we lack the time-lagged files we need).  We should see a file for F060 in COMOUT, but no other files due to the warning.

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin bugfix/refs/skip_metplus_severe
```