### PR TITLE
regrid from 0.25 to 1.0 as well as directory and file name changes for GFSv17

### DIFF
--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
@@ -45,5 +45,7 @@ source $HOMEevs/dev/drivers/set_MAILTO.sh
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."
 else
+#export VDATE=20260901
+ export COMINgfs=/lfs/h2/emc/gfstemp/emc.global/EVS_archive/retrov17_01
    ${HOMEevs}/jobs/JEVS_PREP_GLOBAL_ENS
 fi

--- a/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
+++ b/dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh
@@ -45,7 +45,5 @@ source $HOMEevs/dev/drivers/set_MAILTO.sh
 if [ -z "$MAILTO" ]; then
    echo "MAILTO variable is not defined. Exiting without continuing."
 else
-#export VDATE=20260901
- export COMINgfs=/lfs/h2/emc/gfstemp/emc.global/EVS_archive/retrov17_01
    ${HOMEevs}/jobs/JEVS_PREP_GLOBAL_ENS
 fi

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -14,7 +14,7 @@
 #      in the evs prep sub-directory /prep/global_ens/atmos.YYYYMMDD
 #
 # Updated:
-#          09/01/2026 by Jun Du: regrid from 0.25deg to 1.0deg of gfs anl and fcst (GFS.v17)
+#          09/01/2026 by Jun Du: regrid from 0.25deg to 1.0deg of gfs anl and fcst
 #          05/20/2025 by L. Gwen Chen (lichuan.chen@noaa.gov) 
 #          11/15/2023 by Binbin Zhou, Lynker@EMC/NCEP
 #######################################################################################

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -70,11 +70,10 @@ if [ $modnam = gfsanl ]; then
       fi
     else
       $WGRIB2 $GFSf000 | grep "UGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/temp_U10_f000.${ihour}
-      $WGRIB2 $WORKtask/temp_U10_f000.${ihour} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/U10_f000.${ihour}
-      cat $WORKtask/U10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
       $WGRIB2 $GFSf000 | grep "VGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/temp_V10_f000.${ihour}
-      $WGRIB2 $WORKtask/temp_V10_f000.${ihour} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/V10_f000.${ihour}
-      cat $WORKtask/V10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
+      cat $WORKtask/temp_U10_f000.${ihour} $WORKtask/temp_V10_f000.${ihour} >> $WORKtask/temp_WIND10_f000.${ihour}
+      $WGRIB2 $WORKtask/temp_WIND10_f000.${ihour} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/WIND10_f000.${ihour}
+      cat $WORKtask/WIND10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
     fi
     if [ $SENDCOM="YES" ] ; then
         if [ -s $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2 ]; then

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -45,29 +45,30 @@ cd $WORKtask
 #################################################################################
 if [ $modnam = gfsanl ]; then
   for ihour in 00 06 12 18 ; do
-    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 ] ; then
-      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/products/atmos/grid2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 is not available" 
+    gfs_anl=$COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2
+    if [ ! -s ${gfs_anl} ] ; then
+      echo "WARNING: ${gfs_anl} is not available" 
       if [ $SENDMAIL = YES ]; then
         export subject="GFS Analysis Data Missing for EVS ${COMPONENT}"
         echo "Warning: No GFS analysis available for ${vday}${ihour}" > mailmsg
-        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/products/atmos/grid2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2" >> mailmsg
+        echo "Missing file is ${gfs_anl}" >> mailmsg
         echo "Job ID: $jobid" >> mailmsg
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      $WGRIB2 $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
+      $WGRIB2 ${gfs_anl} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
     fi
-    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2 ]; then
-      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2 is not available"
+    GFSf000=$COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2
+    if [ ! -s $GFSf000 ]; then
+      echo "WARNING: $GFSf000 is not available"
       if [ $SENDMAIL = YES ]; then
         export subject="GFS F000 Data Missing for EVS ${COMPONENT}"
         echo "Warning: No GFS F000 available for ${vday}${ihour}" > mailmsg
