### PR TITLE
Bugfix/cam/firewx plots

### DIFF
--- a/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config
+++ b/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config
@@ -74,7 +74,7 @@ set -x
 
 # Case type settings are used to check if settings are allowed. **
 export VERIF_CASE="grid2obs"
-export VERIF_TYPE="conus_sfc"
+export VERIF_TYPE="firewx"
 export MODELS="rrfs_firewxnest, hrrr, rrfs"
 
 # Used to name the graphics ouput files. File names will start with the URL_HEADER, followed by plot 

--- a/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_ctc_pbl
+++ b/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_ctc_pbl
@@ -74,7 +74,7 @@ set -x
 
 # Case type settings are used to check if settings are allowed. **
 export VERIF_CASE="grid2obs"
-export VERIF_TYPE="conus_sfc"
+export VERIF_TYPE="firewx"
 export MODELS="rrfs_firewxnest"
 
 # Used to name the graphics ouput files. File names will start with the URL_HEADER, followed by plot 

--- a/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_pbl
+++ b/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_pbl
@@ -74,7 +74,7 @@ set -x
 
 # Case type settings are used to check if settings are allowed. **
 export VERIF_CASE="grid2obs"
-export VERIF_TYPE="conus_sfc"
+export VERIF_TYPE="firewx"
 export MODELS="rrfs_firewxnest"
 
 # Used to name the graphics ouput files. File names will start with the URL_HEADER, followed by plot 

--- a/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_thresh
+++ b/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_thresh
@@ -74,7 +74,7 @@ set -x
 
 # Case type settings are used to check if settings are allowed. **
 export VERIF_CASE="grid2obs"
-export VERIF_TYPE="conus_sfc"
+export VERIF_TYPE="firewx"
 
 # Used to name the graphics ouput files. File names will start with the URL_HEADER, followed by plot 
 # details.  Leave blank ("") to include only plot details in the file names.

--- a/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_thresh_pbl
+++ b/parm/metplus_config/plots/cam/grid2obs/cam_firewxnest_plots_py_plotting.config_thresh_pbl
@@ -74,7 +74,7 @@ set -x
 
 # Case type settings are used to check if settings are allowed. **
 export VERIF_CASE="grid2obs"
-export VERIF_TYPE="conus_sfc"
+export VERIF_TYPE="firewx"
 
 # Used to name the graphics ouput files. File names will start with the URL_HEADER, followed by plot 
 # details.  Leave blank ("") to include only plot details in the file names.

--- a/scripts/plots/cam/exevs_plots_cam_firewxnest_grid2obs.sh
+++ b/scripts/plots/cam/exevs_plots_cam_firewxnest_grid2obs.sh
@@ -264,7 +264,7 @@ do
         fi
 done
 
-for varb in PBL
+for varb in HPBL
 do
 	mkdir -p $COMOUTplots/$varb
 	export var=${varb}

--- a/ush/cam/settings.py
+++ b/ush/cam/settings.py
@@ -420,7 +420,6 @@ class Reference():
                                     'TOZNE': 'Total Ozone',
                                     'OZCON1': 'OZCON1',
                                     'HPBL': 'Planetary Boundary Layer Height',
-                                    'PBL': 'Planetary Boundary Layer Height',
                                     'TSOIL': 'Soil Temperature',
                                     'SOILW': ('Volumetric Soil Moisture'
                                               + ' Content'),
@@ -1789,6 +1788,239 @@ class Reference():
                                  'plot_group':'sfc_upper'},
                     }
                 },
