### PR TITLE
Switch from the OSI-SAF multi files to the amsr2 files

### DIFF
--- a/dev/drivers/set_MAILTO.sh
+++ b/dev/drivers/set_MAILTO.sh
@@ -9,7 +9,10 @@ case "$COMPONENT" in
     analyses | aqm | cam | glwu | nwps)
         MAILTO+=",andrew.benjamin@noaa.gov"
         ;;&
-    aigefs | global_ens)
+    global_ens)
+        MAILTO+=",jun.du@noaa.gov"
+        ;;&
+    aigefs)
         MAILTO+=",lichuan.chen@noaa.gov"
         ;;&
     analyses | glwu| nwps | rtofs)

--- a/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
+++ b/scripts/plots/nwps/exevs_plots_nwps_wave_grid2obs.sh
@@ -35,7 +35,7 @@ echo '-------------'
 echo ' '
 [[ "$LOUD" = YES ]] && set -x
 
-WFO='ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
+WFO='ajk alu akq box car chs gyx ilm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 
 for wfo in ${WFO}; do
     export wfo=$wfo
@@ -104,13 +104,31 @@ for wfo in ${WFO}; do
     ###########################################
     # Run the command files for the PAST31DAYS 
     ###########################################
-    chmod 775 ${DATA_wfo}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-    if [ "${run_mpi}" = 'yes' ] ; then
-        mpiexec -np 200 -ppn 100 --cpu-bind verbose,depth cfp plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-    else
-        echo "not running mpiexec"
-        sh plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh
-    fi
+    cmd_file="${DATA_wfo}/plot_all_${MODELNAME}_${RUN}_g2o_${wfo}_plots.sh"
+    
+    if [ -s "${cmd_file}" ]; then
+	sed -i 's/$/ || true/' "${cmd_file}"
+        chmod 775 ${cmd_file}
+
+	if [ "${run_mpi}" = 'yes' ] ; then
+            # Dynamically set NP based on line count to avoid CFP idle-rank SIGTERM crashes
+            ncmd=$(awk 'END {print NR}' ${cmd_file})
+            if [ ${ncmd} -lt 200 ]; then
+                nprocs=${ncmd}
+            else
+                nprocs=200
+            fi
+            
+            echo "Running cfp for ${wfo} with -np ${nprocs} (${ncmd} total commands)"
+            mpiexec -np ${nprocs} --cpu-bind verbose,depth cfp ${cmd_file}
+        else
+	    echo "not running mpiexec"
+            sh ${cmd_file}
+        fi
+     else
+	    echo "WARNING: ${cmd_file} is missing or empty. Skipping execution for ${wfo}."
+            continue
+     fi
 
     ############################
     #  copy all the jobs files

--- a/scripts/prep/nwps/exevs_prep_nwps_wave_grid2obs.sh
+++ b/scripts/prep/nwps/exevs_prep_nwps_wave_grid2obs.sh
@@ -52,7 +52,7 @@ for region in ${regions} ; do
 	fi
 done
 
-wfos='aer afg ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
+wfos='aer afg ajk alu akq box car chs gyx ilm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 #CG1 is the main domain. CG2-CG6 are the nested domains.
 #CGs='CG1 CG2 CG3 CG4 CG5 CG6'
 CGs='CG1'

--- a/scripts/stats/global_ens/exevs_stats_global_ens_atmos_grid2grid.sh
+++ b/scripts/stats/global_ens/exevs_stats_global_ens_atmos_grid2grid.sh
@@ -145,11 +145,11 @@ fi
 if [ $verif_case = sea_ice ] ; then
   day1=`$NDATE -24 ${VDATE}12`
   VDATE_1=${day1:0:8}
-   if [ ! -s ${EVSIN}.${VDATE}/osi_saf/osi_saf.multi.${VDATE_1}00to${VDATE}00_G004.nc ] ; then
+   if [ ! -s ${EVSIN}.${VDATE}/osi_saf/osi_saf.amsr2.${VDATE_1}00to${VDATE}00_G004.nc ] ; then
      if [ $SENDMAIL = YES ]; then
        export subject="OSI_SAF analysis data missing "
        echo "Warning: No OSI_SAF analysis available for ${VDATE}" > mailmsg 
-       echo "Missing file is ${EVSIN}.${VDATE}/osi_saf/osi_saf.multi.${VDATE_1}00to${VDATE}00_G004.nc"  >> mailmsg
+       echo "Missing file is ${EVSIN}.${VDATE}/osi_saf/osi_saf.amsr2.${VDATE_1}00to${VDATE}00_G004.nc"  >> mailmsg
        echo "Job ID: $jobid" >> mailmsg
        cat mailmsg | mail -s "$subject" $MAILTO
      fi

--- a/scripts/stats/nwps/exevs_stats_nwps_wave_grid2obs.sh
+++ b/scripts/stats/nwps/exevs_stats_nwps_wave_grid2obs.sh
@@ -42,7 +42,7 @@ mkdir -p ${DATA}/SFCSHP
 mkdir -p ${DATA}/job_work_dir
 
 vhours='00 06 12 18'
