### PR TITLE
Fix typo in evs-nco.def

### DIFF
--- a/ecf/defs/evs-nco.def
+++ b/ecf/defs/evs-nco.def
@@ -2023,7 +2023,7 @@ suite evs_nco
             task jevs_plots_cam_severe_nbrctc_last90days
               trigger (:TIME >= 1700 or :TIME < 2300)
               edit VHR '17'
-            task evs_plots_cam_snowfall_last90days
+            task jevs_plots_cam_snowfall_last90days
               trigger (:TIME >= 1600 or :TIME < 2200)
               edit VHR '16'
           endfamily 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes
Found a typo in evs-nco.def

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes
* Do you have any planned upcoming annual leave/PTO?
    * No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  * No
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

None
