### PR TITLE
EVS-NWPS enhancement

### DIFF
--- a/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
+++ b/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
@@ -35,7 +35,7 @@ echo '-------------'
 echo ' '
 [[ "$LOUD" = YES ]] && set -x
 
-WFO='ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
+WFO='ajk alu akq box car chs gyx ilm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 
 for wfo in ${WFO}; do
     export wfo=$wfo

--- a/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
+++ b/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
@@ -104,13 +104,31 @@ for wfo in ${WFO}; do
     ###########################################
     # Run the command files for the PAST31DAYS 
     ###########################################
-    chmod 775 ${DATA_wfo}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-    if [ "${run_mpi}" = 'yes' ] ; then
-        mpiexec -np 200 -ppn 100 --cpu-bind verbose,depth cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-    else
-        echo "not running mpiexec"
-        sh plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-    fi
+    cmd_file="${DATA_wfo}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh"
+    
+    if [ -s "${cmd_file}" ]; then
+	sed -i 's/$/ || true/' "${cmd_file}"
+        chmod 775 ${cmd_file}
+
+	if [ "${run_mpi}" = 'yes' ] ; then
+            # Dynamically set NP based on line count to avoid CFP idle-rank SIGTERM crashes
+            ncmd=$(awk 'END {print NR}' ${cmd_file})
+            if [ ${ncmd} -lt 200 ]; then
+                nprocs=${ncmd}
+            else
+                nprocs=200
+            fi
+            
+            echo "Running cfp for ${wfo} with -np ${nprocs} (${ncmd} total commands)"
+            mpiexec -np ${nprocs} --cpu-bind verbose,depth cfp ${cmd_file}
+        else
+	    echo "not running mpiexec"
+            sh ${cmd_file}
+        fi
+     else
+	    echo "WARNING: ${cmd_file} is missing or empty. Skipping execution for ${wfo}."
+            continue
+     fi
 
     ############################
     #  copy all the jobs files

--- a/scripts/prep/nwps/exevs_prep_nwps_wave_grid2obs.sh
+++ b/scripts/prep/nwps/exevs_prep_nwps_wave_grid2obs.sh
@@ -52,7 +52,7 @@ for region in ${regions} ; do
 	fi
 done
 
-wfos='aer afg ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
+wfos='aer afg ajk alu akq box car chs gyx ilm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 #CG1 is the main domain. CG2-CG6 are the nested domains.
 #CGs='CG1 CG2 CG3 CG4 CG5 CG6'
 CGs='CG1'

--- a/scripts/stats/nwps/exevs_stats_nwps_wave_grid2obs.sh
+++ b/scripts/stats/nwps/exevs_stats_nwps_wave_grid2obs.sh
@@ -42,7 +42,7 @@ mkdir -p ${DATA}/SFCSHP
 mkdir -p ${DATA}/job_work_dir
 
 vhours='00 06 12 18'
-WFO='aer afg ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
+WFO='aer afg ajk alu akq box car chs gyx ilm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 CG='CG1'
 lead_hours='0 24 48 72 96 120 144'
 

--- a/ush/nwps/nwps_wave_plots_copy_plots.sh
+++ b/ush/nwps/nwps_wave_plots_copy_plots.sh
@@ -14,7 +14,7 @@
 # set up plot variables
 set -x
 
-small_periods='last31days last90days'
+small_periods=$(echo "$EVAL_PERIOD" | tr '[:upper:]' '[:lower:]')
 
 inithours='00 12'
 wave_vars='HTSGW WIND PERPW'


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

Here are the summary of the changes:
- Correctness: Fixes WFO names and addition of these two WFOS in the verification system.
- Robustness: Dynamic MPI allocation prevents resource waste and crash scenarios.
- Reliability: File validation and error-tolerant execution ensure jobs complete even with individual command failures
- Flexibility: Parameterized evaluation periods ensure the code only operates on the evaluation period in use. This change parameterizes evaluation periods and prevents the code from using any evaluation period other than the one being executed.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
  No.
* Do you have any planned upcoming annual leave/PTO?
  Yes, 8/27 and 8/31.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No.
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.
  There are warnings due to missing files that are expected.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- Environment Preparation
Clone the feature branch: `feature/EVS-NWPS_fixes`
Set `$HOMEevs` to your local test directory:
`HOMEevs=/path/to/your/local/test/directory`
Link the necessary fix files:
`mkdir -p $HOMEevs/fix`
`ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* $HOMEevs/fix/`

2- Test Implementation
Run all steps driver scripts and in each driver script apply these changes:
 In `$COMIN`, replace `${USER}` with `samira.ardani`:
Set test-specific flags:
`export KEEPDATA=YES`
`export SENDMAIL=NO`

3- Job Submission
**prep:**
For prep, we can test with current `$INITDATE` to make sure the changes work without errors. Then, I will provide you with a required prep outputs needed for a full stats run.
`qsub  $HOMEevs/dev/drivers/scripts/prep/nwps/jevs_prep_nwps_wave_grid2obs.sh`

**stats:**
For stats, please change `$COMIN` to point to my prep archive:
**Update:** Here is the path to my prep archive: `/lfs/h2/emc/vpppg/noscrub/samira.ardani/evs_devonly/v2.0/PR1033/prep/nwps/`

then run the driver script using: 
`qsub $HOMEevs/dev/drivers/scripts/stats/nwps/jevs_stats_nwps_wave_grid2obs.sh`

**plots:**
Please change the `$COMIN` in plots drivers to point to your stats output and then run them using:
`qsub $HOMEevs/dev/drivers/scripts/stats/nwps//jevs_plots_nwps_wave_grid2obs_last31days.sh`
`qsub $HOMEevs/dev/drivers/scripts/stats/nwps//jevs_plots_nwps_wave_grid2obs_last90days.sh`