-WFO='aer afg ajk alu akq box car chs gys olm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
+WFO='aer afg ajk alu akq box car chs gyx ilm lwx mhx okx phi gum hfo bro crp hgx jax key lch lix mfl mlb mob sju tae tbw eka lox mfr mtr pqr sew sgx'
 CG='CG1'
 lead_hours='0 24 48 72 96 120 144'
 

--- a/ush/global_ens/evs_gens_atmos_check_input_files.sh
+++ b/ush/global_ens/evs_gens_atmos_check_input_files.sh
@@ -116,7 +116,7 @@ fi
 if [ $var = osi_saf ]; then
     past=`$NDATE -24 ${vday}01`
     export vday1=${past:0:8}
-    export period=multi.${vday1}00to${vday}00_G004
+    export period=amsr2.${vday1}00to${vday}00_G004
    if [ -s ${EVSIN}.${vday}/osi_saf/osi_saf.${period}.nc ] ; then
         echo "OSI_SAF data is OK"
    else

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -901,12 +901,12 @@ fi
 ############################################################
 if [ $modnam = osi_saf ] ; then
   INITDATEm1=$($NDATE -24 ${INITDATE}00 | cut -c1-8)
-  osisaf_comout_file=${COMOUTosi_saf}/osi_saf.multi.${INITDATEm1}00to${INITDATE}00_G004.nc
+  osisaf_comout_file=${COMOUTosi_saf}/osi_saf.amsr2.${INITDATEm1}00to${INITDATE}00_G004.nc
   if [ -s $osisaf_comout_file ]; then
     echo "${osisaf_comout_file} exists"
   else
-    osi_nh=$DCOMINosi_saf/$INITDATEm1/seaice/osisaf/ice_conc_nh_polstere-100_multi_${INITDATEm1}1200.nc
-    osi_sh=$DCOMINosi_saf/$INITDATEm1/seaice/osisaf/ice_conc_sh_polstere-100_multi_${INITDATEm1}1200.nc
+    osi_nh=$DCOMINosi_saf/$INITDATEm1/seaice/osisaf/ice_conc_nh_polstere-100_amsr2_${INITDATEm1}1200.nc
+    osi_sh=$DCOMINosi_saf/$INITDATEm1/seaice/osisaf/ice_conc_sh_polstere-100_amsr2_${INITDATEm1}1200.nc
     if [ ! -s $osi_nh ]; then
       echo "WARNING: $osi_nh is not available" 
       if [ $SENDMAIL = YES ]; then

--- a/ush/global_ens/evs_global_ens_atmos_sea_ice.sh
+++ b/ush/global_ens/evs_global_ens_atmos_sea_ice.sh
@@ -76,7 +76,7 @@ for metplus_job in GenEnsProd EnsembleStat GridStat; do
     for average in 24 ; do
         past=`$NDATE -$average ${vday}01`
         export vday1=${past:0:8}
-        export period=multi.${vday1}00to${vday}00_G004
+        export period=amsr2.${vday1}00to${vday}00_G004
         if [ $average = 24 ] ; then
             leads_chk="024 048 072 096 120 144 168 192 216 240 264 288 312 336 360 384"
         elif [ $average = 168 ] ; then

