### PR TITLE
aigefs: GFSv17 update

### DIFF
--- a/ush/aigefs/evs_get_gens_atmos_data.sh
+++ b/ush/aigefs/evs_get_gens_atmos_data.sh
@@ -8,7 +8,7 @@
 #   4. Store the well-formed analysis/observations or smaller ensemble member files
 #      in the evs prep sub-directory /prep/aigefs/atmos.YYYYMMDD
 #
-# Updated: 10/03/2025 by L. Gwen Chen (lichuan.chen@noaa.gov) 
+# Updated: 09/02/2026 by L. Gwen Chen (lichuan.chen@noaa.gov) 
 #######################################################################################
 set -x
 
@@ -35,34 +35,37 @@ cd $WORKtask
 #################################################################################
 if [ $modnam = gfsanl ]; then
   for ihour in 00 06 12 18 ; do
-    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl ] ; then
-      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl is not available" 
+    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 ] ; then
+      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 is not available" 
       if [ $SENDMAIL = YES ]; then
         export subject="GFS Analysis Data Missing for EVS ${COMPONENT}"
         echo "Warning: No GFS analysis available for ${vday}${ihour}" > mailmsg
-        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl" >> mailmsg
+        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2" >> mailmsg
         echo "Job ID: $jobid" >> mailmsg
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      cp -v $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
+      cp -v $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 $WORKtask/gfsanl.t${ihour}z.0p25.f000.grib2
     fi
-    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000 ]; then
-      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000 is not available"
+
+    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2 ]; then
+      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2 is not available"
       if [ $SENDMAIL = YES ]; then
         export subject="GFS F000 Data Missing for EVS ${COMPONENT}"
         echo "Warning: No GFS F000 available for ${vday}${ihour}" > mailmsg
-        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000" >> mailmsg
+        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2" >> mailmsg
         echo "Job ID: $jobid" >> mailmsg
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      GFSf000=$COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000
+      GFSf000=$COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2
       $WGRIB2 $GFSf000 | grep "UGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/U10_f000.${ihour}
-      cat $WORKtask/U10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
+      cat $WORKtask/U10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.0p25.f000.grib2
       $WGRIB2 $GFSf000 | grep "VGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/V10_f000.${ihour}
-      cat $WORKtask/V10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
+      cat $WORKtask/V10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.0p25.f000.grib2
     fi
+
+    $WGRIB2 $WORKtask/gfsanl.t${ihour}z.0p25.f000.grib2 -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
     if [ $SENDCOM="YES" ] ; then
         if [ -s $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2 ]; then
             cp -v $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2 $COMOUTgefs/gfsanl.t${ihour}z.grid3.f000.grib2


### PR DESCRIPTION
## Description of Changes
This PR updates the path and filename for GFS analysis and f000 files for v17 upgrade. It also regrids these files from 0.25 degree resolution to NCEP GRID 3. GFS analysis is used as a validation dataset for grid2grid verification.

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by? Yes.
* Do you have any planned upcoming annual leave/PTO? No.
* Are there any changes needed in the times when the jobs are supposed to run/kick-off? No.
  
- [X] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [X] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [X] References the feature branch for `HOMEevs` are removed from the code.
- [X] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [X] Jobs over 15 minutes in runtime have restart capability.
- [X] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [X] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [X] Code is using METplus wrappers structure and not calling MET executables directly.
- [X] Log is free of any ERRORs or WARNINGs.

## Testing Instructions
(1) Set up jobs
a. Symlink the EVS_fix directory locally as "fix".
b. In the driver scripts, edit the following environment variables:

HOMEevs - set to your test EVS directory
COMIN - set to /lfs/h2/emc/vpppg/noscrub/emc.vpppg/${NET}/$evs_ver_2d
COMOUT - set to your test output directory
KEEPDATA - set to YES

In the jevs_prep_aigefs_atmos.sh script, add the following line:
export COMINgfs=/lfs/h2/emc/gfstemp/emc.global/EVS_archive/retrov17_01

(2) Run the atmos prep job
Run the following job in dev/drivers/scripts/prep/aigefs for any VDATE:
qsub jevs_prep_aigefs_atmos.sh

After the job completed, log file should only contain warnings for missing 06z and 18z f000 files, because they are not archived in retrov17_01.

(3) Run the atmos stats jobs
Run the following jobs in dev/drivers/scripts/stats/aigefs for any VDATE:
qsub jevs_stats_aigefs_aigefs_atmos_grid2grid.sh
qsub jevs_stats_aigefs_gefs_atmos_grid2grid.sh
qsub jevs_stats_aigefs_hgefs_atmos_grid2grid.sh

After the jobs completed, log files should be free of errors or warnings.