### PR TITLE
feature/subseasonal_umd_olr_removal

### DIFF
--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
@@ -46,7 +46,7 @@ export NET=evs
 export STEP=prep
 export COMPONENT=subseasonal
 export RUN=atmos
-export OBSNAME="gfs ecmwf osi ghrsst umd gdas ccpa"
+export OBSNAME="gfs ecmwf osi ghrsst gdas ccpa"
 export PREP_TYPE=obs
 
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN

--- a/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.ecf
+++ b/ecf/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.ecf
@@ -50,7 +50,7 @@ fi
 export nproc=1
 export NET=evs
 export RUN=atmos
-export OBSNAME="gfs ecmwf osi ghrsst umd gdas ccpa"
+export OBSNAME="gfs ecmwf osi ghrsst gdas ccpa"
 export PREP_TYPE=obs
 export config=$HOMEevs/parm/evs_config/${COMPONENT}/config.${model}.${COMPONENT}.${PREP_TYPE}.${STEP}
 

--- a/jobs/JEVS_PREP_SUBSEASONAL
+++ b/jobs/JEVS_PREP_SUBSEASONAL
@@ -69,7 +69,6 @@ export COMINgfs=${COMINgfs:-$(compath.py ${envir}/com/gfs/${gfs_ver})}
 export DCOMINecmwf=${DCOMINecmwf:-$DCOMROOT}
 export DCOMINosi=${DCOMINosi:-$DCOMROOT}
 export DCOMINghrsst=${DCOMINghrsst:-$DCOMROOT}
-export DCOMINumd=${DCOMINumd:-$DCOMROOT}
 export COMINobsproc=${COMINobsproc:-$(compath.py ${envir}/com/obsproc/${obsproc_ver})}
 export COMINccpa=${COMINccpa:-$(compath.py ${envir}/com/ccpa/${ccpa_ver})}
 export COMOUT=${COMOUT:-$(compath.py -o $NET/$evs_ver/$STEP/$COMPONENT/$RUN)}

--- a/ush/subseasonal/check_subseasonal_config_obs_prep.py
+++ b/ush/subseasonal/check_subseasonal_config_obs_prep.py
@@ -2,7 +2,7 @@
 '''
 Program Name: check_subseasonal_config_obs_prep.py
 Contact(s): Shannon Shields
-Abstract: This script is run by exevs_subseasonal_obs_prep.sh
+Abstract: This script is run by exevs_prep_subseasonal_obs.sh
           in scripts/prep/subseasonal.
           This does a check on the user's settings in
           the passed config file.

--- a/ush/subseasonal/check_subseasonal_config_stats.py
+++ b/ush/subseasonal/check_subseasonal_config_stats.py
@@ -153,7 +153,6 @@ if VERIF_CASE_STEP == 'grid2grid_stats':
         valid_config_var_values_dict[VCS_abbrev_type
                                      +'_truth_name_list'] = ['gfs_anl', 
                                                              'ecmwf_anl',
-                                                             'umd_anl',
                                                              'ghrsst_anl',
                                                              'osi_anl',
                                                              'ccpa']

--- a/ush/subseasonal/subseasonal_prep_obs.py
+++ b/ush/subseasonal/subseasonal_prep_obs.py
@@ -2,7 +2,7 @@
 '''
 Name: subseasonal_prep_obs.py
 Contact(s): Shannon Shields
-Abstract: This script is run by exevs_subseasonal_obs_prep.sh
+Abstract: This script is run by exevs_prep_subseasonal_obs.sh
           in scripts/prep/subseasonal. This script retrieves
           obs data for subseasonal prep step.
 '''
@@ -25,7 +25,6 @@ COMINgfs = os.environ['COMINgfs']
 DCOMINecmwf = os.environ['DCOMINecmwf']
 DCOMINosi = os.environ['DCOMINosi']
 DCOMINghrsst = os.environ['DCOMINghrsst']
-DCOMINumd = os.environ['DCOMINumd']
 COMINobsproc = os.environ['COMINobsproc']
 COMINccpa = os.environ['COMINccpa']
 COMOUT = os.environ['COMOUT']
@@ -105,21 +104,6 @@ subseasonal_obs_dict = {
                                                              +'{init?fmt=%Y%m%d%H}'
                                                              +'.nc'),
                       'vhours': ['00']},
-    'umd': {'prod_file_format': os.path.join(DCOMINumd, 
-                                             '{init?fmt=%Y%m%d}',
-                                             'validation_data',
-                                             'landsfc',
-                                             'olr',
-                                             'olr-daily_'
-                                             +'v01r02-preliminary_'
-                                             +'{init?fmt=%Y}0101_'
-                                             +'latest.nc'),
-                      'arch_file_format': os.path.join(COMOUT_INITDATE,
-                                                       'umd',
-                                                       'umd.olr.'
-                                                       '{init?fmt=%Y%m%d}.nc'),
-                      'vhours': ['00']},
-
     'gdas': {'arch_file_format': os.path.join(COMOUT_INITDATE,
                                              'prepbufr_gdas',
                                              'prepbufr.gdas.'
@@ -318,19 +302,6 @@ for OBS in OBSNAME:
                                     sub_util.run_shell_command(
                                         ['chgrp', 'rstprod', arch_file]
                                     )
-                        else:
-                            sub_util.log_missing_file_obs(
-                                log_missing_file, prod_file, OBS,
-                                CDATE_dt
-                            )
-                elif OBS == 'umd':
-                    if SENDCOM == 'YES':
-                        if sub_util.check_file_exists_size(prod_file):
-                            if not \
-                                    sub_util.check_netcdf_file_corrupt(
-                                        prod_file
-                                    ):
-                                sub_util.copy_file(prod_file, arch_file)
                         else:
                             sub_util.log_missing_file_obs(
                                 log_missing_file, prod_file, OBS,


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR removes prep processing of the UMD OLR dataset that is proving to be unstable/unavailable for long time periods (outages of several weeks or more). Also, this OLR dataset is not currently being used in the stats step of the subseasonal component. Note that "umd_anl" was removed in ush/subseasonal/check_subseasonal_config_stats.py due to an oversight long ago when this script was first created; there is no impact on the stats step as OLR is not verified.
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? No, but merging this PR in the next few days would be preferable.
* Do you have any planned upcoming annual leave/PTO? Not until early Aug.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.
Create prtest directory
git clone https://github.com/ShannonShields-NOAA/EVS.git
cd EVS
git checkout feature/subseasonal_olr_prep_removal
Link fix directory
In dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh:
Set HOMEevs to prtest directory
Set KEEPDATA=YES
Set SENDMAIL=NO
Make sure COMOUT is set appropriately
Run the script (default date is fine): qsub jevs_prep_subseasonal_obs.sh
In the log file and output, there now should be no "umd" instances.