### PR TITLE
Fix cam typos in evs-nco.def

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2201,177 +2201,177 @@ suite evs_nco
               trigger (:TIME >= 2300 or :TIME < 0500) and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_refs_radar_vhr_18
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_refs_radar_vhr_19
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_refs_radar_vhr_20
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_refs_radar_vhr_21
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_refs_radar_vhr_22
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_refs_radar_vhr_23
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_refs_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_hrrr_radar_vhr_18
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_hrrr_radar_vhr_19
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_hrrr_radar_vhr_20
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_hrrr_radar_vhr_21
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_hrrr_radar_vhr_22
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_hrrr_radar_vhr_23
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_hrrr_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_rrfs_radar_vhr_18
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
             task jevs_stats_cam_rrfs_radar_vhr_19
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
             task jevs_stats_cam_rrfs_radar_vhr_20
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
             task jevs_stats_cam_rrfs_radar_vhr_21
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
             task jevs_stats_cam_rrfs_radar_vhr_22
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
             task jevs_stats_cam_rrfs_radar_vhr_23
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_22 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_06 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_07 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_08 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_09 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_10 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_11 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_12 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_13 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_14 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_15 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_16 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_17 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_18 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_19 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_20 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_21 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfs_radar_vhr_22 == complete
               edit VHR '23'
             task jevs_stats_cam_rrfsmem_radar_vhr_18_mem_1
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_radar_vhr_18_mem_2
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_radar_vhr_18_mem_3
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_radar_vhr_18_mem_4
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_radar_vhr_18_mem_5
-              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_cam_radar_prep_vhr_18 == complete
+              trigger (:TIME >= 1840 or :TIME < 0040) and ../../prep/cam/jevs_prep_cam_radar_vhr_18 == complete
               edit VHR '18'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_radar_vhr_19_mem_1
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_radar_vhr_19_mem_2
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_radar_vhr_19_mem_3
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_radar_vhr_19_mem_4
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_radar_vhr_19_mem_5
-              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_cam_radar_prep_vhr_19 == complete
+              trigger (:TIME >= 1940 or :TIME < 0140) and ../../prep/cam/jevs_prep_cam_radar_vhr_19 == complete
               edit VHR '19'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_radar_vhr_20_mem_1
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_radar_vhr_20_mem_2
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_radar_vhr_20_mem_3
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_radar_vhr_20_mem_4
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_radar_vhr_20_mem_5
-              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_cam_radar_prep_vhr_20 == complete
+              trigger (:TIME >= 2040 or :TIME < 0240) and ../../prep/cam/jevs_prep_cam_radar_vhr_20 == complete
               edit VHR '20'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_radar_vhr_21_mem_1
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_radar_vhr_21_mem_2
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_radar_vhr_21_mem_3
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_radar_vhr_21_mem_4
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_radar_vhr_21_mem_5
-              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_cam_radar_prep_vhr_21 == complete
+              trigger (:TIME >= 2140 or :TIME < 0340) and ../../prep/cam/jevs_prep_cam_radar_vhr_21 == complete
               edit VHR '21'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_radar_vhr_22_mem_1
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_radar_vhr_22_mem_2
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_radar_vhr_22_mem_3
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_radar_vhr_22_mem_4
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_radar_vhr_22_mem_5
-              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_cam_radar_prep_vhr_22 == complete
+              trigger (:TIME >= 2240 or :TIME < 0440) and ../../prep/cam/jevs_prep_cam_radar_vhr_22 == complete
               edit VHR '22'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_radar_vhr_23_mem_1
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_1 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_1 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_1 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_1 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_1 == complete
               edit VHR '23'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_radar_vhr_23_mem_2
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_2 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_2 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_2 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_2 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_2 == complete
               edit VHR '23'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_radar_vhr_23_mem_3
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_3 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_3 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_3 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_3 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_3 == complete
               edit VHR '23'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_radar_vhr_23_mem_4
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_4 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_4 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_4 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_4 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_4 == complete
               edit VHR '23'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_radar_vhr_23_mem_5
-              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_cam_radar_prep_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_5 == complete
+              trigger (:TIME >= 2340 or :TIME < 0540) and ../../prep/cam/jevs_prep_cam_radar_vhr_23 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_06_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_07_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_08_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_09_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_10_mem_5 == complete and ../../../../06/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_11_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_12_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_13_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_14_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_15_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_16_mem_5 == complete and ../../../../12/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_17_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_18_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_19_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_20_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_21_mem_5 == complete and ../../../../18/evs/stats/cam/jevs_stats_cam_rrfsmem_radar_vhr_22_mem_5 == complete
               edit VHR '23'
               edit MEM '5'
             task jevs_stats_cam_hrrr_snowfall_vhr_18