-        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2" >> mailmsg
+        echo "Missing file is $GFSf000" >> mailmsg
         echo "Job ID: $jobid" >> mailmsg
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      GFSf000=$COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2
       $WGRIB2 $GFSf000 | grep "UGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/temp_U10_f000.${ihour}
       $WGRIB2 $WORKtask/temp_U10_f000.${ihour} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/U10_f000.${ihour}
       cat $WORKtask/U10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2

--- a/ush/global_ens/evs_get_gens_atmos_data.sh
+++ b/ush/global_ens/evs_get_gens_atmos_data.sh
@@ -13,7 +13,9 @@
 #   5. Store the well-formed analysis/observations or smaller ensemble member files
 #      in the evs prep sub-directory /prep/global_ens/atmos.YYYYMMDD
 #
-# Updated: 05/20/2025 by L. Gwen Chen (lichuan.chen@noaa.gov) 
+# Updated:
+#          09/01/2026 by Jun Du: regrid from 0.25deg to 1.0deg of gfs anl and fcst (GFS.v17)
+#          05/20/2025 by L. Gwen Chen (lichuan.chen@noaa.gov) 
 #          11/15/2023 by Binbin Zhou, Lynker@EMC/NCEP
 #######################################################################################
 set -x
@@ -36,37 +38,41 @@ mkdir -p $WORKtask
 cd $WORKtask
 
 #################################################################################
-# Get GFS analysis grib2 data in GRID#3 (1-degree global) and WMO 1.5 deg for 00Z
-# NOTE: There are no U10, V10 in GFS analysis, so use GFS*f000 as an alternative
+# Get GFS analysis grib2 data and convert it to GRID#3 (1-degree global) and 
+# WMO 1.5 deg for 00Z
+# NOTE: There are no U10, V10 in GFS analysis, so use GFS*f000 and convert it to 
+# GRID#3 as an alternative
 #################################################################################
 if [ $modnam = gfsanl ]; then
   for ihour in 00 06 12 18 ; do
-    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl ] ; then
-      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl is not available" 
+    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 ] ; then
+      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/products/atmos/grid2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 is not available" 
       if [ $SENDMAIL = YES ]; then
         export subject="GFS Analysis Data Missing for EVS ${COMPONENT}"
         echo "Warning: No GFS analysis available for ${vday}${ihour}" > mailmsg
-        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl" >> mailmsg
+        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/products/atmos/grid2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2" >> mailmsg
         echo "Job ID: $jobid" >> mailmsg
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      cp -v $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.anl $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
+      $WGRIB2 $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.analysis.grib2 -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
     fi
-    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000 ]; then
-      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000 is not available"
+    if [ ! -s $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2 ]; then
+      echo "WARNING: $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2 is not available"
       if [ $SENDMAIL = YES ]; then
         export subject="GFS F000 Data Missing for EVS ${COMPONENT}"
         echo "Warning: No GFS F000 available for ${vday}${ihour}" > mailmsg
-        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000" >> mailmsg
+        echo "Missing file is $COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2" >> mailmsg
         echo "Job ID: $jobid" >> mailmsg
         cat mailmsg | mail -s "$subject" $MAILTO
       fi
     else
-      GFSf000=$COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f000
-      $WGRIB2 $GFSf000 | grep "UGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/U10_f000.${ihour}
+      GFSf000=$COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f000.grib2
+      $WGRIB2 $GFSf000 | grep "UGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/temp_U10_f000.${ihour}
+      $WGRIB2 $WORKtask/temp_U10_f000.${ihour} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/U10_f000.${ihour}
       cat $WORKtask/U10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
-      $WGRIB2 $GFSf000 | grep "VGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/V10_f000.${ihour}
+      $WGRIB2 $GFSf000 | grep "VGRD:10 m above ground" | $WGRIB2 -i $GFSf000 -grib $WORKtask/temp_V10_f000.${ihour}
+      $WGRIB2 $WORKtask/temp_V10_f000.${ihour} -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/V10_f000.${ihour}
       cat $WORKtask/V10_f000.${ihour} >> $WORKtask/gfsanl.t${ihour}z.grid3.f000.grib2
     fi
     if [ $SENDCOM="YES" ] ; then
@@ -870,11 +876,12 @@ fi
 
 #################################################################################
 # Get GFS 00Z forecasts 500mb Geopotential Heights for headline score comparison
