### PR TITLE
Bugfix/cam/fix vhr filtering

### DIFF
--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs.sh
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=08:20:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=310GB
+#PBS -l walltime=03:05:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=190GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs_vhr_master.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=08:20:00
-#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=310GB
+#PBS -l walltime=03:05:00
+#PBS -l place=vscatter:exclhost,select=1:ncpus=128:ompthreads=1:mem=190GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ush/cam/cam_stats_grid2obs_filter_valid_hours_list.sh
+++ b/ush/cam/cam_stats_grid2obs_filter_valid_hours_list.sh
@@ -21,9 +21,27 @@ fi
 
 echo "REQUESTED LIST OF VALID HOURS: $VHOUR_LIST"
 NEW_VHOUR_LIST=""
-if [ $vhr -ge 0 ] && [ $vhr -le 11 ]; then
+if [ $vhr -ge 0 ] && [ $vhr -le 2 ]; then
     for VHOUR in $VHOUR_LIST; do
-        if [ $VHOUR -ge 0 ] && [ $VHOUR -le 11 ]; then
+        if [ $VHOUR -ge 0 ] && [ $VHOUR -le 2 ]; then
+            NEW_VHOUR_LIST+="$VHOUR "
+        fi
+    done
+elif [ $vhr -ge 3 ] && [ $vhr -le 5 ]; then
+    for VHOUR in $VHOUR_LIST; do
+        if [ $VHOUR -ge 3 ] && [ $VHOUR -le 5 ]; then
+            NEW_VHOUR_LIST+="$VHOUR "
+        fi
+    done
+elif [ $vhr -ge 6 ] && [ $vhr -le 8 ]; then
+    for VHOUR in $VHOUR_LIST; do
+        if [ $VHOUR -ge 6 ] && [ $VHOUR -le 8 ]; then
+            NEW_VHOUR_LIST+="$VHOUR "
+        fi
+    done
+elif [ $vhr -ge 9 ] && [ $vhr -le 11 ]; then
+    for VHOUR in $VHOUR_LIST; do
+        if [ $VHOUR -ge 9 ] && [ $VHOUR -le 11 ]; then
             NEW_VHOUR_LIST+="$VHOUR "
         fi
     done


### PR DESCRIPTION
## Description of Changes

This PR fixes filtering for valid hours used for verification when a "vhr" is fed into the grid2obs stats jobs.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, as soon as possible (early July release)
* Do you have any planned upcoming annual leave/PTO?
    * Yes, 7/4 is a federal holiday
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/cam/fix_vhr_filtering
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:

```
jevs_stats_cam_rrfs_grid2obs    vhr=02,03,06,09,12,15,18,21
```
[Total: _1 stats job1_]


### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMINrrfs** - set to `/lfs/h1/ops/para/com/rrfs/${rrfs_ver}`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
`cd` into your test directory (where you want the log files to go)

**stats**
- Submit all but the final vhr using `qsub -v vhr=${vhr} ${driver}.sh`.  When all jobs complete cleanly, then run the final vhr

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin bugfix/cam/fix_vhr_filtering
```