### PR TITLE
Change expansion behavior for workdir loops only

### DIFF
--- a/scripts/stats/cam/exevs_stats_cam_rap_grid2obs.sh
+++ b/scripts/stats/cam/exevs_stats_cam_rap_grid2obs.sh
@@ -156,12 +156,14 @@ echo "*****************************"
   fi
 
 # Copy Reformat Output to Main Directory
+  shopt -s nullglob
   if [ $ncount_job -gt 0 ]; then
     for CHILD_DIR in ${DATA}/${VERIF_CASE}/METplus_output/workdirs/${job_type}/*; do
       cp -ru $CHILD_DIR/* ${DATA}/${VERIF_CASE}/METplus_output/.
       export err=$?; err_chk
     done
   fi
+  shopt -u nullglob
 
 echo "*****************************"
 echo "Reformat jobs done"
@@ -262,12 +264,14 @@ echo "*****************************"
   fi
 
 # Copy Generate Output to Main Directory
+  shopt -s nullglob
   if [ $ncount_job -gt 0 ]; then
     for CHILD_DIR in ${DATA}/${VERIF_CASE}/METplus_output/workdirs/${job_type}/*; do
       cp -ru $CHILD_DIR/* ${DATA}/${VERIF_CASE}/METplus_output/.
       export err=$?; err_chk
     done
   fi
+  shopt -u nullglob
 
 echo "*****************************"
 echo "Generate jobs done"
@@ -347,12 +351,14 @@ echo "*****************************"
   fi
 
 # Copy Gather Output to Main Directory
+  shopt -s nullglob
   if [ $ncount_job -gt 0 ]; then
     for CHILD_DIR in ${DATA}/${VERIF_CASE}/METplus_output/workdirs/${job_type}/*; do
        cp -ru $CHILD_DIR/* ${DATA}/${VERIF_CASE}/METplus_output/.
        export err=$?; err_chk
     done
   fi
+  shopt -u nullglob
 
 echo "*****************************"
 echo "Gather jobs done"
@@ -446,12 +452,14 @@ echo "Gather3 jobs done"
 echo "*****************************"
 
 # Copy Gather 3 Output to Main Directory
+  shopt -s nullglob
   if [ $ncount_job -gt 0 ]; then
     for CHILD_DIR in ${DATA}/${VERIF_CASE}/METplus_output/workdirs/${job_type}/*; do
        cp -ru $CHILD_DIR/* ${DATA}/${VERIF_CASE}/METplus_output/.
        export err=$?; err_chk
     done
   fi
+  shopt -u nullglob
 
 # Copy "gather" output files to EVS COMOUTsmall directory
 if [ $SENDCOM = YES ]; then


### PR DESCRIPTION
## Description of Changes

This PR fixes the behavior inside several for loops in the RAP stats grid2obs ex-script so that wildcards expand to nothing when no matches exist, rather than returning the raw path with an asterisk.  This prevents failures on restart runs, in which some workdirs may not exist, and wildcard paths should expand to nothing, causing the loop to skip.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * Yes, August 17th (ASAP)
* Do you have any planned upcoming annual leave/PTO?
    * August 20 (afternoon) and 21
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/cam/rap_cp_block
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_stats_cam_rap_grid2obs
```
[Total: _1 stats job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Edit the driver walltime so we can test restart (maybe 15 minutes)
- Submit the driver using `qsub -v vhr=07 ${driver}.sh` using 
- When the interrupted run completes, rerun so we can confirm no failure on the restart run

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs of all runs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin bugfix/cam/rap_cp_block
```