### PR TITLE
fix spc outlook categ processing

### DIFF
--- a/ush/cam/evs_prep_spc_otlk.py
+++ b/ush/cam/evs_prep_spc_otlk.py
@@ -107,7 +107,7 @@ for DAY in range(1,4):
                                'gis_dump_dbf', 
                                os.path.join(OTLK_DIR,f'{SHP_FILE}.dbf'),
                                '|', 'sed', '-n', f"'/^Record[[:space:]]\\+{REC}/,/^Record[[:space:]]\\+[0-9]\\+/p'" # Get info from Record #REC
-                               '|', 'grep', '-m1', "'LABEL'" # Get the label line from Record #REC
+                               '|', 'grep', '-a', '-m1', "'LABEL'" # Get the label line from Record #REC
                                '|', 'cut', '-d\'"\'', '-f2'], # Get the label value 
                                capture_output=True)
                         NAME = NAME.replace('\n','')


### PR DESCRIPTION
## Description of Changes

This PR fixes SPC outlook preprocessing to treat `gis_dump_dbf` output as text when extracting outlook category labels.

Null characters in some DBF fields caused `grep` to identify the output as binary, so categories beyond TSTM were skipped. Adding the `-a` option allows all outlook categories to be processed correctly.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, RRFS-related changes in EVS will be delivered August 12 2026
* Do you have any planned upcoming annual leave/PTO?
    * August 10-14
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/cam/severe_spcotlk_maps
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_prep_cam_severe
```
[Total: _1 prep job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit the driver using `qsub -v vhr=07 ${driver}.sh` 

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- Confirm masks for outlook areas > TSTM made it to COMOUT

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin bugfix/cam/severe_spcotlk_maps
```