### PR TITLE
Increase memory allocation

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.sh
@@ -4,7 +4,7 @@
 #PBS -S /bin/bash
 #PBS -A VERF-DEV
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=4:ncpus=76:mem=200GB
+#PBS -l place=vscatter,select=4:ncpus=76:mem=290GB
 #PBS -l debug=true
 
 set -x

--- a/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_refs_precip_last90days.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=4:ncpus=76:mem=200GB
+#PBS -l place=vscatter,select=4:ncpus=76:mem=290GB
 #PBS -l debug=true
 
 export model=evs 


### PR DESCRIPTION
## Description of Changes

This PR addresses a recent memory exceedence in the EVS cam parallel.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Possibly, it responds to RRFS-related changes in EVS that will be delivered in August 2026
* Do you have any planned upcoming annual leave/PTO?
    * August 10-14
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout feature/cam/adjust_resources
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_plots_cam_refs_precip_last90days
```
[Total: _1 plots job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit the driver using `qsub -v vhr=00 ${driver}.sh` 

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin feature/cam/adjust_resources
```