### PR TITLE
Feature/update aigfs version

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -37,7 +37,7 @@ export wgrib2_ver=2.0.8
 export zlib_ver=1.2.11
 
 export aigefs_ver=v1.0
-export aigfs_ver=v1.0
+export aigfs_ver=v1.1
 export aqm_ver=v7.0
 export ccpa_ver=v4.2
 export cfs_ver=v2.3


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

update the AIGFS version from v1.0 to v1.1 in run.ver

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? NO
* Do you have any planned upcoming annual leave/PTO? NO
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? NO
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

Make prtest directory
git clone https://github.com/QiShi-NOAA/EVS.git
cd EVS
git checkout Feature/update_aigfs_version
symlink the EVS_fix directory locally as "fix"

test the following script:
dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh


