### PR TITLE
Feature/EVS-Analyses_additions1

### DIFF
--- a/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
@@ -55,7 +55,7 @@ echo $vhr
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_PLOTS_ANALYSES

--- a/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
@@ -46,15 +46,14 @@ export mod_ver=${rtma_ver}
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_last31days}
-export jobid=$job.${PBS_JOBID:-$$}
-
-
-export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
+export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}
 
-export vhr=00
+export vhr=${vhr:-00}
 echo $vhr
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_last31days}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
+++ b/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
@@ -17,8 +17,6 @@ export SENDCOM=YES
 export KEEPDATA=NO
 export SENDDBN=NO
 export SENDDBN_NTC=
-export job=${PBS_JOBNAME:-jevs_prep_analyses_precip}
-export jobid=$job.${PBS_JOBID:-$$}
 export SITE=$(cat /etc/cluster_name)
 export USE_CFP=YES
 export nproc=1
@@ -47,7 +45,10 @@ evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
-export vhr=${vhr:-${vhr}}
+export vhr=${vhr:-00}
+
+export job=${PBS_JOBNAME:-jevs_prep_analyses_precip}
+export jobid=$job.${PBS_JOBID:-$$}
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_ANALYSES

--- a/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
+++ b/dev/drivers/scripts/prep/analyses/jevs_prep_analyses_precip.sh
@@ -31,7 +31,6 @@ export MODELNAME="analyses"
 
 # EVS Settings
 export HOMEevs="/lfs/h2/emc/vpppg/noscrub/$USER/EVS"
-export HOMEevs=${HOMEevs:-${PACKAGEROOT}/evs.${evs_ver}}
 export config=$HOMEevs/parm/evs_config/analyses/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}
 
 # Load Modules

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=ccpa
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
@@ -43,18 +43,18 @@ export VERIF_CASE=precip
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
-export jobid=$job.${PBS_JOBID:-$$}
-
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
-export vhr
+export vhr=${vhr:-00}
 echo $vhr
 
 export mod_ver=${ccpa_ver}
 export modsys=ccpa
 export MODELNAME=ccpa
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
@@ -56,7 +56,7 @@ export MODELNAME=rtma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
@@ -43,18 +43,18 @@ export VERIF_CASE=grid2obs
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
-export jobid=$job.${PBS_JOBID:-$$}
-
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
-export vhr
+export vhr=${vhr:-00}
 echo $vhr
 
 export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=rtma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
@@ -43,18 +43,18 @@ export VERIF_CASE=precip
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
-export jobid=$job.${PBS_JOBID:-$$}
-
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
-export vhr
+export vhr=${vhr:-00}
 echo $vhr
 
 export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
@@ -54,7 +54,7 @@ export MODELNAME=rtma_ru
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
@@ -40,19 +40,19 @@ export VERIF_CASE=grid2obs
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
-export jobid=$job.${PBS_JOBID:-$$}
-
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 
-export vhr
+export vhr=${vhr:-00}
 echo $vhr
 
 export mod_ver=${rtma_ver}
 export modsys=rtma
 export MODELNAME=rtma_ru
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
@@ -40,19 +40,19 @@ export SENDMAIL=YES
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
-export jobid=$job.${PBS_JOBID:-$$}
-
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
-export vhr
+export vhr=${vhr:-00}
 echo $vhr
 export envir=prod
 
 export MODELNAME=urma
 export modsys=urma
 export mod_ver=${urma_ver}
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
@@ -54,7 +54,7 @@ export mod_ver=${urma_ver}
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
@@ -43,18 +43,18 @@ export VERIF_CASE=precip
 
 source $HOMEevs/dev/modulefiles/$COMPONENT/${COMPONENT}_${STEP}.sh
 
-export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
-export jobid=$job.${PBS_JOBID:-$$}
-
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
-export vhr
+export vhr=${vhr:-00}
 echo $vhr
 
 export mod_ver=${urma_ver}
 export modsys=urma
 export MODELNAME=urma