+# (also converted from 0.25deg to 1deg)
 #################################################################################
 if [ $modnam = gfs ] ; then
   for ihour in 00 ; do
     for hhh in 024 048 072 096 120 144 168 192 216 240 264 288 312 336 360 384 ; do     
-      gfs=$COMINgfs/gfs.$vday/${ihour}/atmos/gfs.t${ihour}z.pgrb2.1p00.f${hhh}
+      gfs=$COMINgfs/gfs.$vday/${ihour}/products/atmos/grib2/0p25/gfs.t${ihour}z.pres_a.0p25.f${hhh}.grib2
       if [ ! -s $gfs ]; then
         echo "WARNING: $gfs is not available"
         if [ $SENDMAIL = YES ]; then
@@ -885,7 +892,8 @@ if [ $modnam = gfs ] ; then
           cat mailmsg | mail -s "$subject" $MAILTO
         fi
       else
-        $WGRIB2 $gfs | grep "HGT:500 mb" | $WGRIB2 -i $gfs -grib $WORKtask/gfs.t${ihour}z.grid3.f${hhh}.grib2
+        $WGRIB2 $gfs | grep "HGT:500 mb" | $WGRIB2 -i $gfs -grib $WORKtask/temp_gfs.t${ihour}z.grid3.f${hhh}.grib2
+        $WGRIB2 $WORKtask/temp_gfs.t${ihour}z.grid3.f${hhh}.grib2 -set_grib_type same -new_grid_winds earth -new_grid ncep grid 003 $WORKtask/gfs.t${ihour}z.grid3.f${hhh}.grib2
         if [ $SENDCOM="YES" ] ; then
           if [ -s $WORKtask/gfs.t${ihour}z.grid3.f${hhh}.grib2 ]; then
             cp -v $WORKtask/gfs.t${ihour}z.grid3.f${hhh}.grib2 $COMOUTgefs/gfs.t${ihour}z.grid3.f${hhh}.grib2


### PR DESCRIPTION
<b>Note to developers: You must use this PR template!</b>

## Description of Changes

Due to the forecast output's name, path and resolution changes in GFS.v17,  gfs analysis and gfs forecasts have been re-grided from 0.25 deg to 1.0 deg as well as their path and file names are changed in the script  /ush/global_ens/evs_get_gens_atmos_data.sh

## Developer Questions and Checklist
* Is this a high priority PR? If so, why and is there a date it needs to be merged by?
Yes, the code needs to freeze soon.

* Do you have any planned upcoming annual leave/PTO?
No

* Are there any changes needed in the times when the jobs are supposed to run/kick-off?
No
  
- [x ] The code changes follow [NCO's EE2 Standards](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/ImplementationStandards.v11.0.0.pdf).
- [x ] Developer's name is removed throughout the code and have used `${USER}` where necessary throughout the code.
- [x ] References the feature branch for `HOMEevs` are removed from the code.
- [x ] J-Job environment variables, COMIN and COMOUT directories, and output follow what has been [defined](https://docs.google.com/document/d/1JWg_4q80aYmmAoD21GFjp9R9y5-3w7WGM3-0HJk0Pjs/edit#heading=h.7ysbr191vzu4) for EVS.
- [x ] Jobs over 15 minutes in runtime have restart capability.
- [ x] If applicable, changes in the `dev/drivers/scripts` or `dev/modulefiles` have been made in the corresponding `ecf/scripts` and `ecf/defs/evs-nco.def`? 
- [x ] Jobs contain the appropriate file checking and don't run METplus for any missing data.
- [x ] Code is using METplus wrappers structure and not calling MET executables directly.
- [x ] Log is free of any ERRORs or WARNINGs.

## Testing Instructions

Need to add the following in the /dev/drivers/scripts/prep/global_ens/jevs_prep_global_ens_atmos.sh to use the new gfs.v17 data: 
export COMINgfs=/lfs/h2/emc/gfstemp/emc.global/EVS_archive/retrov17_01

Additional testing:
1. Run headline prep (uses GFS output from jevs_prep_global_ens_atmos.sh)
2. Run a stats job; link previous days prep from emc.vpppg