### PR TITLE
Feature/refs/change precip paths

### DIFF
--- a/parm/metplus_config/stats/cam/precip/EnsembleStat_fcstREFS_obsCCPA_G227.conf
+++ b/parm/metplus_config/stats/cam/precip/EnsembleStat_fcstREFS_obsCCPA_G227.conf
@@ -124,7 +124,7 @@ ENSEMBLE_STAT_OUTPUT_DIR = {OUTPUT_BASE}/stat/{MODEL}
 
 [filename_templates]
 
-FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.m??.t{init?fmt=%H}z.{modelgrid}.f{lead?fmt=%HH}{modeltail}
+FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.t{init?fmt=%H}z.{modelgrid}.m??.f{lead?fmt=%HH}{modeltail}
 
 OBS_ENSEMBLE_STAT_GRID_INPUT_TEMPLATE = ccpa.{valid?fmt=%Y%m%d}/{obsvhead}.t{valid?fmt=%H}z.G240.{obsvtail}
 

--- a/parm/metplus_config/stats/cam/precip/EnsembleStat_fcstREFS_obsMRMS_G255.conf
+++ b/parm/metplus_config/stats/cam/precip/EnsembleStat_fcstREFS_obsMRMS_G255.conf
@@ -124,7 +124,7 @@ ENSEMBLE_STAT_OUTPUT_DIR = {OUTPUT_BASE}/stat/{MODEL}
 
 [filename_templates]
 
-FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.m??.t{init?fmt=%H}z.{modelgrid}.f{lead?fmt=%HH}{modeltail}
+FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.t{init?fmt=%H}z.{modelgrid}.m??.f{lead?fmt=%HH}{modeltail}
 
 OBS_ENSEMBLE_STAT_GRID_INPUT_TEMPLATE = mrms.{valid?fmt=%Y%m%d}/{obsvhead}.t{valid?fmt=%H}z.G255.nc
 

--- a/parm/metplus_config/stats/cam/snowfall/EnsembleStat_fcstREFS_obsNOHRSC.conf
+++ b/parm/metplus_config/stats/cam/snowfall/EnsembleStat_fcstREFS_obsNOHRSC.conf
@@ -126,7 +126,7 @@ ENSEMBLE_STAT_OUTPUT_DIR = {OUTPUT_BASE}/stat/{MODEL}
 
 [filename_templates]
 
-FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.m??.t{init?fmt=%H}z.{modelgrid}.f{lead?fmt=%HH}{modeltail}
+FCST_ENSEMBLE_STAT_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.t{init?fmt=%H}z.{modelgrid}.m??.f{lead?fmt=%HH}{modeltail}
 
 OBS_ENSEMBLE_STAT_GRID_INPUT_TEMPLATE = {valid?fmt=%Y%m%d}/wgrbbul/nohrsc_snowfall/sfav2_CONUS_{obsv}_{valid?fmt=%Y%m%d%H}_{obsvgrid}.grb2
 

--- a/parm/metplus_config/stats/cam/snowfall/GenEnsProd_fcstREFS_obsNOHRSC.conf
+++ b/parm/metplus_config/stats/cam/snowfall/GenEnsProd_fcstREFS_obsNOHRSC.conf
@@ -101,7 +101,7 @@ GEN_ENS_PROD_INPUT_DIR = {modelpath}
 GEN_ENS_PROD_OUTPUT_DIR = {OUTPUT_BASE}/stat/{MODEL}
 
 [filename_templates]
-GEN_ENS_PROD_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.m??.t{init?fmt=%H}z.{modelgrid}.f{lead?fmt=%HH}{modeltail}
+GEN_ENS_PROD_INPUT_TEMPLATE = refs.{init?fmt=%Y%m%d}/{init?fmt=%H}/{extradir}prcip.t{init?fmt=%H}z.{modelgrid}.m??.f{lead?fmt=%HH}{modeltail}
 GEN_ENS_PROD_OUTPUT_TEMPLATE = GenEnsProd_{MODEL}_{obsv}_FHR{lead?fmt=%HH}_{valid?fmt=%Y%m%d_%H%M%S}V_ens.nc
 
 

--- a/scripts/stats/cam/exevs_stats_refs_precip.sh
+++ b/scripts/stats/cam/exevs_stats_refs_precip.sh
@@ -14,6 +14,9 @@ export machine=${machine:-"WCOSS2"}
 #*************************************
 #check input data are available:
 #*************************************
+export verif_precip=${verif_precip:-'yes'}
+export verif_snowfall=${verif_snowfall:-'yes'}
+    
 source $USHevs/cam/evs_check_refs_files.sh
 export err=$?; err_chk
 
@@ -23,8 +26,6 @@ mkdir -p $WORK/scripts
 export all_stats=$WORK/all_stats
 mkdir -p $all_stats
 
