### PR TITLE
increase lower extent of perfdiag graphics

### DIFF
--- a/ush/cam/performance_diagram.py
+++ b/ush/cam/performance_diagram.py
@@ -48,8 +48,8 @@ from check_variables import *
 # ================ GLOBALS AND CONSTANTS ================
 
 plotter = Plotter(
-    fig_size=(10., 8.), legend_font_size=10, fig_subplot_right=.77, 
-    fig_subplot_left=.23, fig_subplot_top=.87, fig_subplot_bottom=.23
+    fig_size=(10., 9.), legend_font_size=10, fig_subplot_right=.77, 
+    fig_subplot_left=.23, fig_subplot_top=.884, fig_subplot_bottom=.316
 )
 plotter.set_up_plots()
 toggle = Toggle()
@@ -1010,7 +1010,7 @@ def plot_performance_diagram(df: pd.DataFrame, logger: logging.Logger,
     )
 
     fig.subplots_adjust(wspace=0, hspace=0)
-    cax = fig.add_axes([.775, .23, .01, .64])
+    cax = fig.add_axes([.775, .316, .01, .569])
     cbar_ticks = [0.,.1,.2,.3,.4,.5,.6,.7,.8,.9,1.]
     cb = plt.colorbar(
         csi_contour, orientation='vertical', cax=cax, ticks=cbar_ticks,


### PR DESCRIPTION
## Description of Changes

This PR increases the lower extent of cam performance diagrams.  This change responds to new graphics in which part of the legend is cut off, the result of a recent increase in the number of cams on graphics.

See PR comments for a sample graphic in which the legend is cut off.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Possibly, it responds to RRFS-related changes in EVS that will be delivered in August 2026
* Do you have any planned upcoming annual leave/PTO?
    * No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/extend_perfdiag_legend
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_plots_cam_precip_last90days
```
[Total: _1 plots job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit using `qsub -v vhr=00 ${driver}.sh` 

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- Also check that performance diagrams showing many models aren't cut off (try 12Z F24 verification for 24-h precip)

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin feature/extend_perfdiag_legend
```