### PR TITLE
Update ecf walltime and memory to match dev

### DIFF
--- a/ecf/scripts/plots/cam/jevs_plots_cam_precip_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_precip_last90days.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=01:30:00
-#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=120GB
+#PBS -l walltime=02:40:00
+#PBS -l place=vscatter:exclhost,select=8:ncpus=128:mem=150GB
 #PBS -l debug=true
 
 export model=evs 

--- a/ecf/scripts/plots/cam/jevs_plots_cam_snowfall_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_snowfall_last90days.ecf
@@ -3,8 +3,8 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=00:25:00
-#PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=75GB
+#PBS -l walltime=01:00:00
+#PBS -l place=vscatter:exclhost,select=4:ncpus=128:mem=170GB
 #PBS -l debug=true
 
 export model=evs

--- a/ecf/scripts/prep/cam/jevs_prep_cam_precip_vhr_master.ecf
+++ b/ecf/scripts/prep/cam/jevs_prep_cam_precip_vhr_master.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:10:00
-#PBS -l place=vscatter,select=1:ncpus=3:ompthreads=1:mem=75GB
+#PBS -l place=vscatter,select=1:ncpus=3:ompthreads=1:mem=2GB
 #PBS -l debug=true
 
 export model=evs


### PR DESCRIPTION
## Description of Changes

I did a check to compare the ecf scripts walltime and memory to the dev driver walltime and memory. This fixes and few differences.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, before 8/11
* Do you have any planned upcoming annual leave/PTO?
    * Taking a few hours on Friday 
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  * No

- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

No need to test but please compare the ecf changes its dev driver counterpart to make sure I got them right.