### PR TITLE
Create single reference for setting MAILTO

### DIFF
--- a/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
@@ -55,7 +55,7 @@ echo $vhr
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'samira.ardani@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_PLOTS_ANALYSES

--- a/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
+++ b/dev/drivers/scripts/plots/analyses/jevs_plots_analyses_grid2obs_last31days.sh
@@ -55,7 +55,7 @@ echo $vhr
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}_last31days}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'samira.ardani@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_PLOTS_ANALYSES

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last31days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last31days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=31
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last31days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last31days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=31
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last90days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2grid_hourly_last90days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last31days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last31days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=daily
 export NDAYS=31
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last31days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last31days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=daily
 export NDAYS=31
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last90days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=daily
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_daily_last90days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=daily
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last31days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last31days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=31
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last31days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last31days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=31
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last90days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_atmos_grid2obs_hourly_last90days.sh
@@ -61,7 +61,7 @@ export nproc=128    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=hourly
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_headline_grid2obs_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_headline_grid2obs_last90days.sh
@@ -61,7 +61,7 @@ export nproc=1    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=daily
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_headline_grid2obs_last90days.sh
+++ b/dev/drivers/scripts/plots/aqm/jevs_plots_aqm_headline_grid2obs_last90days.sh
@@ -61,7 +61,7 @@ export nproc=1    ## nproc must match with the ncpus allocation above
 export DATA_TYPE=daily
 export NDAYS=90
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.sh
@@ -59,7 +59,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-YES}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last31days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrcnt_last90days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last31days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_severe_nbrctc_last90days.sh
@@ -58,7 +58,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export USE_CFP=${USE_CFP:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/aigefs/jevs_prep_aigefs_atmos.sh
+++ b/dev/drivers/scripts/prep/aigefs/jevs_prep_aigefs_atmos.sh
@@ -36,7 +36,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/aigefs/jevs_prep_aigefs_atmos.sh
+++ b/dev/drivers/scripts/prep/aigefs/jevs_prep_aigefs_atmos.sh
@@ -36,7 +36,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov' 
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2grid.sh
@@ -51,7 +51,7 @@ export SENDDBN=NO
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
  
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2grid.sh
@@ -51,7 +51,7 @@ export SENDDBN=NO
 export COMIN=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
  
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2obs.sh
@@ -52,7 +52,7 @@ export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
  
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/prep/aqm/jevs_prep_aqm_atmos_grid2obs.sh
@@ -52,7 +52,7 @@ export KEEPDATA=NO
 export SENDMAIL=YES
 export SENDDBN=NO
  
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_precip.sh
@@ -47,7 +47,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_CAM

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_precip.sh
@@ -47,7 +47,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_CAM

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_severe.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_hrrr_severe.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_radar.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_radar.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_radar.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_radar.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
@@ -55,7 +55,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export SENDMAIL=${SENDMAIL:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_refs_severe.sh
@@ -55,7 +55,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export SENDMAIL=${SENDMAIL:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -57,7 +57,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 ## CALL executable job script here
 #############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh
@@ -57,7 +57,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 ## CALL executable job script here
 #############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_precip.sh
@@ -47,7 +47,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_CAM

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_precip.sh
@@ -47,7 +47,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_CAM

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_severe.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_severe.sh
@@ -55,7 +55,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_precip.sh
@@ -48,7 +48,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_CAM

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_precip.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_precip.sh
@@ -48,7 +48,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_PREP_CAM

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfsmem_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_severe.sh
@@ -54,7 +54,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/cam/jevs_prep_cam_severe.sh
+++ b/dev/drivers/scripts/prep/cam/jevs_prep_cam_severe.sh
@@ -54,7 +54,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh
@@ -63,7 +63,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 ## CALL executable job script here
 #############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/prep/global_chem/jevs_prep_global_chem_atmos_grid2obs.sh
@@ -63,7 +63,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 ## CALL executable job script here
 #############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
@@ -29,8 +29,6 @@ source $HOMEevs/dev/modulefiles/global_det/global_det_prep.sh
 
 evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=prep
@@ -44,6 +42,8 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT/
 
 export MODELNAME="cfs cmc cmc_regional dwd fnmoc gfs aigfs jma metfra ukmet ecmwf"
 export OBSNAME="osi_saf ghrsst_ospo ccpa_accum24hr prepbufr_gdas prepbufr_rrfs"
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_PREP_GLOBAL_DET

--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_atmos.sh
@@ -29,7 +29,7 @@ source $HOMEevs/dev/modulefiles/global_det/global_det_prep.sh
 
 evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_wave.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_wave.sh
@@ -29,8 +29,6 @@ source $HOMEevs/dev/modulefiles/global_det/global_det_prep.sh
 
 evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=prep
@@ -44,6 +42,8 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT/
 
 export MODELNAME="gfs"
 export OBSNAME="prepbufr_gdas ndbc jason3"
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_PREP_GLOBAL_DET

--- a/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_wave.sh
+++ b/dev/drivers/scripts/prep/global_det/jevs_prep_global_det_wave.sh
@@ -29,7 +29,7 @@ source $HOMEevs/dev/modulefiles/global_det/global_det_prep.sh
 
 evs_ver_2d=$(echo $evs_ver | cut -d'.' -f1-2)
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
@@ -40,7 +40,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov' 
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
@@ -40,7 +40,7 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_headline.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_headline.sh
@@ -41,7 +41,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export run_mpi=no
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_headline.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_headline.sh
@@ -41,7 +41,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export run_mpi=no
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_naefs_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_naefs_atmos.sh
@@ -43,7 +43,7 @@ export get_gefs_bc_apcp24h=yes
 export get_model_bc=yes
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_naefs_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_naefs_atmos.sh
@@ -43,7 +43,7 @@ export get_gefs_bc_apcp24h=yes
 export get_model_bc=yes
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_wave.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_wave.sh
@@ -42,7 +42,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export KEEPDATA=${KEEPDATA:-NO}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ## developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_wave.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_wave.sh
@@ -42,7 +42,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-YES}
 export KEEPDATA=${KEEPDATA:-NO}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ## developers directories
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp

--- a/dev/drivers/scripts/prep/glwu/jevs_prep_glwu_wave_grid2obs.sh
+++ b/dev/drivers/scripts/prep/glwu/jevs_prep_glwu_wave_grid2obs.sh
@@ -48,7 +48,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export SENDMAIL=${SENDMAIL:-YES}
 
-export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 
 # developers directories

--- a/dev/drivers/scripts/prep/glwu/jevs_prep_glwu_wave_grid2obs.sh
+++ b/dev/drivers/scripts/prep/glwu/jevs_prep_glwu_wave_grid2obs.sh
@@ -48,7 +48,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export SENDMAIL=${SENDMAIL:-YES}
 
-export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'
 
 
 # developers directories

--- a/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh
+++ b/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh
@@ -48,7 +48,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export SENDMAIL=${SENDMAIL:-YES}
 
-export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 
 # developers directories

--- a/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh
+++ b/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh
@@ -48,7 +48,7 @@ export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 export SENDMAIL=${SENDMAIL:-YES}
 
-export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'
 
 
 # developers directories

--- a/dev/drivers/scripts/prep/rtofs/jevs_prep_rtofs.sh
+++ b/dev/drivers/scripts/prep/rtofs/jevs_prep_rtofs.sh
@@ -39,7 +39,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_PREP_RTOFS

--- a/dev/drivers/scripts/prep/rtofs/jevs_prep_rtofs.sh
+++ b/dev/drivers/scripts/prep/rtofs/jevs_prep_rtofs.sh
@@ -39,7 +39,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_PREP_RTOFS

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.sh
@@ -31,7 +31,7 @@ export SITE=$(cat /etc/cluster_name)
 export KEEPDATA=NO
 export SENDMAIL=YES
 
-export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov,mallory.row@noaa.gov'
 
 export USER=$USER
 export ACCOUNT=VERF-DEV

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_cfs.sh
@@ -31,8 +31,6 @@ export SITE=$(cat /etc/cluster_name)
 export KEEPDATA=NO
 export SENDMAIL=YES
 
-export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov,mallory.row@noaa.gov'
-
 export USER=$USER
 export ACCOUNT=VERF-DEV
 export QUEUE=dev
@@ -52,6 +50,8 @@ export PREP_TYPE=cfs
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN
 
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.cfs.prep
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Call executable job script
 $HOMEevs/jobs/JEVS_PREP_SUBSEASONAL

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -31,7 +31,7 @@ export SITE=$(cat /etc/cluster_name)
 export KEEPDATA=NO
 export SENDMAIL=YES
 
-export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov,mallory.row@noaa.gov'
 
 export USER=$USER
 export ACCOUNT=VERF-DEV

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_gefs.sh
@@ -31,8 +31,6 @@ export SITE=$(cat /etc/cluster_name)
 export KEEPDATA=NO
 export SENDMAIL=YES
 
-export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov,mallory.row@noaa.gov'
-
 export USER=$USER
 export ACCOUNT=VERF-DEV
 export QUEUE=dev
@@ -53,6 +51,8 @@ export PREP_TYPE=gefs
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN
 
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.gefs.prep
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Call executable job script
 $HOMEevs/jobs/JEVS_PREP_SUBSEASONAL

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
@@ -31,7 +31,7 @@ export SITE=$(cat /etc/cluster_name)
 export KEEPDATA=NO
 export SENDMAIL=YES
 
-export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov,mallory.row@noaa.gov'
 
 export USER=$USER
 export ACCOUNT=VERF-DEV

--- a/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
+++ b/dev/drivers/scripts/prep/subseasonal/jevs_prep_subseasonal_obs.sh
@@ -31,8 +31,6 @@ export SITE=$(cat /etc/cluster_name)
 export KEEPDATA=NO
 export SENDMAIL=YES
 
-export MAILTO='alicia.bentley@noaa.gov,shannon.shields@noaa.gov,mallory.row@noaa.gov'
-
 export USER=$USER
 export ACCOUNT=VERF-DEV
 export QUEUE=dev
@@ -52,6 +50,8 @@ export PREP_TYPE=obs
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/${evs_ver_2d}/$STEP/$COMPONENT/$RUN
 
 export config=$HOMEevs/parm/evs_config/subseasonal/config.evs.subseasonal.obs.prep
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Call executable job script
 $HOMEevs/jobs/JEVS_PREP_SUBSEASONAL

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_aigefs_atmos_precip.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2grid.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_gefs_atmos_precip.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2grid.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/aigefs/jevs_stats_aigefs_hgefs_atmos_precip.sh
@@ -37,6 +37,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export KEEPDATA=NO
 export SENDMAIL=NO
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_AIGEFS

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=ccpa
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_ccpa_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=ccpa
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
@@ -56,7 +56,7 @@ export MODELNAME=rtma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_grid2obs.sh
@@ -56,7 +56,7 @@ export MODELNAME=rtma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=rtma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=rtma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
@@ -54,7 +54,7 @@ export MODELNAME=rtma_ru
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_rtma_ru_grid2obs.sh
@@ -54,7 +54,7 @@ export MODELNAME=rtma_ru
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
@@ -54,7 +54,7 @@ export mod_ver=${urma_ver}
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_grid2obs.sh
@@ -54,7 +54,7 @@ export mod_ver=${urma_ver}
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=urma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
+++ b/dev/drivers/scripts/stats/analyses/jevs_stats_analyses_urma_precip.sh
@@ -56,7 +56,7 @@ export MODELNAME=urma
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'mallory.row@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'andrew.benjamin@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_ANALYSES

--- a/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2grid.sh
@@ -53,7 +53,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
 
 ########################################################################
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2grid.sh
@@ -53,7 +53,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/${NET}/${evs_ver_2d}
 
 ########################################################################
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2obs.sh
@@ -53,7 +53,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 ########################################################################
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/aqm/jevs_stats_aqm_atmos_grid2obs.sh
@@ -53,7 +53,7 @@ export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/${NET}/${evs_ver_2d}
 
 ########################################################################
 
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_grid2obs.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_grid2obs.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_precip.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_precip.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_radar.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_radar.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_snowfall.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_hrrr_snowfall.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_grid2obs.sh
@@ -58,7 +58,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}
-  export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov"
+  export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_grid2obs.sh
@@ -58,7 +58,7 @@ export PYTHONPATH=$HOMEevs/ush/$COMPONENT:$PYTHONPATH
   export COMOUT=/lfs/h2/emc/vpppg/noscrub/${USER}/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
   export vhr=${vhr:-${vhr}}
-  export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov"
+  source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_precip.sh
@@ -37,7 +37,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_precip.sh
@@ -37,7 +37,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_snowfall.sh
@@ -37,7 +37,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov"
+export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov"
 
 export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rap_snowfall.sh
@@ -37,7 +37,7 @@ export USE_CFP=YES
 export nproc=128  
 export evs_run_mode="production"
 
-export MAILTO="marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 export config=$HOMEevs/parm/evs_config/cam/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_grid2obs.sh
@@ -40,7 +40,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 if [ -z "$MAILTO" ]; then
 
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_grid2obs.sh
@@ -40,7 +40,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
 if [ -z "$MAILTO" ]; then
 
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_precip.sh
@@ -42,7 +42,7 @@ export verif_precip=yes
 export verif_snowfall=no
 export gather=yes
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_precip.sh
@@ -42,7 +42,7 @@ export verif_precip=yes
 export verif_snowfall=no
 export gather=yes
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
@@ -58,7 +58,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_radar.sh
@@ -58,7 +58,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_snowfall.sh
@@ -42,7 +42,7 @@ export verif_precip=no
 export verif_snowfall=yes
 export gather=yes
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_snowfall.sh
@@ -42,7 +42,7 @@ export verif_precip=no
 export verif_snowfall=yes
 export gather=yes
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_spcoutlook.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_spcoutlook.sh
@@ -39,7 +39,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov'
+export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
 if [ -z "$MAILTO" ]; then
 
   echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_spcoutlook.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_refs_spcoutlook.sh
@@ -39,7 +39,7 @@ export envir=prod
 export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO='andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 if [ -z "$MAILTO" ]; then
 
   echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh
@@ -54,7 +54,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
     echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_aeronet_aod.sh
@@ -54,7 +54,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
     echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
@@ -55,7 +55,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm10.sh
@@ -55,7 +55,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
@@ -55,7 +55,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_chem_grid2obs_airnow_pm25.sh
@@ -55,7 +55,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs.sh
@@ -47,7 +47,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_firewxnest_grid2obs.sh
@@ -47,7 +47,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_grid2obs.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_precip.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_precip.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_radar.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_radar.sh
@@ -59,7 +59,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_severe.sh
@@ -56,7 +56,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_snowfall.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfs_snowfall.sh
@@ -48,7 +48,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_grid2obs.sh
@@ -49,7 +49,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_grid2obs.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_grid2obs.sh
@@ -49,7 +49,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_precip.sh
@@ -49,7 +49,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_precip.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_precip.sh
@@ -49,7 +49,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_radar.sh
@@ -60,7 +60,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_radar.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_radar.sh
@@ -60,7 +60,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_severe.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov'}
+export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_severe.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_severe.sh
@@ -57,7 +57,7 @@ export SENDECF=${SENDECF:-YES}
 export SENDDBN=${SENDDBN:-NO}
 export KEEPDATA=${KEEPDATA:-NO}
 
-export MAILTO=${MAILTO:-'marcel.caron@noaa.gov,andrew.benjamin@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
 

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_snowfall.sh
@@ -49,7 +49,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov"
+export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_snowfall.sh
+++ b/dev/drivers/scripts/stats/cam/jevs_stats_cam_rrfsmem_snowfall.sh
@@ -49,7 +49,7 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 export vhr=${vhr:-${vhr}}
-export MAILTO="andrew.benjamin@noaa.gov,marcel.caron@noaa.gov,mallory.row@noaa.gov"
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # Job Settings and Run
 . ${HOMEevs}/jobs/JEVS_STATS_CAM

--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
@@ -56,7 +56,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
     echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_aeronet.sh
@@ -56,7 +56,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
     echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
@@ -57,7 +57,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov'}
+export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov,mallory.row@noaa.gov'}
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
+++ b/dev/drivers/scripts/stats/global_chem/jevs_stats_global_chem_atmos_grid2obs_airnow.sh
@@ -57,7 +57,7 @@ export jobid=$job.${PBS_JOBID:-$$}
 ############################################################
 # CALL executable job script here
 ############################################################
-export MAILTO=${MAILTO:-'ho-chun.huang@noaa.gov,alicia.bentley@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_aigfs_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=40
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=40
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=28
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cfs_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=28
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=31
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=31
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=11
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_cmc_regional_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=11
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=11
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_dwd_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=11
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=53
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=53
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ecmwf_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=20
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=20
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,9 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_fnmoc_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_daily.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_daily.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export TMPDIR=$DATAROOT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_daily.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_daily.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_monthly.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_monthly.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export TMPDIR=$DATAROOT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_monthly.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_atmos_wmo_monthly.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=128
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.sh
@@ -35,8 +35,6 @@ export nproc=25
 
 export OMP_NUM_THREADS=1
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export DATAROOT=/lfs/h2/emc/stmp/$USER/evs_test/$envir/tmp
 export TMPDIR=$DATAROOT
 export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_gfs_wave_grid2obs.sh
@@ -35,7 +35,7 @@ export nproc=25
 
 export OMP_NUM_THREADS=1
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=43
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=43
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_imd_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=31
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=31
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_jma_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=11
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_metfra_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=11
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=32
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2grid.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=32
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs.sh
@@ -33,8 +33,6 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
-
 export envir=prod
 export NET=evs
 export STEP=stats
@@ -49,6 +47,8 @@ export COMIN=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d
 export COMOUT=/lfs/h2/emc/vpppg/noscrub/$USER/$NET/$evs_ver_2d/$STEP/$COMPONENT
 
 export config=$HOMEevs/parm/evs_config/global_det/config.evs.prod.${STEP}.${COMPONENT}.${RUN}.${VERIF_CASE}.${MODELNAME}
+
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # CALL executable job script here
 $HOMEevs/jobs/JEVS_STATS_GLOBAL_DET

--- a/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_det/jevs_stats_global_det_ukmet_atmos_grid2obs.sh
@@ -33,7 +33,7 @@ export machine=WCOSS2
 export USE_CFP=YES
 export nproc=14
 
-export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,qi.shi@noaa.gov,mallory.row@noaa.gov'
 
 export envir=prod
 export NET=evs

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2grid.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_grid2obs.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip.sh
@@ -39,6 +39,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
 export run_mpi=no
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_precip.sh
@@ -39,6 +39,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
 export run_mpi=no
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall.sh
@@ -38,6 +38,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_atmos_snowfall.sh
@@ -38,6 +38,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_wmo_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_wmo_grid2grid.sh
@@ -42,6 +42,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_wmo_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_wmo_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_cmce_wmo_grid2grid.sh
@@ -42,6 +42,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_wmo_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2grid.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_grid2obs.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip.sh
@@ -40,6 +40,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
 export run_mpi=no
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_precip.sh
@@ -40,6 +40,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
 export run_mpi=no
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_ecme_atmos_snowfall.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_cnv.sh
@@ -38,6 +38,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh
@@ -40,6 +40,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh
@@ -40,6 +40,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2obs.sh
@@ -37,6 +37,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_precip.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sea_ice.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_snowfall.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_sst.sh
@@ -39,6 +39,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_headline_grid2grid.sh
@@ -41,6 +41,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_headline_grid2grid.sh
@@ -41,6 +41,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wmo_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wmo_grid2grid.sh
@@ -42,6 +42,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_wmo_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wmo_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_wmo_grid2grid.sh
@@ -42,6 +42,6 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_wmo_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gfs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gfs_headline_grid2grid.sh
@@ -41,6 +41,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gfs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gfs_headline_grid2grid.sh
@@ -41,6 +41,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh
@@ -41,6 +41,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2grid.sh
@@ -41,6 +41,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs.sh
@@ -39,6 +39,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_grid2obs.sh
@@ -39,6 +39,6 @@ export job=${PBS_JOBNAME:-jevs_${STEP}_${MODELNAME}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 export OMP_NUM_THREADS=1
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip.sh
@@ -42,6 +42,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_atmos_precip.sh
@@ -42,6 +42,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 
 export run_mpi=no
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_headline_grid2grid.sh
@@ -43,6 +43,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 export run_mpi=no
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov'
+export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_headline_grid2grid.sh
+++ b/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_naefs_headline_grid2grid.sh
@@ -43,6 +43,6 @@ export jobid=$job.${PBS_JOBID:-$$}
 export run_mpi=no
 
 #export SENDMAIL=YES
-export MAILTO='alicia.bentley@noaa.gov,lichuan.chen@noaa.gov,mallory.row@noaa.gov'
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 ${HOMEevs}/jobs/JEVS_STATS_GLOBAL_ENS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_argo_grid2obs.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_aviso_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ghrsst_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_ndbc_grid2obs.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_osisaf_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STATS}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smap_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STATS}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.sh
+++ b/dev/drivers/scripts/stats/rtofs/jevs_stats_rtofs_smos_grid2grid.sh
@@ -42,7 +42,7 @@ export DATAROOT=/lfs/h2/emc/stmp/${USER}/evs_test/$envir/tmp
 export job=${PBS_JOBNAME:-jevs_${STEP}_${COMPONENT}_${OBTYPE}_${VERIF_CASE}}
 export jobid=$job.${PBS_JOBID:-$$}
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,samira.ardani@noaa.gov,mallory.row@noaa.gov'}
 
 # call j-job
 $HOMEevs/jobs/JEVS_STATS_RTOFS

--- a/dev/drivers/scripts/stats/wafs/jevs_stats_wafs_atmos.sh
+++ b/dev/drivers/scripts/stats/wafs/jevs_stats_wafs_atmos.sh
@@ -45,7 +45,7 @@ export pid=${PBS_JOBID:-$$}
 export job=${PBS_JOBNAME:-jevs_stats_wafs_atmos}
 export jobid=$job.$pid
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,yali.mao@noaa.gov,mallory.row@noaa.gov'}
+source $HOMEevs/dev/drivers/set_MAILTO.sh
 export SENDMAIL=${SENDMAIL:-YES}
 
 ############################################################

--- a/dev/drivers/scripts/stats/wafs/jevs_stats_wafs_atmos.sh
+++ b/dev/drivers/scripts/stats/wafs/jevs_stats_wafs_atmos.sh
@@ -45,7 +45,7 @@ export pid=${PBS_JOBID:-$$}
 export job=${PBS_JOBNAME:-jevs_stats_wafs_atmos}
 export jobid=$job.$pid
 
-export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,yali.mao@noaa.gov'}
+export MAILTO=${MAILTO:-'alicia.bentley@noaa.gov,yali.mao@noaa.gov,mallory.row@noaa.gov'}
 export SENDMAIL=${SENDMAIL:-YES}
 
 ############################################################

--- a/dev/drivers/set_MAILTO.sh
+++ b/dev/drivers/set_MAILTO.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+MAILTO="mallory.row@noaa.gov"
+
+case "$COMPONENT" in
+    aigefs | global_chem | global_det | global_ens | rtofs | subseasonal | wafs)
+        MAILTO+=",alicia.bentley@noaa.gov"
+        ;;&
+    analyses | aqm | cam | glwu | nwps)
+        MAILTO+=",andrew.benjamin@noaa.gov"
+        ;;&
+    aigefs | global_ens)
+        MAILTO+=",lichuan.chen@noaa.gov"
+        ;;&
+    analyses | glwu| nwps | rtofs)
+        MAILTO+=",samira.ardani@noaa.gov"
+        ;;&
+    aqm | global_chem)
+        MAILTO+=",ho-chun.huang@noaa.gov"
+        ;;&
+    cam)
+        MAILTO+=",marcel.caron@noaa.gov"
+        ;;&
+    global_det)
+        MAILTO+=",qi.shi@noaa.gov"
+        ;;&
+    subseasonal)
+        MAILTO+=",shannon.shields@noaa.gov"
+        ;;&
+    wafs)
+        MAILTO+=",yali.mao@noaa.gov"
+        ;;&
+esac
+
+if [[ ${COMPONENT} = cam && ${RUN} = chem ]]; then
+     MAILTO=${MAILTO//marcel.caron/ho-chun.huang}
+fi
+
+echo "Setting MAILTO to ${MAILTO}"
+export MAILTO


### PR DESCRIPTION
## Description of Changes

This creates a script for the dev drivers to source to set `MAILTO`.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * No
* Do you have any planned upcoming annual leave/PTO?
    * No
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * N/A
  
- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

1. `git clone https://github.com/malloryprow/EVS.git`
2. `cd EVS`, `git checkout feature/mailto_mallory`
3. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/`
4. `cd dev/drivers/scripts/prep/aqm`
5. In `jevs_prep_aqm_atmos_grid2obs.sh`, change...
   - `HOMEevs` to your clone
   - `COMOUT` to your desired testing location output
   - `COMIN` to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
   - Add in export DCOMINairnow=/lfs/h1/ops/prod/dcomm` (this will make sure that we get a missing data email for airnow data)
6. `qsub jevs_prep_aqm_atmos_grid2obs.sh` 

@Ho-ChunHuang-NOAA Tagging you for your awareness because you will also receive an email but it is nothing to be concerned about.