### PR TITLE
Updated the code to create strict WFO sandboxing

### DIFF
--- a/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last31days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=02:30:00
+#PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=2:ncpus=100:mem=100G
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last90days.sh
+++ b/dev/drivers/scripts/plots/nwps/jevs_plots_nwps_wave_grid2obs_last90days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=04:00:00
+#PBS -l walltime=01:00:00
 #PBS -l place=vscatter,select=2:ncpus=100:mem=100G
 #PBS -l debug=true
 

--- a/parm/metplus_config/plots/nwps/wave_grid2obs/py_plotting_wave.config
+++ b/parm/metplus_config/plots/nwps/wave_grid2obs/py_plotting_wave.config
@@ -94,7 +94,7 @@ export PRUNE_DIR=${job_work_dir}
 mkdir -p $PRUNE_DIR
 export SAVE_DIR=${job_work_dir}
 mkdir -p $SAVE_DIR
-export OUTPUT_BASE_DIR=${DATA}/stats/
+export OUTPUT_BASE_DIR=${DATA_wfo}/stats/
 
 # Logfile settings. Log level options are "DEBUG", "INFO", "WARNING", "ERROR", and "CRITICAL"
 metric1=${METRIC//, /_}

--- a/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
+++ b/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
@@ -21,8 +21,6 @@ export MET_VERSION_major_minor=$(echo $MET_VERSION | sed "s/\([^.]*\.[^.]*\)\..*
 export LOUD=${LOUD:-YES}; [[ $LOUD = yes ]] && export LOUD=YES
 [[ "$LOUD" != YES ]] && set -x
 
-# Save the master DATA directory root
-export DATA_base=${DATA}
 
 echo "Starting grid2obs_plots for ${MODELNAME}_${RUN}"
 
@@ -43,12 +41,12 @@ for wfo in ${WFO}; do
     export wfo=$wfo
     
     # Create an isolated workspace for this specific WFO
-    export DATA="${DATA_base}/${wfo}"
+    export DATA_wfo="${DATA}/${wfo}"
     
-    mkdir -p ${DATA}/stats
-    mkdir -p ${DATA}/job_work_dir
-    mkdir -p ${DATA}/images
-    cd ${DATA}
+    mkdir -p ${DATA_wfo}/stats
+    mkdir -p ${DATA_wfo}/job_work_dir
+    mkdir -p ${DATA_wfo}/images
+    cd ${DATA_wfo}
 
     echo ' '
     echo "Copying *.stat files for ${wfo}:"
@@ -62,7 +60,7 @@ for wfo in ${WFO}; do
     while (( ${theDate} <= ${plot_end_date} )); do
         EVSINnwps=${COMIN}/stats/${COMPONENT}/${MODELNAME}.${theDate}
         if [ -s ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ]; then
-            cp ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ${DATA}/stats/.
+            cp ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ${DATA_wfo}/stats/.
         else
             echo "WARNING: ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat DOES NOT EXIST"
         fi
@@ -73,7 +71,7 @@ for wfo in ${WFO}; do
     # quick error check 
     ####################
     # Check for files specifically inside this WFO's stats sandbox
-    nc=$(ls ${DATA}/stats/evs.stats.${MODELNAME}.${wfo}*stat 2>/dev/null | wc -l | awk '{print $1}')
+    nc=$(ls ${DATA_wfo}/stats/evs.stats.${MODELNAME}.${wfo}*stat 2>/dev/null | wc -l | awk '{print $1}')
     
     if [ "${nc}" != '0' ] && [ -n "${nc}" ]; then
         set -x
@@ -106,7 +104,7 @@ for wfo in ${WFO}; do
     ###########################################
     # Run the command files for the PAST31DAYS 
     ###########################################
-    chmod 775 ${DATA}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+    chmod 775 ${DATA_wfo}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
     if [ "${run_mpi}" = 'yes' ] ; then
         mpiexec -np 200 -ppn 100 --cpu-bind verbose,depth cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
     else
@@ -125,9 +123,9 @@ for wfo in ${WFO}; do
     #######################
     periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
     if [ "$gather" = "yes" ] ; then
-        if [ "$(ls -A "${DATA}/images")" ]; then
-            echo "Found ${DATA}/images/*.png "
-            nc_images=$(ls ${DATA}/images/*.png | wc -l | awk '{print $1}')
+        if [ "$(ls -A "${DATA_wfo}/images")" ]; then
+            echo "Found ${DATA_wfo}/images/*.png "
+            nc_images=$(ls ${DATA_wfo}/images/*.png | wc -l | awk '{print $1}')
             
             for period in ${periods} ; do
                 period_lower=$(echo ${period,,})
@@ -160,7 +158,7 @@ for wfo in ${WFO}; do
                 
                 # tar and copy them to the final destination
                 if [ "${nc_images}" -gt '0' ] ; then
-                    cd ${DATA}/images
+                    cd ${DATA_wfo}/images
                     tar -cvf evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar evs.*${period_lower}*_${wfo}.png
                 fi
                 
@@ -189,10 +187,10 @@ done
 # copy log files into logs and cat them
 #########################################
 # Set working directory back to global root to find all sandboxed logs
-cd ${DATA_base}
-log_dir="${DATA_base}/*/job_work_dir/*/logs"
+cd ${DATA_wfo}
+log_dir="${DATA_wfo}/*/job_work_dir/*/logs"
 
-log_file_count=$(find ${DATA_base} -type f \( -name "*.out" -o -name "*.log" \) | wc -l)
+log_file_count=$(find ${DATA_wfo} -type f \( -name "*.out" -o -name "*.log" \) | wc -l)
 if [[ $log_file_count -ne 0 ]]; then
     for log_file in $log_dir; do
         if [ -f "$log_file" ]; then

--- a/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
+++ b/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
@@ -22,7 +22,7 @@ export LOUD=${LOUD:-YES}; [[ $LOUD = yes ]] && export LOUD=YES
 [[ "$LOUD" != YES ]] && set -x
 
 # Save the master DATA directory root
-export DATA_ROOT=${DATA}
+export DATA_base=${DATA}
 
 echo "Starting grid2obs_plots for ${MODELNAME}_${RUN}"
 
@@ -43,7 +43,7 @@ for wfo in ${WFO}; do
     export wfo=$wfo
     
     # Create an isolated workspace for this specific WFO
-    export DATA="${DATA_ROOT}/${wfo}"
+    export DATA="${DATA_base}/${wfo}"
     
     mkdir -p ${DATA}/stats
     mkdir -p ${DATA}/job_work_dir
@@ -189,10 +189,10 @@ done
 # copy log files into logs and cat them
 #########################################
 # Set working directory back to global root to find all sandboxed logs
-cd ${DATA_ROOT}
-log_dir="${DATA_ROOT}/*/job_work_dir/*/logs"
+cd ${DATA_base}
+log_dir="${DATA_base}/*/job_work_dir/*/logs"
 
-log_file_count=$(find ${DATA_ROOT} -type f \( -name "*.out" -o -name "*.log" \) | wc -l)
+log_file_count=$(find ${DATA_base} -type f \( -name "*.out" -o -name "*.log" \) | wc -l)
 if [[ $log_file_count -ne 0 ]]; then
     for log_file in $log_dir; do
         if [ -f "$log_file" ]; then

--- a/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
+++ b/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
@@ -1,42 +1,28 @@
 #!/bin/bash
 ##################################################################################
 # Name of Script: exevs_plots_nwps_wave_grid2obs.sh                           
-# Samira Ardani / samira.ardani@noaa.gov                                    
+# Samira Ardani / samira.ardani@noaa.gov                            
 # Purpose of Script: Run the grid2obs plots for NWPS wave model           
 #           Updates: 
 #           - Updated the code structure (11/2024)
 #           - Addressed mpmd (03/2025)
 #           - Added most of the available WFOs for plotting purposes (08/2025).
-#           - Adjusted the code to skip the rest of the loops for WFO without stat file (08/2025).        
-#                                                                               
-# Usage:                                                                        
-#  Parameters: None                                                             
-#  Input files:                                                                 
-#     evs.stats.nwps.wave.grid2obs.vYYYYMMDD.stat                             
-#  Output files:                                                                
-#     evs.plots.nwps.wave.grid2obs.last31days.vYYYYMMDD.tar                   
-#     evs.plots.nwps.wave.grid2obs.last90days.vYYYYMMDD.tar                   
-#                                                
+#           - Adjusted the code to skip the rest of the loops for WFO without stat file (08/2025).       
+#           - added file-space isolation between loop iterations and created strict WFO sandboxing.
+
 #################################################################################
 
 set -x
 
 # set major & minor MET version
-export MET_VERSION_major_minor=`echo $MET_VERSION | sed "s/\([^.]*\.[^.]*\)\..*/\1/g"`
+export MET_VERSION_major_minor=$(echo $MET_VERSION | sed "s/\([^.]*\.[^.]*\)\..*/\1/g")
 
-# Use LOUD variable to turn on/off trace.  Defaults to YES (on).
+# Use LOUD variable to turn on/off trace. Defaults to YES (on).
 export LOUD=${LOUD:-YES}; [[ $LOUD = yes ]] && export LOUD=YES
 [[ "$LOUD" != YES ]] && set -x
 
-#############################
-# grid2obs wave model plots 
-#############################
-
-cd $DATA
-
-mkdir -p ${DATA}/stats
-mkdir -p ${DATA}/job_work_dir
-mkdir -p ${DATA}/images
+# Save the master DATA directory root
+export DATA_ROOT=${DATA}
 
 echo "Starting grid2obs_plots for ${MODELNAME}_${RUN}"
 
@@ -46,189 +32,186 @@ echo ' ******************************************'
 echo " *** ${MODELNAME}-${RUN} grid2obs plots ***"
 echo ' ******************************************'
 echo ' '
-echo "Starting at : `date`"
+echo "Starting at : $(date)"
 echo '-------------'
 echo ' '
-[[ "$LOUD" = YES ]] && set -x
-
-#############################
-# get the model .stat files 
-#############################
-set -x
-echo ' '
-echo 'Copying *.stat files :'
-echo '-----------------------------'
 [[ "$LOUD" = YES ]] && set -x
 
 WFO='ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 
 for wfo in ${WFO}; do
-	export wfo=$wfo
-	plot_start_date=${PDYm90}
-	plot_end_date=${VDATE}
+    export wfo=$wfo
+    
+    # Create an isolated workspace for this specific WFO
+    export DATA="${DATA_ROOT}/${wfo}"
+    
+    mkdir -p ${DATA}/stats
+    mkdir -p ${DATA}/job_work_dir
+    mkdir -p ${DATA}/images
+    cd ${DATA}
 
-	theDate=${plot_start_date}
-	while (( ${theDate} <= ${plot_end_date} )); do
-  		EVSINnwps=${COMIN}/stats/${COMPONENT}/${MODELNAME}.${theDate}
-    		if [ -s ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ]; then
-			cp ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ${DATA}/stats/.
-    		else
-	    		echo "WARNING: ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat DOES NOT EXIST"
-    		fi
-    		theDate=$(date --date="${theDate} + 1 day" '+%Y%m%d')
-	done
+    echo ' '
+    echo "Copying *.stat files for ${wfo}:"
+    echo '-----------------------------'
+    [[ "$LOUD" = YES ]] && set -x
 
-####################
-# quick error check 
-####################
-	if [ -s ${DATA}/stats/evs.stats.nwps.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ]; then
-		
-		nc=`ls ${DATA}/stats/evs.stats.nwps.${wfo}*stat | wc -l | awk '{print $1}'`
-		echo " Found ${nc} ${DATA}/stats/evs.stats.nwps.${wfo}*stat file for ${VDATE} "
-		if [ "${nc}" != '0' ]
-			then
-			set -x
-			echo "Successfully copied the NWPS *.stat file for ${VDATE}"
-			[[ "$LOUD" = YES ]] && set -x
-		else
-			set -x
-			echo ' '
-			echo '**************************************** '
-			echo '*** WARNING: NO NWPS *.stat FILES *** '
-			echo "             for ${wfo} at ${VDATE} "
-			echo '**************************************** '
-			echo ' '
-			echo "${MODELNAME}_${RUN} $VDATE $vhour : NWPS *.stat files missing."
-			[[ "$LOUD" = YES ]] && set -x
-			continue # This will skip the rest of the loop for this WFO
-		fi
-	else
-		echo "WARNING: ${DATA}/stats/evs.stats.nwps.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat DOES NOT EXIST"
-	fi
-#################################
-## Make the command files for cfp 
-#################################
-	# time_series
-	${USHevs}/${COMPONENT}/evs_wave_timeseries.sh
-	export err=$?; err_chk
+    plot_start_date=${PDYm90}
+    plot_end_date=${VDATE}
 
-	# lead_averages
-	${USHevs}/${COMPONENT}/evs_wave_leadaverages.sh
-	export err=$?; err_chk
+    theDate=${plot_start_date}
+    while (( ${theDate} <= ${plot_end_date} )); do
+        EVSINnwps=${COMIN}/stats/${COMPONENT}/${MODELNAME}.${theDate}
+        if [ -s ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ]; then
+            cp ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat ${DATA}/stats/.
+        else
+            echo "WARNING: ${EVSINnwps}/evs.stats.${MODELNAME}.${wfo}.${RUN}.${VERIF_CASE}.v${theDate}.stat DOES NOT EXIST"
+        fi
+        theDate=$(date --date="${theDate} + 1 day" '+%Y%m%d')
+    done
 
-###########################################
-# Run the command files for the PAST31DAYS 
-###########################################
-	cd ${DATA}
-	chmod 775 ${DATA}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-	if [ ${run_mpi} = 'yes' ] ; then
-		mpiexec -np 200 -ppn 100 --cpu-bind verbose,depth cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-	else
-		echo "not running mpiexec"
-		sh plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-	fi
+    ####################
+    # quick error check 
+    ####################
+    # Check for files specifically inside this WFO's stats sandbox
+    nc=$(ls ${DATA}/stats/evs.stats.${MODELNAME}.${wfo}*stat 2>/dev/null | wc -l | awk '{print $1}')
+    
+    if [ "${nc}" != '0' ] && [ -n "${nc}" ]; then
+        set -x
+        echo "Successfully found ${nc} NWPS *.stat file(s) for ${wfo} up to ${VDATE}"
+        [[ "$LOUD" = YES ]] && set -x
+    else
+        set -x
+        echo ' '
+        echo '**************************************** '
+        echo '*** WARNING: NO NWPS *.stat FILES *** '
+        echo "             for ${wfo} at ${VDATE} "
+        echo '**************************************** '
+        echo ' '
+        echo "${MODELNAME}_${RUN} $VDATE : NWPS *.stat files missing for ${wfo}."
+        [[ "$LOUD" = YES ]] && set -x
+        continue # Safely skips the rest of the loop for this WFO without breaking the others
+    fi
 
+    #################################
+    ## Make the command files for cfp 
+    #################################
+    # time_series
+    ${USHevs}/${COMPONENT}/evs_wave_timeseries.sh
+    export err=$?; err_chk
 
-############################
-#  copy all the jobs files
-############################
-        ${USHevs}/${COMPONENT}/nwps_wave_plots_copy_plots.sh
-        export err=$?; err_chk
+    # lead_averages
+    ${USHevs}/${COMPONENT}/evs_wave_leadaverages.sh
+    export err=$?; err_chk
 
+    ###########################################
+    # Run the command files for the PAST31DAYS 
+    ###########################################
+    chmod 775 ${DATA}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+    if [ "${run_mpi}" = 'yes' ] ; then
+        mpiexec -np 200 -ppn 100 --cpu-bind verbose,depth cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+    else
+        echo "not running mpiexec"
+        sh plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+    fi
 
-#####################
-# Gather all the files 
-#######################
+    ############################
+    #  copy all the jobs files
+    ############################
+    ${USHevs}/${COMPONENT}/nwps_wave_plots_copy_plots.sh
+    export err=$?; err_chk
 
-	periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
-	if [ $gather = yes ] ; then
-		if [ "$(ls -A "${DATA}/images")" ]; then
-		echo "Found ${DATA}/images/*.png "
-		nc=$(ls ${DATA}/images/*.png | wc -l | awk '{print $1}')
-		for period in ${periods} ; do
-			period_lower=$(echo ${period,,})
-			if [ ${period} = 'LAST31DAYS' ] ; then
-				period_out='last31days'
-			elif [ ${period} = 'LAST90DAYS' ] ; then
-				period_out='last90days'
-			fi
+    #####################
+    # Gather all the files 
+    #######################
+    periods=$(echo "$EVAL_PERIOD" | tr '[:lower:]' '[:upper:]')
+    if [ "$gather" = "yes" ] ; then
+        if [ "$(ls -A "${DATA}/images")" ]; then
+            echo "Found ${DATA}/images/*.png "
+            nc_images=$(ls ${DATA}/images/*.png | wc -l | awk '{print $1}')
+            
+            for period in ${periods} ; do
+                period_lower=$(echo ${period,,})
+                if [ "${period}" = 'LAST31DAYS' ] ; then
+                    period_out='last31days'
+                elif [ "${period}" = 'LAST90DAYS' ] ; then
+                    period_out='last90days'
+                else
+                    period_out=${period_lower}
+                fi
 
-			# check to see if the plots are there
-			if [ "${nc}" != '0' ]; then
+                # check to see if the plots are there
+                if [ "${nc_images}" != '0' ]; then
+                    set -x
+                    echo "Found ${nc_images} ${period_lower} plots for ${VDATE}"
+                    [[ "$LOUD" = YES ]] && set -x
+                else
+                    set -x
+                    echo ' '
+                    echo '**************************************** '
+                    echo "*** FATAL ERROR: NO ${period} PLOTS   *** "
+                    echo "        found for ${VDATE} "
+                    echo '**************************************** '
+                    echo ' '
+                    echo "${MODELNAME}_${RUN} ${VDATE} ${period}: PLOTS are missing for ${wfo}."
+                    [[ "$LOUD" = YES ]] && set -x
+            
+                    err_exit "FATAL ERROR: Did not find any ${period} plots for ${VDATE}"
+                fi                                                                                                                                                                                      
+                
+                # tar and copy them to the final destination
+                if [ "${nc_images}" -gt '0' ] ; then
+                    cd ${DATA}/images
+                    tar -cvf evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar evs.*${period_lower}*_${wfo}.png
+                fi
+                
+                if [ "$SENDCOM" = "YES" ]; then
+                    if [ -s evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar ]; then
+                        cp -v evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar ${COMOUTplots}/evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar
+                    fi
+                fi
+                
+                if [ "$SENDDBN" = "YES" ]; then
+                    $DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job ${COMOUTplots}/${NET}.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar
+                fi
+            done
+        else
+            echo "Found no png images for ${wfo}. Folder is empty"
+        fi
+    else  
+        echo "not copying the plots"
+    fi
 
-				set -x
-				echo "Found ${nc} ${period_lower} plots for ${VDATE}"
-				[[ "$LOUD" = YES ]] && set -x
-			else
-				set -x
-				echo ' '
-				echo '**************************************** '
-				echo "*** FATAL ERROR: NO ${period} PLOTS  *** "
-				echo "    found for ${VDATE} "
-				echo '**************************************** '
-				echo ' '
-				echo "${MODELNAME}_${RUN} ${VDATE} ${period}: PLOTS are missing."
-				[[ "$LOUD" = YES ]] && set -x
-		
-				"FATAL ERROR : NO ${period} PLOTS FOR ${VDATE}"
-				err_exit "FATAL ERROR: Did not find any ${period} plots for ${VDATE}"
-			fi    	    	                                                                                                                                                                                                    		
-				# tar and copy them to the final destination
-
-			if [ "${nc}" > '0' ] ; then
-				cd ${DATA}/images
-				tar -cvf evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar evs.*${period_lower}*_${wfo}.png
-			fi
-			if [ $SENDCOM = YES ]; then
-				if [ -s evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar ]; then
-					cp -v evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar ${COMOUTplots}/evs.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar
-				fi
-			fi
-			if [ $SENDDBN = YES ]; then
-				$DBNROOT/bin/dbn_alert MODEL EVS_RZDM $job ${COMOUTplots}/${NET}.${STEP}.${COMPONENT}.${wfo}.${RUN}.${VERIF_CASE}.${period_out}.v${VDATE}.tar
-			fi
-
-		done
-		else
-		echo "Found no png images. Folder is empty"
-		fi
-
-
-	else  
-		echo "not copying the plots"
-	fi
-
-	msg="JOB $job HAS COMPLETED NORMALLY."
+    msg="JOB $job FOR ${wfo} HAS COMPLETED NORMALLY."
 
 done
+
 #########################################
 # copy log files into logs and cat them
 #########################################
+# Set working directory back to global root to find all sandboxed logs
+cd ${DATA_ROOT}
+log_dir="${DATA_ROOT}/*/job_work_dir/*/logs"
 
-cd ${DATA}
-log_dir=$DATA/job_work_dir/*/logs
-
-log_file_count=$(find ${DATA} -type f -name "*.out" -o -name ".log" |wc -l)
+log_file_count=$(find ${DATA_ROOT} -type f \( -name "*.out" -o -name "*.log" \) | wc -l)
 if [[ $log_file_count -ne 0 ]]; then
-	for log_file in $log_dir/*; do
-		echo "Start: $log_file"
-		cat $log_file
-
-		echo "End: $log_file"
-	done
+    for log_file in $log_dir; do
+        if [ -f "$log_file" ]; then
+            echo "Start: $log_file"
+            cat "$log_file"
+            echo "End: $log_file"
+        fi
+    done
 fi
-
 
 # --------------------------------------------------------------------------- #
 # Ending output 
-#
 set -x
 echo ' '
-echo "Ending at : `date`"
+echo "Ending at : $(date)"
 echo ' '
 echo " *** End of ${MODELNAME}-${RUN} grid2obs stat *** "
 echo ' '
 [[ "$LOUD" = YES ]] && set -x
 
 
-# End of NWPS grid2obs plots script ------------------------------------- #
+

--- a/ush/nwps/evs_wave_leadaverages.sh
+++ b/ush/nwps/evs_wave_leadaverages.sh
@@ -21,7 +21,7 @@ ptype='lead_average'
 
 export GRID2OBS_CONF="${PARMevs}/metplus_config/${STEP}/${COMPONENT}/${RUN}_${VERIF_CASE}"
 
-cd ${DATA}
+cd ${DATA_wfo}
 export wfo=$wfo
 touch plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
 
@@ -35,13 +35,13 @@ for period in ${periods} ; do
   for vhr in ${inithours} ; do
     for wvar in ${wave_vars} ; do
       for stats in ${stats_list}; do
-	job_work_dir=${DATA}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}      
+	job_work_dir=${DATA_wfo}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}      
 	echo "export VX_MASK_LIST=${MASK} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export VERIF_CASE=${VERIF_CASE} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export RUN=${RUN} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export USHevs=${USHevs}/${COMPONENT} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export FIXevs=${FIXevs}  " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
-        echo "export DATA=${DATA} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
+        echo "export DATA_wfo=${DATA_wfo} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export MODNAM=${MODNAM} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export PERIOD=${period} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         echo "export VERIF_CASE=${VERIF_CASE} " >> plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
@@ -85,7 +85,7 @@ for period in ${periods} ; do
         
         chmod +x plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh
         
-        echo "${DATA}/plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh" >> plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+        echo "${DATA_wfo}/plot_${wfo}_${wvar}_${vhr}_${stats}_${ptype}_${period}.sh" >> plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
         
       done  # end of stats
     done  # end of wave vars

--- a/ush/nwps/evs_wave_timeseries.sh
+++ b/ush/nwps/evs_wave_timeseries.sh
@@ -19,7 +19,7 @@ stats_list='stats1 stats2 stats3 stats4 stats5'
 ptype='time_series'
 
 export GRID2OBS_CONF="${PARMevs}/metplus_config/${STEP}/${COMPONENT}/${RUN}_${VERIF_CASE}"
-cd ${DATA}
+cd ${DATA_wfo}
 
 # write the commands
 
@@ -35,13 +35,13 @@ for period in ${periods} ; do
 		for wvar in ${wave_vars} ; do
 			for stats in ${stats_list}; do
 				for fhr in ${fhrs} ; do
-					job_work_dir=${DATA}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}
+					job_work_dir=${DATA_wfo}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}
 					echo "export VX_MASK_LIST=${MASK} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh	
 					echo "export VERIF_CASE=${VERIF_CASE} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
 					echo "export RUN=${RUN} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
 					echo "export USHevs=${USHevs}/${COMPONENT} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
 					echo "export FIXevs=${FIXevs}  " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
-					echo "export DATA=${DATA} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
+					echo "export DATA_wfo=${DATA_wfo} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
 					echo "export MODNAM=${MODNAM} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
 					echo "export PERIOD=${period} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
 					echo "export VERIF_CASE=${VERIF_CASE} " >> plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
@@ -86,7 +86,7 @@ for period in ${periods} ; do
   
 					chmod +x plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh
           
-					echo "${DATA}/plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh" >> plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
+					echo "${DATA_wfo}/plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_${ptype}_${period}.sh" >> plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
           
 				done  # fcst hrs
 			done  # end of stats

--- a/ush/nwps/nwps_wave_plots_copy_plots.sh
+++ b/ush/nwps/nwps_wave_plots_copy_plots.sh
@@ -4,7 +4,7 @@
 # Name of Script: evs_wave_timeseries.sh
 # Developed for EVS-NWPS: Samira Ardani (samira.ardani@noaa.gov)                   
 # Cited to: Mallory Rows's work for global_det component.     
-# Purpose of Script: Copy individual plot from tmp directory in $DATA to job working directory to address mpmd (03/2025)   
+# Purpose of Script: Copy individual plot from tmp directory in $DATA_wfo to job working directory to address mpmd (03/2025)   
 
 #######################################
 # Copy the plots to a common directory
@@ -61,8 +61,8 @@ for small_period in ${small_periods} ; do
 				# Lead average plots
 				for fhr in ${fhrs}; do
 					imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.fhrmean_valid${vhr}z_f${fhr}.${region}.png
-            				tmp_image=$DATA/images/$imagename
-					job_work_dir=${DATA}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${stats}_lead_average_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
+            				tmp_image=$DATA_wfo/images/$imagename
+					job_work_dir=${DATA_wfo}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${stats}_lead_average_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
 					job_image=$job_work_dir/images/$imagename
 					if [[ ! -s $tmp_image ]]; then
 						if [[ -s $job_image ]]; then
@@ -75,8 +75,8 @@ for small_period in ${small_periods} ; do
 				# Time series plots
 				for fhr in ${fhrs} ; do
 					imagename=evs.${COMPONENT}.${image_stat}.${w_var}_${image_level}_${obstype}.${small_period}.timeseries_valid${vhr}z_f${fhr}.${region}.png
-            				tmp_image=$DATA/images/$imagename
-					job_work_dir=${DATA}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_time_series_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
+            				tmp_image=$DATA_wfo/images/$imagename
+					job_work_dir=${DATA_wfo}/job_work_dir/plot_${wfo}_${wvar}_${vhr}_${fhr}_${stats}_time_series_$(echo ${small_period} | tr '[a-z]' '[A-Z]')
 					job_image=$job_work_dir/images/$imagename
 					if [[ ! -s $tmp_image ]]; then
 						if [[ -s $job_image ]]; then


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

When running the verification script, running the entire suite of Weather Forecast Offices (WFOs) yielded different visual and data outputs than running a single WFO individually. This behavior was tracked down to a lack of file-space isolation between loop iterations. Subsequent iterations were inheriting and/or overwriting files (e.g., in the shared `${DATA}/images` and `${DATA}/stats` directories), leading to data pollution.
To resolve this, this PR introduces strict WFO Sandboxing alongside various modernizations, structural optimizations, and syntax bug fixes.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
No.
* Do you have any planned upcoming annual leave/PTO?
No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No.  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
Restart capability is not required for this component since this component is in dev.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

### 1. Environment Preparation
Clone the feature branch: `bugfix/EVS-NWPS_plots_fix`
Set `$HOMEevs` to your local test directory:
`HOMEevs=/path/to/your/local/test/directory`
Link the necessary fix files:
`mkdir -p $HOMEevs/fix`
`ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* $HOMEevs/fix/`
### 2. Test Implementation
Run all **plots** driver scripts and in each driver script apply these changes:

In `$COMIN`, replace `${USER}` with `emc.vpppg`:
`export COMIN=/lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/${evs_ver_2d}`
Set test-specific flags:
`export KEEPDATA=YES`
`export SENDMAIL=NO`
### 3. Job Submission
`qsub $HOMEevs/dev/drivers/scripts/plots/nwps/*` 