### PR TITLE
Fix bug in processing bad characters

### DIFF
--- a/ush/cam/evs_prep_spc_otlk.py
+++ b/ush/cam/evs_prep_spc_otlk.py
@@ -131,8 +131,8 @@ for DAY in range(1,4):
 
                         os.environ['VERIF_GRID'] = VERIF_GRID
                         os.environ['REC'] = str(REC)
-                        os.environ['MASK_FNAME'] = MASK_FNAME
-                        os.environ['MASK_NAME'] = MASK_NAME
+                        os.environ['MASK_FNAME'] = MASK_FNAME.replace('\x00', '')
+                        os.environ['MASK_NAME'] = MASK_NAME.replace('\x00', '')
 
                         cutil.run_shell_command([
                         os.path.join(os.environ['METPLUS_PATH'],'ush','run_metplus.py'), '-c',


### PR DESCRIPTION
## Description of Changes

In `/lfs/h2/emc/ptmp/emc.vpppg/output/jevs_prep_cam_severe.o134916743`, there was a failure seen below

```
Processing Record Number #3: ENH^@
Traceback (most recent call last):
  File "/lfs/h2/emc/vpppg/noscrub/emc.vpppg/EVS/ush/cam/evs_prep_spc_otlk.py", line 134, in <module>
    os.environ['MASK_FNAME'] = MASK_FNAME
  File "/apps/spack/python/3.10.4/intel/19.1.3.304/xqft4d45h4dp4xnbz2ue3nbxv65i6bgp/lib/python3.10/os.py", line 685, in __setitem__
    putenv(key, value)
ValueError: embedded null byte
61 + export err=1
61 + err=1
61 + err_chk

-------------------------------------------------------------
-- FATAL ERROR: Job jevs_prep_cam_severe.134916743.dbqs01 failed RETURN CODE 1
-- ABNORMAL EXIT at Tue Aug 11 07:31:48 UTC 2026 on nid001044
-------------------------------------------------------------
```
## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
   * Yes must be merged today
* Do you have any planned upcoming annual leave/PTO?
   * No 
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
   * No

I asked Gemini for a fix and the resulting code changes are what it suggested. I also tested and I'm not seeing the failure anymore.

- [ ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ ] References the feature branch for `HOMEevs` are removed from the code.
- [ ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ ] Jobs over 15 minutes in runtime have restart capability.
- [ ] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [ ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [ ] Code is using METplus wrappers structure and not calling MET executables directly.
- [ ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

1. `git clone https://github.com/malloryprow/EVS.git`
2. `cd EVS`
3. `git checkout bug/cam_severe_bad_str`
4. `ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix fix`
5. `cd dev/drivers/scripts/prep/cam`
6. In `jevs_prep_cam_severe.sh`, change...
   - `HOMEevs` to your clone
   - `COMOUT` to your desired testing location output
   - `COMIN` to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
7. `qsub -v vhr=07 jevs_prep_cam_severe.sh` 