+            },
+            'grid2obs_firewx': {
+                'SL1L2': {
+                    'plot_stats_list': ('me, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GAC', 'APL', 'NAK', 'SAK', 'FireWx'
+                    ],
+                    'var_dict': {
+                        'TMP2m': {'fcst_var_names': ['TMP'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['TMP'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'RH2m': {'fcst_var_names': ['RH'],
+                                 'fcst_var_levels': ['Z2'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['RH'],
+                                 'obs_var_levels': ['Z2'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'TCDC': {'fcst_var_names': ['TCDC'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': 'GRIB_lvl_typ = 200;',
+                                 'obs_var_names': ['TCDC'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'PRMSL': {'fcst_var_names': ['PRMSL'],
+                                  'fcst_var_levels': ['Z0'],
+                                  'fcst_var_thresholds': '',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['PRMSL'],
+                                  'obs_var_levels': ['Z0'],
+                                  'obs_var_thresholds': '',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'VISsfc': {'fcst_var_names': ['VIS'],
+                                   'fcst_var_levels': ['L0'],
+                                   'fcst_var_thresholds': '',
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['VIS'],
+                                   'obs_var_levels': ['L0'],
+                                   'obs_var_thresholds': '',
+                                   'obs_var_options': '',
+                                   'plot_group':'ceil_vis'},
+                        'HGTcldceil': {'fcst_var_names': ['HGT'],
+                                       'fcst_var_levels': ['L0'],
+                                       'fcst_var_thresholds': '',
+                                       'fcst_var_options': ('GRIB_lvl_typ ='
+                                                            + ' 215;'),
+                                       'obs_var_names': ['CEILING','HGT'],
+                                       'obs_var_levels': ['L0'],
+                                       'obs_var_thresholds': '',
+                                       'obs_var_options': '',
+                                       'plot_group':'ceil_vis'},
+                        'CAPEsfc': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['CAPE'],
+                                    'obs_var_levels': ['L100000-0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                        'GUSTsfc': {'fcst_var_names': ['GUST'],
+                                    'fcst_var_levels': ['Z0'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['GUST'],
+                                    'obs_var_levels': ['Z0'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'HPBL': {'fcst_var_names': ['HPBL'],
+                                 'fcst_var_levels': ['L0'],
+                                 'fcst_var_thresholds': '',
+                                 'fcst_var_options': '',
+                                 'obs_var_names': ['PBL'],
+                                 'obs_var_levels': ['L0'],
+                                 'obs_var_thresholds': '',
+                                 'obs_var_options': '',
+                                 'plot_group':'sfc_upper'},
+                        'UGRD10m': {'fcst_var_names': ['UGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['UGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'VGRD10m': {'fcst_var_names': ['VGRD'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['VGRD'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                        'WIND10m': {'fcst_var_names': ['WIND'],
+                                    'fcst_var_levels': ['Z10'],
+                                    'fcst_var_thresholds': '',
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['WIND'],
+                                    'obs_var_levels': ['Z10'],
+                                    'obs_var_thresholds': '',
+                                    'obs_var_options': '',
+                                    'plot_group':'sfc_upper'},
+                    }
+                },
+                'VL1L2': {
+                    'plot_stats_list': ('me, rmse, bcrmse, fbar_obar, fbar,'
+                                        + ' obar'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GAC', 'APL', 'NAK', 'SAK', 'FireWx'
+                    ],
+                    'var_dict': {
+                        'UGRD_VGRD10m': {'fcst_var_names': ['UGRD_VGRD'],
+                                         'fcst_var_levels': ['Z10'],
+                                         'fcst_var_thresholds': '',
+                                         'fcst_var_options': '',
+                                         'obs_var_names': ['UGRD_VGRD'],
+                                         'obs_var_levels': ['Z10'],
+                                         'obs_var_thresholds': '',
+                                         'obs_var_options': '',
+                                         'plot_group':'sfc_upper'},
+                    }
+                },
+                'CTC': {
+                    'plot_stats_list': ('csi, fbias, fss, pod,'
+                                        + ' faratio, sratio'),
+                    'interp': 'NEAREST, BILIN',
+                    'vx_mask_list' : [
+                        'CONUS', 'G130', 'G214', 'G221', 'WEST', 'EAST', 'MDW', 'NPL', 'SPL', 'NEC', 
+                        'SEC', 'NWC', 'SWC', 'NMT', 'SMT', 'SWD', 'GRB', 
+                        'LMV', 'GAC', 'APL', 'NAK', 'SAK', 'FireWx'
+                    ],
+                    'var_dict': {
+                         'RH2m': {'fcst_var_names': ['RH'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': (' <=15, <=20,'
+                                                          + ' <=25, <=30'),
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['RH'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': (' <=15, <=20,'
+                                                         + ' <=25, <=30'),
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                         'DPT2m': {'fcst_var_names': ['DPT'],
+                                  'fcst_var_levels': ['Z2'],
+                                  'fcst_var_thresholds': '>=277.594,>=283.15,>=288.706,>=294.261',
+                                  'fcst_var_options': '',
+                                  'obs_var_names': ['DPT'],
+                                  'obs_var_levels': ['Z2'],
+                                  'obs_var_thresholds': '>=277.594,>=283.15,>=288.706,>=294.261',
+                                  'obs_var_options': '',
+                                  'plot_group':'sfc_upper'},
+                        'VISsfc': {'fcst_var_names': ['VIS'],
+                                   'fcst_var_levels': ['L0'],
+                                   'fcst_var_thresholds': ('<=800, <805, <=1600, <1609,'
+                                                           + ' <=4800, <4828, <=8000, <8045,'
+                                                           + ' >=8045,'
+                                                           + ' <=16000, <16090'),
+                                   'fcst_var_options': '',
+                                   'obs_var_names': ['VIS'],
+                                   'obs_var_levels': ['L0'],
+                                   'obs_var_thresholds': ('<=800, <805, <=1600, <1609,'
+                                                          + ' <=4800, <4828, <=8000, <8045,'
+                                                          + ' >=8045,'
+                                                          + ' <=16000, <16090'),
+                                   'obs_var_options': '',
+                                   'plot_group':'ceil_vis'},
+                        'HGTcldceil': {'fcst_var_names': ['HGT'],
+                                       'fcst_var_levels': ['L0'],
+                                       'fcst_var_thresholds': ('<152, <=152, <305,'
+                                                               + ' <=305, <914,'
+                                                               + ' >=914, <=916,'
+                                                               + ' <1520, <=1524, '
+                                                               + ' <3040, <=3048'),
+                                       'fcst_var_options': ('GRIB_lvl_typ ='
+                                                            + ' 215;'),
+                                       'obs_var_names': ['CEILING','HGT'],
+                                       'obs_var_levels': ['L0'],
+                                       'obs_var_thresholds': ('<152, <=152, <305,'
+                                                              + ' <=305, <914, '
+                                                              + '>=914, <=916, '
+                                                              + '<1520, <=1524, '
+                                                              + '<3040, <=3048'),
+                                       'obs_var_options': '',
+                                       'plot_group':'ceil_vis'},
+                        'CAPEsfc': {'fcst_var_names': ['CAPE'],
+                                    'fcst_var_levels': ['L0'],
+                                    'fcst_var_thresholds': ('>500, >1000,'
+                                                            + ' >1500, >2000,'
+                                                            + ' >3000,'
+                                                            + ' >4000'),
+                                    'fcst_var_options': '',
+                                    'obs_var_names': ['CAPE'],
+                                    'obs_var_levels': ['L100000-0'],
+                                    'obs_var_thresholds': ('>500, >1000,'
+                                                           + ' >1500, >2000,'
+                                                           + ' >3000,'
+                                                           + ' >4000'),
+                                    'obs_var_options': '',
+                                    'plot_group':'cape'},
+                    }
+                }
             },
             'grid2obs_ptype': {
                 'MCTC': {


### PR DESCRIPTION
## Description of Changes

This PR adds plotting specs back into ush/cam/settings.py that were inadvertently removed in #985.  Also HPBL plotting specs are modified following changes made in #989.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, code freeze for the next delivery was 6/17
* Do you have any planned upcoming annual leave/PTO?
    * Yes, 7/4 is a federal holiday
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/cam/firewx_plots
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:

```
jevs_plots_cam_firewxnest_grid2obs_last31days    vhr=00
```

[Total: _1 plots job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/marcel.caron/$NET/$evs_ver_2d/realtime`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit using using `qsub -v vhr=00 ${driver}.sh`

We can discuss whether or not we want to test anything else.

### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin bugfix/cam/firewx_plots
```