### PR TITLE
prune_stat_files.py code fix

### DIFF
--- a/ush/global_ens/prune_stat_files.py
+++ b/ush/global_ens/prune_stat_files.py
@@ -86,8 +86,10 @@ def prune_data(data_dir, prune_dir, tmp_dir, output_base_template, valid_range,
          ' | grep -F '+shlex.quote(vx_mask)
          +' | grep -F '+shlex.quote(line_type)
       )
-      log_msg = "Pruning "+data_dir+" files for model "+model+", vx_mask "
+      log_msg = ( 
+                 "Pruning "+data_dir+" files for model "+model+", vx_mask "
                +vx_mask+", variable "+'/'.join(fcst_var_names)+", line_type "+line_type
+      )
       if RUN_type == 'anom' and 'HGT' in var_name:
          filter_cmd += ' | grep -F '+shlex.quote(os.environ['INTERP'])
          log_msg += ", interp "+os.environ['INTERP']


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

> Please include a summary of the changes and the related GitHub issue(s). Please also include relevant motivation and context.

The plotting routine prune_stat_files.py failed consistently due to the "expected indent" error in the parallel run. 
A fix has been added to fix this. It works fine now with the fix. 

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [ x] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [ x] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [ x] Jobs over 15 minutes in runtime have restart capability.
- [ x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

> Please include testing instructions for the PR assignee. Include all relevant input datasets needed to run the tests.

qsub /lfs/h2/emc/vpppg/noscrub/emc.vpppg/EVS/dev/drivers/scripts/plots/global_ens/jevs_plots_global_ens_wave_gefs_grid2obs_last90days.sh

Use your stats data from the parallel system
