### PR TITLE
Enhancement/global ens/prune data

### DIFF
--- a/ush/global_ens/prune_stat_files.py
+++ b/ush/global_ens/prune_stat_files.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import numpy as np
+import shlex
 from datetime import datetime, timedelta as td
 SETTINGS_DIR = os.environ['USH_DIR']
 sys.path.insert(0, os.path.abspath(SETTINGS_DIR))
@@ -78,33 +79,31 @@ def prune_data(data_dir, prune_dir, tmp_dir, output_base_template, valid_range,
          continue
       with open(met_stat_files[0]) as msf:
          met_header_cols = msf.readline()
-      all_grep_output = ''
-      if RUN_type == 'anom' and 'HGT' in var_name:
-         print("Pruning "+data_dir+" files for model "+model+", vx_mask "
+      fcst_var_filter = ' '.join(
+        '-e '+shlex.quote(fcst_var_name) for fcst_var_name in fcst_var_names
+      )
+      filter_cmd = (
+         ' | grep -F '+shlex.quote(vx_mask)
+         +' | grep -F '+shlex.quote(line_type)
+      )
+      log_msg = "Pruning "+data_dir+" files for model "+model+", vx_mask "
                +vx_mask+", variable "+'/'.join(fcst_var_names)+", line_type "+line_type
-               +", interp "+os.environ['INTERP'])
-         filter_cmd = (
-            ' | grep "'+vx_mask
-            +'" | grep "'+'\|'.join(fcst_var_names)
-            +'" | grep "'+line_type
-            +'" | grep "'+os.environ['INTERP']+'"'
-         )
-      else:
-         print("Pruning "+data_dir+" files for model "+model+", vx_mask "
-               +vx_mask+", variable "+'/'.join(fcst_var_names)+", line_type "+line_type)
-         filter_cmd = (
-            ' | grep "'+vx_mask
-            +'" | grep "'+'\|'.join(fcst_var_names)
-            +'" | grep "'+line_type+'"'
-         )
+      if RUN_type == 'anom' and 'HGT' in var_name:
+         filter_cmd += ' | grep -F '+shlex.quote(os.environ['INTERP'])
+         log_msg += ", interp "+os.environ['INTERP']
+      
+      filter_cmd += ' | grep -F '+shlex.quote(model)
       # Prune the MET .stat files and write to new file
-      for met_stat_file in met_stat_files:
-         grep = subprocess.run('grep -R "'+model+'" '+met_stat_file+filter_cmd,
-                               shell=True, capture_output=True, encoding='UTF-8')
-         grep_output = grep.stdout
-         all_grep_output = all_grep_output+grep_output
-      pruned_met_stat_file = os.path.join(pruned_data_dir,
-                                          model+'.stat')
+      met_stat_files_cmd = ' '.join(
+         shlex.quote(str(met_stat_file)) for met_stat_file in met_stat_files
+      )
+      pruned_met_stat_file = os.path.join(
+         pruned_data_dir, model+'.stat'
+      )
+      grep_cmd = (
+         'grep -Fh '+fcst_var_filter+' '+met_stat_files_cmd+filter_cmd
+      )
       with open(pruned_met_stat_file, 'w') as pmsf:
-         pmsf.write(met_header_cols+all_grep_output)
+         pmsf.write(met_header_cols)
+         subprocess.run(grep_cmd, shell=True, stdout=pmsf, encoding='UTF-8')
    print("END: "+os.path.basename(__file__))


### PR DESCRIPTION
## Description of Changes

This PR addresses some of the issues discussed in https://github.com/NOAA-EMC/EVS/issues/926 and makes File I/O and reading enhancements in the preprocessing portion of global_ens plotting. 

**Enhancements** (Copied from https://github.com/NOAA-EMC/EVS/issues/926) 
- Using `grep` on all the files at once. 
- Changing the order of what is being grepped (most selective first). 
- Using `fgrep` (or `grep -F`) instead of `grep`, as this treats the patterns as literal, fixed strings instead of regular expressions. 

The global_ens job was chosen due to previous failures and can serve as a basis for this kind of enhancement. 

**Prior Testing** 
Two versions of this job were run concurrently: the current version in develop (**normal**) and the version using the changes in this PR (**test**). Below are some of the results (thanks to Russell Manser for providing scripts to derive summary statistics). 

**Normal** 
- Memory used: **64928 MB** 
- Run time: **7m42s** 

Summary statistics of individual plotting processes:
```
count                        190
mean   0 days 00:04:20.526315789
std    0 days 00:00:42.875071901
min              0 days 00:02:40
25%              0 days 00:03:51
50%              0 days 00:04:19
75%              0 days 00:04:41
max              0 days 00:05:31
```
Top ten longest-running processes:
```
                                              job_name  runtime (est.)
129  run_fss.time_series.120.WEASD_24_gt0p1016.L0.n... 0 days 00:05:30
144  run_fss.time_series.24.WEASD_24_gt0p1016.L0.nb... 0 days 00:05:31
114  run_fss.time_series.72.WEASD_24_gt0p0254.L0.nb... 0 days 00:05:31
57   run_fss.time_series.24.WEASD_24_gt0p0254.L0.nb... 0 days 00:05:31
15   run_fss.time_series.24.WEASD_24_gt0p1016.L0.nb... 0 days 00:05:31
139  run_fss.time_series.24.WEASD_24_gt0p2032.L0.nb... 0 days 00:05:31
11   run_fss.time_series.72.WEASD_24_gt0p0254.L0.nb... 0 days 00:05:31
25   run_fss.time_series.24.WEASD_24_gt0p3048.L0.nb... 0 days 00:05:31
71   run_fss.time_series.72.WEASD_24_gt0p3048.L0.nb... 0 days 00:05:31
177  run_fss.time_series.24.WEASD_24_gt0p2032.L0.nb... 0 days 00:05:31
```


**Test** 
- Memory used: **64722 MB** *(200 MB lower)* 
- Run time: **7m30s** *(12 seconds faster)* 

Summary statistics of individual plotting processes:
```
count                        190
mean   0 days 00:04:15.057894736
std    0 days 00:00:43.910223656
min              0 days 00:02:28
25%              0 days 00:03:49
50%              0 days 00:04:12
75%              0 days 00:04:37
max              0 days 00:05:24
```

Top ten longest-running processes:
```
                                              job_name  runtime (est.)
100  run_fss.time_series.24.WEASD_24_gt0p3048.L0.nb... 0 days 00:05:23
144  run_fss.time_series.24.WEASD_24_gt0p1016.L0.nb... 0 days 00:05:23
57   run_fss.time_series.24.WEASD_24_gt0p0254.L0.nb... 0 days 00:05:23
177  run_fss.time_series.24.WEASD_24_gt0p2032.L0.nb... 0 days 00:05:24
91   run_fss.time_series.120.WEASD_24_gt0p3048.L0.n... 0 days 00:05:24
133  run_fss.time_series.72.WEASD_24_gt0p2032.L0.nb... 0 days 00:05:24
148  run_fss.time_series.72.WEASD_24_gt0p2032.L0.nb... 0 days 00:05:24
25   run_fss.time_series.24.WEASD_24_gt0p3048.L0.nb... 0 days 00:05:24
138  run_fss.time_series.72.WEASD_24_gt0p1016.L0.nb... 0 days 00:05:24
114  run_fss.time_series.72.WEASD_24_gt0p0254.L0.nb... 0 days 00:05:24
```

It's difficult to say if these changes will make the plotting job more robust to handle issues causing https://github.com/NOAA-EMC/EVS/issues/926, but given the improvements shown in testing, I recommend moving forward with these changes.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * No
* Do you have any planned upcoming annual leave/PTO?
    * September 4
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout enhancement/global_ens/prune_data
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter):
```
jevs_plots_global_ens_atmos_gefs_snowfall_last90days
```
[Total: _1 plots job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit the driver using `qsub -v vhr=00 ${driver}.sh`

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs of all runs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- I suggest @malloryprow and @GwenChen-NOAA review the changes and tests in some capacity, given their prior involvement with either this issue or EVS component

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin enhancement/global_ens/prune_data
```