### PR TITLE
Bugfix/refs/missing grid2obs fcsts

### DIFF
--- a/ush/cam/evs_refs_prepare.sh
+++ b/ush/cam/evs_refs_prepare.sh
@@ -687,7 +687,6 @@ if [ "$data" = "sfc" ] ; then
   VDATE_1=`echo ${D1} | cut -c 1-8`
 
   >prepare_poe.sh 
-  #for day in $PDYm1 $PDYm2 $PDYm3 ; do
   for day in $VDATE $VDATE_1 $VDATE_2 $VDATE_3; do
    work=$DATA/refs.$day/verf_g2g
    mkdir -p $work

--- a/ush/cam/evs_refs_prepare.sh
+++ b/ush/cam/evs_refs_prepare.sh
@@ -686,7 +686,7 @@ if [ "$data" = "sfc" ] ; then
 
   >prepare_poe.sh 
   #for day in $PDYm1 $PDYm2 $PDYm3 ; do
-  for day in $VDATE $VDATE_1 $VDATE_2 ; do
+  for day in $VDATE $VDATE_1 $VDATE_2 $VDATE_3; do
    work=$DATA/refs.$day/verf_g2g
    mkdir -p $work
 

--- a/ush/cam/evs_refs_prepare.sh
+++ b/ush/cam/evs_refs_prepare.sh
@@ -698,6 +698,17 @@ if [ "$data" = "sfc" ] ; then
     day_tl=`echo ${DTL} | cut -c 1-8`
     cyc_tl=`echo ${DTL} | cut -c 9-10`
 
+    fhr_list=""
+    for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 51 54 57 60 ; do
+        valid_time=`$NDATE $fhr ${day}${cyc}`
+        valid_date=`echo $valid_time | cut -c 1-8`
+
+        if [ "$valid_date" = "$VDATE" ] ; then
+            fhr_list="$fhr_list $fhr"
+        fi
+    done
+
+    [ -z "$fhr_list" ] && continue
 
     for domain in conus ak ; do
      
@@ -717,7 +728,7 @@ if [ "$data" = "sfc" ] ; then
       echo "set -x" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "work=$work" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "cd \$work">> run_prepare.${day}.${cyc}.${domain}.sh
-      echo "for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 51 54 57 60 63 66; do" >> run_prepare.${day}.${cyc}.${domain}.sh
+      echo "for fhr in $fhr_list ; do" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "    typeset -Z2 hh" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "    hh=\$fhr      " >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "      for mbr in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 ; do" >> run_prepare.${day}.${cyc}.${domain}.sh
@@ -820,6 +831,18 @@ if [ "$data" = "upper_air" ] ; then
     DTL=`$NDATE -6 ${day}${cyc}`
     day_tl=`echo ${DTL} | cut -c 1-8`
     cyc_tl=`echo ${DTL} | cut -c 9-10`
+    
+    fhr_list=""
+    for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 51 54 57 60 ; do
+        valid_time=`$NDATE $fhr ${day}${cyc}`
+        valid_date=`echo $valid_time | cut -c 1-8`
+
+        if [ "$valid_date" = "$VDATE" ] ; then
+            fhr_list="$fhr_list $fhr"
+        fi
+    done
+
+    [ -z "$fhr_list" ] && continue
 
     for domain in conus ak hi pr ; do
 
@@ -853,7 +876,7 @@ if [ "$data" = "upper_air" ] ; then
      echo "work=$work" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "cd \$work" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
 
-     echo "for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 51 54 57 60 63 66 ; do" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
+     echo "for fhr in $fhr_list ; do" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "    typeset -Z2 hh" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "    hh=\$fhr" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "    typeset -Z2 hh_tl" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh

--- a/ush/cam/evs_refs_prepare.sh
+++ b/ush/cam/evs_refs_prepare.sh
@@ -679,6 +679,8 @@ if [ "$data" = "sfc" ] ; then
   echo "GUST" >> $DATA/pat
   echo "HPBL" >> $DATA/pat
 
+  D3=`$NDATE -72 ${VDATE}00`
+  VDATE_3=`echo ${D3} | cut -c 1-8`
   D2=`$NDATE -48 ${VDATE}00`
   VDATE_2=`echo ${D2} | cut -c 1-8`
   D1=`$NDATE -24 ${VDATE}00`