--- a/ush/global_ens/global_ens_atmos_util.py
+++ b/ush/global_ens/global_ens_atmos_util.py
@@ -785,7 +785,7 @@ def prep_prod_osi_saf_file(daily_source_file_format, daily_dest_file,
     for hem in ['nh', 'sh']:
         hem_source_file = daily_source_file_format.replace('{hem?fmt=str}',
                                                            hem)
-        hem_dest_file = daily_dest_file.replace('multi.', 'multi.'+hem+'.')
+        hem_dest_file = daily_dest_file.replace('amsr2.', 'amsr2.'+hem+'.')
         hem_prepped_file = os.path.join(os.getcwd(), 'atmos.'
                                         +hem_dest_file.rpartition('/')[2])
         if check_file_exists_size(hem_source_file):

--- a/ush/global_ens/global_ens_sea_ice_prep.py
+++ b/ush/global_ens/global_ens_sea_ice_prep.py
@@ -36,27 +36,27 @@ if not os.path.exists(COMOUT_INITDATE):
 
 ###### OBS
 # Get operational observation data
-# Northern & Southern Hemisphere 10 km OSI-SAF multi-sensor analysis - osi_saf
+# Northern & Southern Hemisphere 10 km OSI-SAF amsr2-sensor analysis - osi_saf
 global_det_obs_dict = {
     'osi_saf': {'daily_prod_file_format': os.path.join(DCOMINosi_saf,
                                                        '{init_shift?fmt=%Y%m%d'
                                                        +'?shift=-12}',
                                                        'seaice', 'osisaf',
                                                        'ice_conc_{hem?fmt=str}_'
-                                                       +'polstere-100_multi_'
+                                                       +'polstere-100_amsr2_'
                                                        +'{init_shift?fmt=%Y%m%d%H'
                                                        +'?shift=-12}'
                                                        +'00.nc'),
                 'daily_arch_file_format': os.path.join(WORKtask, RUN+'.'+INITDATE,
                                                        'osi_saf',
-                                                       'osi_saf.multi.'
+                                                       'osi_saf.amsr2.'
                                                        +'{init_shift?fmt=%Y%m%d%H'
                                                        +'?shift=-24}to'
                                                        +'{init?fmt=%Y%m%d%H}'
                                                        +'_G004.nc'),
                 'weekly_arch_file_format': os.path.join(WORKtask, RUN+'.'+INITDATE,
                                                        'osi_saf',
-                                                       'osi_saf.multi.'
+                                                       'osi_saf.amsr2.'
                                                        +'{init_shift?fmt=%Y%m%d%H?'
                                                        +'shift=-168}'
                                                        +'to'

--- a/ush/global_ens/ush_gens_plot_py/global_det_atmos_util.py
+++ b/ush/global_ens/ush_gens_plot_py/global_det_atmos_util.py
@@ -802,7 +802,7 @@ def prep_prod_osi_saf_file(daily_source_file_format, daily_dest_file,
     for hem in ['nh', 'sh']:
         hem_source_file = daily_source_file_format.replace('{hem?fmt=str}',
                                                            hem)
-        hem_dest_file = daily_dest_file.replace('multi.', 'multi.'+hem+'.')
+        hem_dest_file = daily_dest_file.replace('amsr2.', 'amsr2.'+hem+'.')
         hem_prepped_file = os.path.join(os.getcwd(), 'atmos.'
                                         +hem_dest_file.rpartition('/')[2])
         if check_file_exists_size(hem_source_file):
@@ -1436,7 +1436,7 @@ def check_truth_files(job_dict):
             elif job_dict['VERIF_TYPE'] == 'sea_ice':
                 osi_saf_file = os.path.join(
                     verif_case_dir, 'data', 'osi_saf',
-                    'osi_saf.multi.'
+                    'osi_saf.amsr2.'
                     +(valid_date_dt-datetime.timedelta(hours=24))\
                     .strftime('%Y%m%d%H')
                     +'to'+valid_date_dt.strftime('%Y%m%d%H')+'_G004.nc'

--- a/ush/nwps/nwps_wave_plots_copy_plots.sh
+++ b/ush/nwps/nwps_wave_plots_copy_plots.sh
@@ -14,7 +14,7 @@
 # set up plot variables
 set -x
 
-small_periods='last31days last90days'
+small_periods=$(echo "$EVAL_PERIOD" | tr '[:upper:]' '[:lower:]')
 
 inithours='00 12'
 wave_vars='HTSGW WIND PERPW'


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.
This PR replaces the "multi" observation product with "amsr2" across EVS for the RTOFS/OSI-SAF workflows. It updates configuration, file-pattern matching, verification scripts, and tests so EVS ingests and verifies amsr2 data instead of the previous "multi" input.
Background and Motivation: According to dataflow's previous communications with the OSI-SAF team, who stated: "the SSMIS-based product is only provided on a best effort basis, since the access to SSMIS data is unstable. We advise all our users to use our sea ice concentration product based on AMSR-2 data.", this change was tested and amsr2 is the intended satellite product for the affected checks replacing "multi" with "amsr2".

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes, please test it before internal code freeze deadline of 9/14.

* Do you have any planned upcoming annual leave/PTO?
  No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
  No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

1- Environment Preparation
Clone the feature branch: amsr2
Set $HOMEevs to your local test directory:
HOMEevs=/path/to/your/local/test/directory
Link the necessary fix files:
mkdir -p $HOMEevs/fix
ln -sf /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* $HOMEevs/fix/

2- Test Implementation
Run prep and osisaf stats driver scripts and in each driver script apply these changes:

In $COMIN, replace ${USER} with jun.du:
export COMIN=/lfs/h2/emc/vpppg/noscrub/jun.du/${NET}/${evs_ver_2d}
Set test-specific flags:
export KEEPDATA=YES
export SENDMAIL=NO

Job Submission
For prep, we can test with current INITDATE to make sure the changes work without errors. We then check the number of files to make sure all files are generated with the comparable size as emc.vpppg.
qsub  $HOMEevs/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh

For stats, I have an archive of prep for 20260719-20260822 in /lfs/h2/emc/vpppg/noscrub/jun.du/evs/v2.0/prep/global_ens/* . You can use those prep archive and point to them to test the stats.
qsub -v VDATE=20260822 $HOMEevs/dev/drivers/scripts/stats/global_ens/jevs_stats_global_ens_gefs_atmos_grid2grid.sh and jevs_stats_global_ens_gefs_atmos_sea_ice.sh