### PR TITLE
Update transfer_evs_plots.list

### DIFF
--- a/parm/transfer/transfer_evs_plots.list
+++ b/parm/transfer/transfer_evs_plots.list
@@ -38,6 +38,9 @@ _COMROOT_/evs/_SHORTVER_/plots/
 + /cam/*._PDYm3_/***
 + /cam/*._PDYm2_/***
 + /cam/*._PDYm1_/***
++ /global_chem/
++ /global_chem/*._PDYm5_/***
++ /global_chem/*._PDYm4_/***
 + /global_det/
 + /global_det/*._PDYm2_/
 + /global_det/*._PDYm2_/*.tar


### PR DESCRIPTION
## Description of Changes

In preparing the EVS v2.0.12 release candidate I noticed the release branches and develop have differing transfer plot files. develop is missing global_che,

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes 
* Do you have any planned upcoming annual leave/PTO?
   * No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  * No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

None
