### PR TITLE
Refactor/cam/change pdy

### DIFF
--- a/jobs/JEVS_PLOTS_CAM
+++ b/jobs/JEVS_PLOTS_CAM
@@ -69,24 +69,22 @@ setpdy.sh 31
 . ./PDY
 
 if [ $MODELNAME = refs ] ; then
-   export VDATE=${VDATE:-$PDYm2}
-   export INITDATE=${INITDATE:-$PDYm2}
-   export eval_period=${EVAL_PERIOD:-last90days}
+    export VDATE=${VDATE:-$PDYm2}
+    export INITDATE=${INITDATE:-$PDYm2}
+    export eval_period=${EVAL_PERIOD:-last90days}
 elif [[ "$MODELNAME" == "rrfs" && "$RUN" == chem* ]]; then
     export VDATE_END=${VDATE_END:-${PDYm4}}
     export NDAYS=${NDAYS:-31}
     export VDATE_START=${VDATE_START:-$(finddate.sh ${VDATE_END} d-$((${NDAYS}-1)))}
+elif [ $VERIF_CASE = severe ] ; then
+    export VDATE=${VDATE:-$PDYm7}
+    export EVAL_PERIOD=${EVAL_PERIOD:-last90days}
+elif [ $VERIF_CASE = headline ] ; then
+    export VDATE=${VDATE:-$PDYm1}
+    export EVAL_PERIOD=${EVAL_PERIOD:-last90days}
 else
-   if [ $VERIF_CASE = severe ] ; then
-      export VDATE=${VDATE:-$PDYm7}
-      export EVAL_PERIOD=${EVAL_PERIOD:-last90days}
-   elif [ $VERIF_CASE = radar ] ; then
-      export VDATE=${VDATE:-$PDYm2}
-      export EVAL_PERIOD=${EVAL_PERIOD:-last90days}
-   else
-      export VDATE=${VDATE:-$PDYm1}
-      export EVAL_PERIOD=${EVAL_PERIOD:-last90days}
-   fi
+    export VDATE=${VDATE:-$PDYm2}
+    export EVAL_PERIOD=${EVAL_PERIOD:-last90days}
 fi
 
 


### PR DESCRIPTION
## Description of Changes

This PR moves the VDATE setting in EVS cam det grid2obs, precip, and snowfall plots jobs from PDYm1 to PDYm2.  This change better matches the timing of available statistics, and provides additional flexibility for setting the submission times of these jobs.  

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, it responds to RRFS-related changes in EVS that will be delivered in August 2026
* Do you have any planned upcoming annual leave/PTO?
    * August 10-14
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

I'm not sure we need to test anything; I think a few eyes on the changes will be sufficient.  

Let me know what you think in the thread below; we can decide there and I can update these instructions if needed.