### PR TITLE
Feature/increase walltime refs radar

### DIFF
--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_precip.sh
@@ -4,7 +4,7 @@
 #PBS -q dev
 #PBS -A VERF-DEV
 #PBS -l walltime=00:40:00
-#PBS -l place=shared,select=1:ncpus=3:ompthreads=1:mem=110GB
+#PBS -l place=shared,select=1:ncpus=3:ompthreads=1:mem=210GB
 #PBS -l debug=true
 
 set -x

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:25:00
 #PBS -l select=1:ncpus=9:mem=8GB
 #PBS -l debug=true
 

--- a/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_precip_vhr_master.ecf
+++ b/ecf/scripts/prep/cam/jevs_prep_cam_rrfs_precip_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:40:00
-#PBS -l place=shared,select=1:ncpus=3:ompthreads=1:mem=110GB
+#PBS -l place=shared,select=1:ncpus=3:ompthreads=1:mem=210GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/stats/cam/jevs_stats_cam_refs_radar_vhr_master.ecf
+++ b/ecf/scripts/stats/cam/jevs_stats_cam_refs_radar_vhr_master.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:25:00
 #PBS -l select=1:ncpus=9:mem=8GB
 #PBS -l debug=true
 


### PR DESCRIPTION
## Description of Changes

This PR changes the resource allocation of some EVS cam jobs. 

After RRFS verification was recently merged into EVS develop, one job has hit its wallclock time, and another its memory limit.  This PR increases the resources for each job.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, code delivery for RRFS verification in EVS is planned for August 2026
* Do you have any planned upcoming annual leave/PTO?
    * No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/increase_walltime_refs_radar
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_prep_cam_rrfs_precip
jevs_stats_cam_refs_radar
```
[Total: _1 prep job; 1 stats job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMINrrfs** - set to `/lfs/h1/ops/para/com/rrfs/${rrfs_ver}`
**COMINrefs** - set to `/lfs/h1/ops/para/com/refs/${refs_ver}`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- For **jevs_prep_cam_rrfs_precip**, submit using `qsub -v vhr=${vhr} ${driver}.sh` for `vhr=00`, `06`, `12`, and `18`
- For **jevs_stats_cam_refs_radar**, submit using `qsub -v vhr=23 ${driver}.sh` (`vhr=23` is the one that takes the longest)

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- We can also check the actual memory usage / runtime to confirm settings are appropriate

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin feature/increase_walltime_refs_radar
```