### PR TITLE
fix plots script error and adjust vhr=00 stats timeing

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_rrfs_chem_grid2obs_hourly_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_rrfs_chem_grid2obs_hourly_last31days.sh
@@ -52,7 +52,7 @@ export SENDDBN=NO
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 today=$(cut -c7-14 ${COMROOT}/date/t${vhr}z)
 export VDATE_END=$(finddate.sh ${today} d-4)
-export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END})
+export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 export USE_CFP=YES
 export nproc=128    ## nproc must match with the ncpus allocation above

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_rrfs_chem_grid2obs_hourly_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_rrfs_chem_grid2obs_hourly_last90days.sh
@@ -52,7 +52,7 @@ export SENDDBN=NO
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 today=$(cut -c7-14 ${COMROOT}/date/t${vhr}z)
 export VDATE_END=$(finddate.sh ${today} d-4)
-export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END})
+export COMOUT=/lfs/h2/emc/ptmp/$USER/${NET}/${evs_ver_2d}/${STEP}/${COMPONENT}/${RUN}.${VDATE_END}
 
 export USE_CFP=YES
 export nproc=128    ## nproc must match with the ncpus allocation above

--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -420,10 +420,10 @@ suite evs_nco
               edit VHR '03'
               edit MEM '5'
             task jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod_vhr_00
-              trigger :TIME >= 0005 and :TIME < 1130 and ../../../../00/evs/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs == complete
+              trigger :TIME >= 0015 and :TIME < 1130 and ../../../../00/evs/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs == complete
               edit VHR '00'
             task jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10_vhr_00
-              trigger :TIME >= 0010 and :TIME < 1130 and ../../../../00/evs/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs == complete
+              trigger :TIME >= 0015 and :TIME < 1130 and ../../../../00/evs/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs == complete
               edit VHR '00'
             task jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25_vhr_00
               trigger :TIME >= 0015 and :TIME < 1130 and ../../../../00/evs/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs == complete


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

fix syntax error for plots scripts and stats vhr=00 to to be on 00:15 for all three variables.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES, 

* Do you have any planned upcoming annual leave/PTO?
NO

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
YES, vhr=00 stats for rrfs-chem for   aeronet_aod and airnow_pm10

- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Please perform code review and reference the error message in emc.vpppg plots log file. 