### PR TITLE
set COMINrrfs and COMINresf as common variables

### DIFF
--- a/jobs/JEVS_PREP_CAM
+++ b/jobs/JEVS_PREP_CAM
@@ -116,6 +116,9 @@ export COMOUT=${COMOUT:-$(compath.py -o $NET/$evs_ver/$STEP/$COMPONENT)}
 
 mkdir -p $COMOUT
 
+export COMINrrfs=${COMINrrfs:-$(compath.py ${envir}/com/rrfs/${rrfs_ver})}
+export COMINrefs=${COMINrefs:-$(compath.py ${envir}/com/refs/${refs_ver})}
+
 if [[ "${RUN}" == "chem" ]]; then
     export DCOMINairnow=${DCOMINairnow:-${DCOMROOT}}
     export DCOMINaeronet=${DCOMINaeronet:-${DCOMROOT}}
@@ -130,7 +133,6 @@ if [[ "${RUN}" == "chem" ]]; then
 else
     export COMINccpa=${COMINccpa:-$(compath.py ${envir}/com/ccpa/$ccpa_ver)}
     export COMINhrrr=${COMINhrrr:-$(compath.py ${envir}/com/hrrr/${hrrr_ver})}
-    export COMINrrfs=${COMINrrfs:-$(compath.py ${envir}/com/rrfs/${rrfs_ver})}
     export COMINobsproc=${COMINobsproc:-$(compath.py ${envir}/com/obsproc/${obsproc_ver})}
     export DCOMINmrms=${DCOMINmrms:-$DCOMROOT/ldmdata/obs/upperair/mrms}
     export DCOMINspc=${DCOMINspc:-$DCOMROOT}


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

COMINrrfs serves as a shared variable across both RRFS and RRFS-CHEM, rather than being exclusive to RRFS. Additionally, COMINrefs was found to be currently missing from JEVS_PREP_CAM and needs to be included, at least for RRFS. This PR addresses the issue by updating the configuration to establish both COMINrrfs and COMINrefs as common settings across all applications.


## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
YES. before code delivery

* Do you have any planned upcoming annual leave/PTO?
YES, from 08/17-08/24

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
 NO
 
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.


Pleas note the RRFS model output has been changed from 
/lfs/h1/ops/para/com/rrfs/v1.0
to
/lfs/h1/ops/prod/com/rrfs/v1.0 from 12Z cycle

(1) RRFS-CHEM prep test
In /lfs/h2/emc/vpppg/noscrub/ho-chun.huang/EVSRRFSfix/dev/drivers/scripts/prep/cam/jevs_prep_cam_rrfs_chem_grid2obs.sh

(1) set INITDATE=20260811 to have full cycle of model output.
(2) remove setting for COMINrrfs and COMINrefs

While files for DCOMairnow or DCOMaeronet may be missing due to the test date, ensure that the model output files can be located.

(2) For the remaining RRFS and REFS prep runs, it may be necessary to wait until Marcel returns from PTO. The same verification test as outlined in (1) should be conducted to ensure that the RRFS model output files can be successfully located.