@@ -2401,107 +2401,107 @@ suite evs_nco
               edit VHR '18'
               edit MEM '5'
             task jevs_stats_cam_hrrr_precip_vhr_19
-              trigger (:TIME >= 1930 or :TIME < 0100) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1930 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_hrrr_precip_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_hrrr_precip_vhr_20
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_hrrr_precip_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_hrrr_precip_vhr_21
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_hrrr_precip_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_hrrr_precip_vhr_22
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_hrrr_precip_prep_vhr_18 == complete and ./jevs_stats_cam_hrrr_precip_vhr_19 == complete and ./jevs_stats_cam_hrrr_precip_vhr_20 == complete and ./jevs_stats_cam_hrrr_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_hrrr_precip_vhr_18 == complete and ./jevs_stats_cam_hrrr_precip_vhr_19 == complete and ./jevs_stats_cam_hrrr_precip_vhr_20 == complete and ./jevs_stats_cam_hrrr_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_rrfs_precip_vhr_19
-              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_rrfs_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_rrfs_precip_vhr_18 == complete
               edit VHR '19'
             task jevs_stats_cam_rrfs_precip_vhr_20
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_rrfs_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_rrfs_precip_vhr_18 == complete
               edit VHR '20'
             task jevs_stats_cam_rrfs_precip_vhr_21
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_rrfs_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_rrfs_precip_vhr_18 == complete
               edit VHR '21'
             task jevs_stats_cam_rrfs_precip_vhr_22
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_rrfs_precip_prep_vhr_18 == complete and ./jevs_stats_cam_rrfs_precip_vhr_19 == complete and ./jevs_stats_cam_rrfs_precip_vhr_20 == complete and ./jevs_stats_cam_rrfs_precip_vhr_21 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_rrfs_precip_vhr_18 == complete and ./jevs_stats_cam_rrfs_precip_vhr_19 == complete and ./jevs_stats_cam_rrfs_precip_vhr_20 == complete and ./jevs_stats_cam_rrfs_precip_vhr_21 == complete
               edit VHR '22'
             task jevs_stats_cam_rrfsmem_precip_vhr_19_mem_1
-              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '19'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_precip_vhr_19_mem_2
-              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '19'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_precip_vhr_19_mem_3
-              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '19'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_precip_vhr_19_mem_4
-              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '19'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_precip_vhr_19_mem_5
-              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 1900 or :TIME < 0100) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '19'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_precip_vhr_20_mem_1
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '20'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_precip_vhr_20_mem_2
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '20'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_precip_vhr_20_mem_3
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '20'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_precip_vhr_20_mem_4
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '20'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_precip_vhr_20_mem_5
-              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2000 or :TIME < 0200) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '20'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_precip_vhr_21_mem_1
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '21'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_precip_vhr_21_mem_2
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '21'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_precip_vhr_21_mem_3
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '21'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_precip_vhr_21_mem_4
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '21'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_precip_vhr_21_mem_5
-              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete
+              trigger (:TIME >= 2100 or :TIME < 0300) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete
               edit VHR '21'
               edit MEM '5'
             task jevs_stats_cam_rrfsmem_precip_vhr_22_mem_1
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_1 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_1 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_1 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_1 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_1 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_1 == complete
               edit VHR '22'
               edit MEM '1'
             task jevs_stats_cam_rrfsmem_precip_vhr_22_mem_2
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_2 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_2 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_2 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_2 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_2 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_2 == complete
               edit VHR '22'
               edit MEM '2'
             task jevs_stats_cam_rrfsmem_precip_vhr_22_mem_3
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_3 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_3 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_3 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_3 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_3 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_3 == complete
               edit VHR '22'
               edit MEM '3'
             task jevs_stats_cam_rrfsmem_precip_vhr_22_mem_4
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_4 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_4 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_4 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_4 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_4 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_4 == complete
               edit VHR '22'
               edit MEM '4'
             task jevs_stats_cam_rrfsmem_precip_vhr_22_mem_5
-              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_cam_rrfsmem_precip_prep_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_5 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_5 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_5 == complete
+              trigger (:TIME >= 2200 or :TIME < 0400) and ../../prep/cam/jevs_prep_cam_rrfsmem_precip_vhr_18 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_19_mem_5 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_20_mem_5 == complete and ./jevs_stats_cam_rrfsmem_precip_vhr_21_mem_5 == complete
               edit VHR '22'
               edit MEM '5'
             task jevs_stats_cam_hrrr_grid2obs_vhr_18


### PR DESCRIPTION
## Description of Changes

This PR corrects the file names of several cam prep ecf drivers in the evs-nco.def file.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, 7/8 is the next code delivery
* Do you have any planned upcoming annual leave/PTO?
    * Yes, 7/4 is a federal holiday
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

I don't think we need to test any jobs, but a few eyes on the "Files changed" tab for any unintended changes would be appreciated.