+
+export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
+export jobid=$job.${PBS_JOBID:-$$}
 
 export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
 

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=urma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO="alicia.bentley@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/ush/analyses/settings.py
+++ b/ush/analyses/settings.py
@@ -211,74 +211,6 @@ class ModelSpecs():
         be defined here as aliases of the same model settings, if desired.
         '''
         self.model_alias = {
-            'ARW': {
-                'settings_key':'HRW_ARW', 
-                'plot_name':'HiResW ARW'
-            },
-            'ARW2': {
-                'settings_key':'HRW_ARW2', 
-                'plot_name':'HiResW ARW2'
-            },
-            'FV3': {
-                'settings_key':'HRW_FV3', 
-                'plot_name':'HiResW FV3'
-            },
-            'NMMB': {
-                'settings_key':'HRW_NMMB', 
-                'plot_name':'HiResW NMMB'
-            },
-            'AKARW': {
-                'settings_key':'HRW_ARW', 
-                'plot_name':'HiResW ARW'
-            },
-            'AKARW2': {
-                'settings_key':'HRW_ARW2', 
-                'plot_name':'HiResW ARW2'
-            },
-            'AKFV3': {
-                'settings_key':'HRW_FV3', 
-                'plot_name':'HiResW FV3'
-            },
-            'AKNEST': {
-                'settings_key':'NAM_NEST', 
-                'plot_name':'NAM Nest'
-            },
-            'AKNMMB': {
-                'settings_key':'HRW_NMMB', 
-                'plot_name':'HiResW NMMB'
-            },
-            'CONUSARW': {
-                'settings_key':'HRW_ARW', 
-                'plot_name':'HiResW ARW'
-            },
-            'CONUSARW2': {
-                'settings_key':'HRW_ARW2', 
-                'plot_name':'HiResW ARW2'
-            },
-            'CONUSFV3': {
-                'settings_key':'HRW_FV3', 
-                'plot_name':'HiResW FV3'
-            },
-            'CONUSNEST': {
-                'settings_key':'NAM_NEST', 
-                'plot_name':'NAM Nest'
-            },
-            'CONUSNMMB': {
-                'settings_key':'HRW_NMMB', 
-                'plot_name':'HiResW NMMB'
-            },
-            'hireswarw': {
-                'settings_key':'HRW_ARW', 
-                'plot_name':'HiResW ARW'
-            },
-            'hireswarwmem2': {
-                'settings_key':'HRW_ARW2', 
-                'plot_name':'HiResW ARW2'
-            },
-            'hireswfv3': {
-                'settings_key':'HRW_FV3', 
-                'plot_name':'HiResW FV3'
-            },
             'HREF_MEAN':{
                 'settings_key':'HREF_MEAN', 
                 'plot_name':'HREF Mean'
@@ -399,50 +331,6 @@ class ModelSpecs():
                 'settings_key':'HREFX_MEAN', 
                 'plot_name':'HREF-X Mean'
             },
-            'NARRE_MEAN':{
-                'settings_key':'NARRE_MEAN', 
-                'plot_name':'NARRE Mean'
-            },
-            'HIARW': {
-                'settings_key':'HRW_ARW', 
-                'plot_name':'HiResW ARW'
-            },
-            'HIARW2': {
-                'settings_key':'HRW_ARW2', 
-                'plot_name':'HiResW ARW2'
-            },
-            'HIFV3': {
-                'settings_key':'HRW_FV3', 
-                'plot_name':'HiResW FV3'
-            },
-            'HINMMB': {
-                'settings_key':'HRW_NMMB', 
-                'plot_name':'HiResW NMMB'
-            },
-            'HAWAIINEST': {
-                'settings_key':'NAM_NEST', 
-                'plot_name':'NAM Nest'
-            },
-            'PRARW': {
-                'settings_key':'HRW_ARW', 
-                'plot_name':'HiResW ARW'
-            },
-            'PRARW2': {
-                'settings_key':'HRW_ARW2', 
-                'plot_name':'HiResW ARW2'
-            },
-            'PRFV3': {
-                'settings_key':'HRW_FV3', 
-                'plot_name':'HiResW FV3'
-            },
-            'PRNMMB': {
-                'settings_key':'HRW_NMMB', 
-                'plot_name':'HiResW NMMB'
-            },
-            'PRICONEST': {
-                'settings_key':'NAM_NEST', 
-                'plot_name':'NAM Nest'
-            },
             'FV3LAMDA': {
                 'settings_key':'LAMDA', 
                 'plot_name':'FV3LAM-DA'
@@ -507,17 +395,9 @@ class ModelSpecs():
                 'settings_key':'LAMX', 
                 'plot_name':'FV3LAM-X'
             },
-            'NAM_NEST': {
-                'settings_key':'NAM_NEST', 
-                'plot_name':'NAM Nest'
-            },
             'NAM_FIREWXNEST': {
                 'settings_key':'NAM_NEST', 
                 'plot_name':'NAM Fire Wx Nest'
-            },
-            'namnest': {
-                'settings_key':'NAM_NEST', 
-                'plot_name':'NAM Nest'
             },
             'HRRRAK': {
                 'settings_key':'HRRR', 
@@ -526,10 +406,6 @@ class ModelSpecs():
             'hrrr': {
                 'settings_key':'HRRR', 
                 'plot_name':'HRRR'
-            },
-            'NAMNA': {
-                'settings_key':'NAM', 
-                'plot_name':'NAM'
             },
             'RAPAK': {
                 'settings_key':'RAP', 
@@ -682,15 +558,6 @@ class ModelSpecs():
             'HMON': {'color': '#8400c8',
                      'marker': 'o', 'markersize': 12,
                      'linestyle': 'solid', 'linewidth': 3.},
-            'HRW_ARW': {'color': '#00dc00',
-                     'marker': 'o', 'markersize': 12,
-                     'linestyle': 'solid', 'linewidth': 3.},
-            'HRW_ARW2': {'color': '#e69f00',
-                     'marker': 'o', 'markersize': 12,
-                     'linestyle': 'solid', 'linewidth': 3.},
-            'HRW_FV3': {'color': '#56b4e9',
-                     'marker': 'o', 'markersize': 12,
-                     'linestyle': 'solid', 'linewidth': 3.},
             'HREF_MEAN': {'color': '#000000',
                      'marker': 'o', 'markersize': 12,
                      'linestyle': 'solid', 'linewidth': 3.},
@@ -709,12 +576,6 @@ class ModelSpecs():
             'HRRR': {'color': '#fb2020',
                      'marker': 'o', 'markersize': 12,
                      'linestyle': 'solid', 'linewidth': 3.},
-            'NAM': {'color': '#1e3cff',
-                     'marker': 'o', 'markersize': 12,
-                     'linestyle': 'solid', 'linewidth': 3.},
-            'NAM_NEST': {'color': '#1e3cff',
-                     'marker': 'o', 'markersize': 12,
-                     'linestyle': 'solid', 'linewidth': 3.},
             'RRFS_A': {'color': '#00dc00',
                       'marker': 'o', 'markersize': 12,
                       'linestyle': 'solid', 'linewidth': 3.},
@@ -728,9 +589,6 @@ class ModelSpecs():
                            'marker': 'o', 'markersize': 12,
                            'linestyle': 'dashed', 'linewidth': 5.},
             'GEFS': {'color': '#000000',
-                     'marker': 'o', 'markersize': 12,
-                     'linestyle': 'solid', 'linewidth': 5.},
-            'NARRE_MEAN': {'color': '#000000',
                      'marker': 'o', 'markersize': 12,
                      'linestyle': 'solid', 'linewidth': 5.},
             'EC': {'color': '#fb2020',


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

This PR refactors analyses job driver scripts and the settings configuration to improve consistency, maintainability, and code organization. The changes focus on standardizing variable initialization patterns and removing deprecated or unused model aliases and plotting configurations.

**Key improvements:**
- Moved job and jobid variable declarations to appear after model-specific configurations for better logical flow
- Changed `export vhr` initialization from bare variable to `export vhr=${vhr:-00}` to ensure a default value of "00" hours
- Removed unnecessary blank lines to improve code formatting

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No. 
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.


### 1. Environment Preparation
- Clone the feature branch: `feature/EVS-Analyses_additions1`
- Set `$HOMEevs` to your local test directory:
`HOMEevs=/path/to/your/local/test/directory`
- Link the necessary fix files:
`mkdir -p $HOMEevs/fix`
`ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* $HOMEevs/fix/`

### 2. Test Implementation
 Run **all** prep, stats and plots driver scripts and in each driver script apply these changes:
- In $COMIN, replace `${USER}` with emc.vpppg:
`export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/${evs_ver_2d}`
- Set test-specific flags:
`export KEEPDATA=YES`        
`export SENDMAIL=NO`  
### 3. Job Submission
**prep**
`qsub -v vhr=08 $HOMEevs/dev/drivers/scripts/prep/analyses/*`     
**stats**
To test individual stats, only test for one sample `vhr` (e.g. `vhr=08`): 
`qsub -v vhr=08 $HOMEevs/dev/drivers/scripts/stats/analyses/* `
To test final stats, test for `vhr=23`:
`qsub -v vhr=23 $HOMEevs/dev/drivers/scripts/stats/analyses/* `
**plots**
`qsub -v vhr=08 $HOMEevs/dev/drivers/scripts/plots/analyses/* `