-export verif_precip=${verif_precip:-'yes'}
-export verif_snowfall=${verif_snowfall:-'yes'}
 if [ "$verif_precip" = "no" ] && [ "$verif_snowfall" = "no" ] ; then
     export gather='no'
     export prepare='no'

--- a/ush/cam/evs_check_refs_files.sh
+++ b/ush/cam/evs_check_refs_files.sh
@@ -37,7 +37,7 @@ if [ $VERIF_CASE = grid2obs ] || [ $VERIF_CASE = spcoutlook ] ; then
 fi
 
 
-if [ $VERIF_CASE = precip ] ; then
+if [ $VERIF_CASE = precip ] && [ "$verif_precip" = "yes" ] ; then
    echo "Checking precip files...." 
 
    next=`$NDATE +24 ${vday}12 |cut -c 1-8`

--- a/ush/cam/evs_refs_precip.sh
+++ b/ush/cam/evs_refs_precip.sh
@@ -154,7 +154,7 @@ for obsvtype in ccpa mrms ; do
             
 	      #Check if input fcst and input_obsv files are available 
 	      if [ $extra = "verf_g2g" ] ; then
-		 input_fcst=${modelpath}/refs.${iday}/${ihr}/verf_g2g/refs.m??.t${ihr}z.${domain}.f${fhr}
+		 input_fcst=${modelpath}/refs.${iday}/${ihr}/preproc/prcip/prcip.t${ihr}z.${domain}.m??.f${fhr}.grib2
 	      elif [ $extra = "ensprod" ] ; then
 		 input_fcst=${modelpath}/refs.${iday}/${ihr}/ensprod/refs.t${ihr}z.${prod}.f${fhr}.${domain}.grib2
               else
@@ -313,8 +313,8 @@ for obsvtype in ccpa mrms ; do
                   fi
                   if [ $prod = system ] ; then
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export modeltail=''" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export extradir='verf_g2g/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export modeltail='.grib2'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export extradir='preproc/prcip/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   else
                      echo  "export modelhead=refs" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
@@ -333,8 +333,8 @@ for obsvtype in ccpa mrms ; do
                   fi
                   if [ $prod = system ] ; then
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export modeltail=''" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export extradir='verf_g2g/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export modeltail='.grib2'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export extradir='preproc/prcip/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   else
                      echo  "export modelhead=refs" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
@@ -353,8 +353,8 @@ for obsvtype in ccpa mrms ; do
                   fi
                   if [ $prod = system ] ; then
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export modeltail=''" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export extradir='verf_g2g/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export modeltail='.grib2'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export extradir='preproc/prcip/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   else
                      echo  "export modelhead=refs" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
@@ -372,8 +372,8 @@ for obsvtype in ccpa mrms ; do
                   fi
                   if [ $prod = system ] ; then
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export modeltail=''" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export extradir='verf_g2g/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export modeltail='.grib2'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export extradir='preproc/prcip/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   else
                      echo  "export modelhead=refs" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
@@ -391,8 +391,8 @@ for obsvtype in ccpa mrms ; do
                      echo  "export modelgrid=${prod}" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   elif [ $prod = system ] ; then
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export extradir='verf_g2g/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export modeltail=''" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export extradir='preproc/prcip/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export modeltail='.grib2'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                      echo  "export modelgrid=conus" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   else  # mean pmmn avrg lpmm (only these 24hr mean need to derived)
                      echo  "export modelhead=refs${prod}" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
@@ -412,8 +412,8 @@ for obsvtype in ccpa mrms ; do
                      echo  "export modelgrid=${prod}" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   elif [ $prod = system ] ; then
                      echo  "export modelpath=$COMREFS" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export extradir='verf_g2g/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
-                     echo  "export modeltail=''" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export extradir='preproc/prcip/'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
+                     echo  "export modeltail='.grib2'" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                      echo  "export modelgrid=ak" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh
                   else  # mean pmmn avrg lpmm (only these 24hr mean need to derived)
                      echo  "export modelhead=refs${prod}" >> run_refs_precip_${prod}.${obsv}.f${fhr}.v${vhr}.sh

--- a/ush/cam/evs_refs_prepare.sh
+++ b/ush/cam/evs_refs_prepare.sh
@@ -567,7 +567,7 @@ if [ "$data" = "mrms" ] ; then
  # Otherwise, copy the mrms files from the restart directory
  ############################################################	
  export accum
- if [ -s $DCOMINmrms/MultiSensor_QPE_??H_Pass2_00.00_${vday}-??0000.grib2.gz ] ; then 
+ if [ -s $DCOMINmrms/alaska/MultiSensorQPE/MultiSensor_QPE_??H_Pass2_00.00_${vday}-??0000.grib2.gz ] ; then 
     [[ ! -d $COMOUTrestart/prepare ]] && mkdir -p $COMOUTrestart/prepare
 
     for accum in 01 03 24 ; do
