### PR TITLE
zero-pad walltimes

### DIFF
--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=0:15:00
+#PBS -l walltime=00:15:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=50GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=0:45:00
+#PBS -l walltime=00:45:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=120GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=0:30:00
+#PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=70GB
 #PBS -l debug=true
 

--- a/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.sh
+++ b/dev/drivers/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.sh
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q dev
 #PBS -A VERF-DEV
-#PBS -l walltime=1:50:00
+#PBS -l walltime=01:50:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=170GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last31days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=0:15:00
+#PBS -l walltime=00:15:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=50GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrcnt_last90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=0:45:00
+#PBS -l walltime=00:45:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=120GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last31days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=0:30:00
+#PBS -l walltime=00:30:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=70GB
 #PBS -l debug=true
 

--- a/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.ecf
+++ b/ecf/scripts/plots/cam/jevs_plots_cam_radar_nbrctc_last90days.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=1:50:00
+#PBS -l walltime=01:50:00
 #PBS -l select=1:ncpus=64:ompthreads=1:mem=170GB
 #PBS -l debug=true
 


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Added zero-padding to dev/ and ecf/ radar plots drivers.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes.  Merge as soon as possible (code delivery is August 12, but I'll be OOO August 10-14)
* Do you have any planned upcoming annual leave/PTO?
August 10-14
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

No testing is needed but please review the "Files Changed" tab for updated walltime formatting.  Any comments about other lingering issues are also welcome!