@@ -716,7 +718,7 @@ if [ "$data" = "sfc" ] ; then
       echo "set -x" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "work=$work" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "cd \$work">> run_prepare.${day}.${cyc}.${domain}.sh
-      echo "for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 54 60 66; do" >> run_prepare.${day}.${cyc}.${domain}.sh
+      echo "for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 51 54 57 60 63 66; do" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "    typeset -Z2 hh" >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "    hh=\$fhr      " >> run_prepare.${day}.${cyc}.${domain}.sh
       echo "      for mbr in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 ; do" >> run_prepare.${day}.${cyc}.${domain}.sh
@@ -852,7 +854,7 @@ if [ "$data" = "upper_air" ] ; then
      echo "work=$work" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "cd \$work" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
 
-     echo "for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 54 60 66 ; do" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
+     echo "for fhr in 3 6 9 12 15 18 21 24 27 30 33 36 39 42 45 48 51 54 57 60 63 66 ; do" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "    typeset -Z2 hh" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "    hh=\$fhr" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh
      echo "    typeset -Z2 hh_tl" >> run_prepare_upper_air.${day}.${cyc}.${domain}.sh


### PR DESCRIPTION
## Description of Changes

This PR addresses missing input forecast files when checking for REFS membership at earlier valid dates and later forecast leads.  Changes include copying Day 3 forecasts, as well as F51, F57, and F63, which were needed for some METplus processes.

Result is additional statistics, although due to existing logic, this issue did not cause the job to fail.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
    * No
* Do you have any planned upcoming annual leave/PTO?
    * September 4
* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
    * No
  
- [x] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x] References the feature branch for `HOMEevs` are removed from the code.
- [x] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x] Jobs over 15 minutes in runtime have restart capability.
- [x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x] Code is using METplus wrappers structure and not calling MET executables directly.
- [x] Log is free of any ERRORs or WARNINGs.

## Testing Instructions


### 1) Clone this branch for testing

- `cd` into any testing location on WCOSS2-dev, e.g. `/lfs/h2/emc/vpppg/noscrub/${USER}`
- Set up this EVS branch for testing:
```
git clone https://github.com/MarcelCaron-NOAA/EVS.git
cd EVS # You are now in HOMEevs
git checkout bugfix/refs/missing_grid2obs_fcsts
```

### 2) Which jobs to test

- Follow setup and testing instructions for the following jobs (called "`${driver}`" hereafter) and each of the listed vhrs:
```
jevs_stats_cam_refs_grid2obs
```
[Total: _1 stats job_]

### 3) Set up jobs

- symlink the EVS_fix directory locally as "fix":
```
cd $HOMEevs
mkdir fix
ln -s /lfs/h2/emc/vpppg/noscrub/emc.vpppg/verification/EVS_fix/* fix/
```
- In each driver script for the listed jobs (see the list of jobs above): 
```
vi dev/drivers/scripts/${STEP}/cam/${driver}.sh 
```
... where `${STEP}` is `prep`, `stats`, or `plots`, and `${driver}` is the name of the job
- Then edit or add the following environment variables:

For all drivers:
**HOMEevs** - set to your test EVS directory
**COMIN** - set to `/lfs/h2/emc/vpppg/noscrub/emc.vpppg/$NET/$evs_ver_2d`
**COMOUT** - set to your test output directory
**KEEPDATA** - (_optional_) set to `"YES"`
**SENDMAIL** - (_optional_) set to `"NO"`
**DATAROOT** - (_optional_) set to your test DATAROOT directory

**COMINrefs** - add this in and set to `/lfs/h1/ops/prod/com/refs/${refs_ver}`
**COMINrrfs** - add this in and set to `/lfs/h1/ops/prod/com/rrfs/${rrfs_ver}`


### 4) Test jobs
- `cd` into your test directory (where you want the log files to go)
- Submit the driver using `qsub -v vhr=13 ${driver}.sh`

We can discuss whether or not we want to test anything else.


### 5) Check jobs
- Check the logs of all runs for the following keywords:
```
check="FATAL\|WARNING\|error\|Error\|Killed\|Cgroup\|argument expected\|No such file\|cannot\|failed\|unexpected\|exceeded"
grep "$check" $logfile
```
- Additionally, grep the log for "FORECAST FILES FOUND:" and make sure there are no lines indicating that no forecasts ("0") were found.

### 6) During testing ...

- If changes are pushed during testing, you can update your branch like this:
```
git pull origin bugfix/refs/missing_grid2obs_fcsts
```