@@ -590,7 +590,7 @@ if [ "$data" = "mrms" ] ; then
 	  if [ ! -s $COMOUTrestart/prepare/mrms${accum}h.t${vhr}z.G*.nc ] ; then 
             export vbeg=$vday$vhr
             export vend=$vday$vhr
-            mrms03=$DCOMINmrms/MultiSensor_QPE_${accum}H_Pass2_00.00_${vday}-${vhr}0000.grib2.gz
+            mrms03=$DCOMINmrms/alaska/MultiSensorQPE/MultiSensor_QPE_${accum}H_Pass2_00.00_${vday}-${vhr}0000.grib2.gz
             if [ -s $mrms03 ] ; then 
                cp $mrms03 $mrmsdir/.
                gunzip MultiSensor_QPE_${accum}H_Pass2_00.00_${vday}-${vhr}0000.grib2.gz
@@ -629,11 +629,11 @@ if [ "$data" = "mrms" ] ; then
       done
 
    else
-      echo "WARNING:  No MRMS data $DCOMINmrms/MultiSensor_QPE_*.grib2.gz available for EVS ${COMPONENT}"
+      echo "WARNING:  No MRMS data $DCOMINmrms/alaska/MultiSensorQPE/MultiSensor_QPE_*.grib2.gz available for EVS ${COMPONENT}"
       if [ "$SENDMAIL" = "YES" ] ; then
          export subject="MRMS Data Missing for EVS ${COMPONENT}"
          echo "WARNING:  No MRMS data available for ${VDATE}" > mailmsg
-         echo Missing file is $DCOMINmrms/MultiSensor_QPE_*.grib2.gz  >> mailmsg
+         echo Missing file is $DCOMINmrms/alaska/MultiSensorQPE/MultiSensor_QPE_*.grib2.gz  >> mailmsg
          echo "Job ID: $jobid" >> mailmsg
          cat mailmsg | mail -s "$subject" $MAILTO
       fi

--- a/ush/cam/evs_refs_snowfall.sh
+++ b/ush/cam/evs_refs_snowfall.sh
@@ -76,7 +76,7 @@ for obsv in 6h 24h  ; do
 	    ihr=`$NDATE -$fhr $VDATE$vhr|cut -c 9-10`
 	    iday=`$NDATE -$fhr $VDATE$vhr|cut -c 1-8`
 
-	    input_fcst=$COMINrefs/refs.${iday}/${ihr}/verf_g2g/refs.*.t${ihr}z.conus.f${fhr}
+	    input_fcst=$COMINrefs/refs.${iday}/${ihr}/preproc/prcip/prcip.t${ihr}z.conus.*.f${fhr}.grib2
         input_obsv=$COMSNOW/${VDATE}/wgrbbul/nohrsc_snowfall/sfav2_CONUS_${obsv}_${VDATE}${vhr}_grid184.grb2
 
 	   if [ -s $input_fcst ] && [ -s $input_obsv ] ; then
@@ -118,8 +118,8 @@ for obsv in 6h 24h  ; do
             echo  "export regrid=FCST" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
             echo  "export modelpath=$COMREFS" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
             echo  "export modelgrid=conus" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
-            echo  "export modeltail=''" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
-            echo  "export extradir='verf_g2g/'" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
+            echo  "export modeltail='.grib2'" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
+            echo  "export extradir='preproc/prcip/'" >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
 
             echo  "export verif_grid='' " >> run_refs_snow${obsv}.${fhr}.${vhr}.sh
             echo  "export verif_poly='${maskpath}/Bukovsky_NOHRSC_CONUS.nc, ${maskpath}/Bukovsky_NOHRSC_CONUS_East.nc, ${maskpath}/Bukovsky_NOHRSC_CONUS_West.nc, ${maskpath}/Bukovsky_NOHRSC_CONUS_South.nc, ${maskpath}/Bukovsky_NOHRSC_CONUS_Central.nc' " >> run_refs_snow${obsv}.${fhr}.${vhr}.sh


### PR DESCRIPTION
## Description of Changes

This PR changes the paths to COMINrefs prcip files used for refs precip and snowfall stats jobs. 

In addition, a bug was discovered in the path to DCOMINmrms files used for OCONUS precip verification, caused by changes to jobs/JEVS_STATS_CAM in #970.  The fix is a few small paths changes in a single script.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, code freeze was 6/17
* Do you have any planned upcoming annual leave/PTO?
    * Yes, 7/4 is a federal holiday
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/refs/change_precip_paths
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_stats_cam_refs_precip
jevs_stats_cam_refs_snowfall
```
[Total: _2 stats jobs_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMINrefs** - set to `/lfs/h1/ops/para/com/refs/${rrfs_ver}`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit using `qsub -v vhr=13 ${driver}.sh` 

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin feature/refs/change_precip_paths
```