### PR TITLE
Add all global_det stats job resources into drive_EVS.py file

### DIFF
--- a/dev/drivers/drive_EVS.py
+++ b/dev/drivers/drive_EVS.py
@@ -191,6 +191,46 @@ def create_job_script(
         nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
         memory = "25GB"
         vhr="00"
+    elif "jevs_stats_global_det_fnmoc_atmos_grid2grid" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "20"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB" 
+        vhr="00"
+    elif "jevs_stats_global_det_fnmoc_atmos_grid2obs" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "14"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_gfs_atmos_grid2grid" == dev_driver:
+        walltime = "01:10:00"
+        place = "place=vscatter:exclhost"
+        nodes = "1"
+        nproc = "128"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "225GB"
+        vhr="00"
+    elif "jevs_stats_global_det_gfs_atmos_grid2obs" == dev_driver:
+        walltime = "01:45:00"
+        place = "place=vscatter:exclhost"
+        nodes = "1"
+        nproc = "128"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "300GB"
+        vhr="00"
+    elif "jevs_stats_global_det_gfs_wave_grid2obs" == dev_driver:
+        walltime = "00:20:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "25"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "50GB"
+        vhr="00"
 
     # ------------------------------------------------------------------------
     # Machine-specific resource information
@@ -414,6 +454,76 @@ def create_job_script(
         sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
         sh.write("\n")
         modelname = "ecmwf"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_fnmoc_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "fnmoc"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_fnmoc_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "fnmoc"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_gfs_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "gfs"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_gfs_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "gfs"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_gfs_wave_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "gfs"
         verif_case = "grid2obs"
         config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
         sh.write(f"export MODELNAME={modelname}\n")

--- a/dev/drivers/drive_EVS.py
+++ b/dev/drivers/drive_EVS.py
@@ -231,6 +231,46 @@ def create_job_script(
         nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
         memory = "50GB"
         vhr="00"
+    elif "jevs_stats_global_det_jma_atmos_grid2grid" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "31"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_jma_atmos_grid2obs" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "14"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_metfra_atmos_grid2grid" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "11"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_ukmet_atmos_grid2grid" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "32"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_ukmet_atmos_grid2obs" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "14"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
 
     # ------------------------------------------------------------------------
     # Machine-specific resource information
@@ -524,6 +564,76 @@ def create_job_script(
         sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
         sh.write("\n")
         modelname = "gfs"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_jma_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "jma"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_jma_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "jma"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_metfra_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "metfra"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_ukmet_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "ukmet"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_ukmet_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "ukmet"
         verif_case = "grid2obs"
         config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
         sh.write(f"export MODELNAME={modelname}\n")

--- a/dev/drivers/drive_EVS.py
+++ b/dev/drivers/drive_EVS.py
@@ -119,6 +119,78 @@ def create_job_script(
         nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
         memory = "225GB"
         vhr="00"
+    elif "jevs_stats_global_det_aigfs_atmos_grid2obs" == dev_driver:
+        walltime = "01:45:00"
+        place = "place=vscatter:exclhost"
+        nodes = "1"
+        nproc = "128"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "300GB"
+        vhr="00"
+    elif "jevs_stats_global_det_cfs_atmos_grid2grid" == dev_driver:
+        walltime = "01:05:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "40"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "75GB"
+        vhr="00"
+    elif "jevs_stats_global_det_cfs_atmos_grid2obs" == dev_driver:
+        walltime = "01:00:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "28"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "50GB"
+        vhr="00"
+    elif "jevs_stats_global_det_cmc_atmos_grid2grid" == dev_driver:
+        walltime = "00:30:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "31"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "35GB" 
+        vhr="00"
+    elif "jevs_stats_global_det_cmc_atmos_grid2obs" == dev_driver:
+        walltime = "00:20:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "14"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_cmc_regional_atmos_grid2grid" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "11"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB" 
+        vhr="00"
+    elif "jevs_stats_global_det_dwd_atmos_grid2grid" == dev_driver:
+        walltime = "00:15:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "11"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
+    elif "jevs_stats_global_det_ecmwf_atmos_grid2grid" == dev_driver:
+        walltime = "00:30:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "53"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "60GB" 
+        vhr="00"
+    elif "jevs_stats_global_det_ecmwf_atmos_grid2obs" == dev_driver:
+        walltime = "00:25:00"
+        place = "place=vscatter:shared"
+        nodes = "1"
+        nproc = "14"
+        nodes_info = f"{nodes}:ncpus={nproc}:ompthreads=1"
+        memory = "25GB"
+        vhr="00"
 
     # ------------------------------------------------------------------------
     # Machine-specific resource information
@@ -226,6 +298,132 @@ def create_job_script(
         sh.write(f"{clean_line}\n")
         sh.write(f"export nproc={nproc}\n")
         sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_aigfs_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "aigfs"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_cfs_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "cfs"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_cfs_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "cfs"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_cmc_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "cmc"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_cmc_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "cmc"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_cmc_regional_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "cmc_regional"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_dwd_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "dwd"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_ecmwf_atmos_grid2grid" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "ecmwf"
+        verif_case = "grid2grid"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
+    elif "jevs_stats_global_det_ecmwf_atmos_grid2obs" == dev_driver:
+        sh.write(f"export COMOUT={COMOUT_ROOT}/$NET/$evs_ver_2d/$STEP/$COMPONENT\n")
+        sh.write("\n")
+        modelname = "ecmwf"
+        verif_case = "grid2obs"
+        config_file=f"{HOMEevs}/parm/evs_config/{component}/config.evs.prod.$STEP.$COMPONENT.$RUN.$VERIF_CASE.$MODELNAME"
+        sh.write(f"export MODELNAME={modelname}\n")
+        sh.write(f"export VERIF_CASE={verif_case}\n")
+        sh.write(f"export config={config_file}\n")
+        line=f"export VDATE={evsdate}"
+        clean_line = line.replace("-", "")
+        sh.write(f"{clean_line}\n")
+        sh.write(f"export nproc={nproc}\n")
+        sh.write(f"export USE_CFP=YES\n")
     else:
         pass
 
@@ -233,6 +431,7 @@ def create_job_script(
     # Final machine-specific information
     # ------------------------------------------------------------------------
     if machine_name == 'WCOSS2':
+        sh.write(f"export machine={machine_name}\n")
         sh.write(f"export job=${{PBS_JOBNAME:-{dev_driver}}}\n")
         sh.write("export jobid=$job.${PBS_JOBID:-$$}\n")
         sh.write("export SITE=$(cat /etc/cluster_name)\n")


### PR DESCRIPTION
## Description of Changes

This PR allows all global_det stats jobs to be run using the new driver script and parm/config.EVS file. This is done by adding all of the global_det stat job resources to the driver script. The global_det stats jobs can be tested by setting those jobs to YES in the parm/config.EVS file.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? 
No

* Do you have any planned upcoming annual leave/PTO?
**Yes, 7/9/26-7/20/26**

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

git clone https://github.com/AliciaBentley-NOAA/EVS.git
cd EVS
git checkout feature/add_jobs
[No need to build /exec; the scripts will do that for you!]
[No need to soft link the /fix directory; the scripts will do that for you!]
cd dev/parm
vi config.EVS
[To test the new driver, make sure that RUN_PREP=NO (not running prep today), RUN_STATS=YES, component_list=global_det, and that vdate is equal to the last date thatwe have stats for in the emc.vpppg parallel (e.g., 20260704). Be sure to change HOMEevs to the location where you cloned by fork. **Set all jobs under STATS_GLOBAL_DET equal to YES.**]
cd ../drivers
python drive_EVS.py ../parm/config.EVS
[Note that this will NOT submit the scripts right away, but it will build the "submit" scripts in DATAROOT/jobs/.]

Please take a look at the "submit" scripts in DATAROOT/jobs/. Do they look like your dev/drivers/scripts/? Are they missing anything critical for other components besides global_det? 

If you like the "submit" scripts, you can submit them using qsub. Example:

```
qsub /lfs/h2/emc/stmp/$USER/evs_test/prod/tmp/jobs/submit_jevs_stats_global_det_aigfs_atmos_grid2obs_20260704.sh
```

I tested all jobs and they worked! My personal test output can be found here:
/lfs/h2/emc/vpppg/noscrub/alicia.bentley/evs/v2.0/stats/global_det